### PR TITLE
direct to issues in this repo, not forked one

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 We welcome contributions to this plugin repository. If you're interested in building and sharing your own, please follow these steps:
 
-- [Open a ticket](https://github.com/mapbox/mapbox-plugins-android/issues/new) to kick off a conversation, feel free to tag the `@mapbox/android` team. It's a good idea to explain your plans before you push any code to make sure noone else is working on something similar and to discuss the best approaches to tackle your particular idea.
+- [Open a ticket](https://github.com/maplibre/maplibre-plugins-android/issues/new) to kick off a conversation, feel free to tag the `@mapbox/android` team. It's a good idea to explain your plans before you push any code to make sure noone else is working on something similar and to discuss the best approaches to tackle your particular idea.
 
 - Create a new branch that will contain the code for your plugin.
 


### PR DESCRIPTION
BTW, is there some replacement for

> feel free to tag the `@mapbox/android` team

group or should it be simply removed completely?

PS There are many Mapbox-specific things in this repo, including logo in https://github.com/maplibre/maplibre-plugins-android/blob/main/README.md and https://github.com/maplibre/maplibre-plugins-android/blob/main/CONTRIBUTING.md (after this one, #4 #6 #8 are processed I will open more PRs)

PPS Is there a replacement for the logo? Or should it be simply removed?