### PR TITLE
Fix performance when adding many individual annotations to map

### DIFF
--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/AnnotationManager.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/AnnotationManager.java
@@ -233,9 +233,12 @@ public abstract class AnnotationManager<
   void postUpdateSource() {
     // Only schedule a new refresh if not already scheduled
     if (isSourceUpToDate.compareAndSet(true, false)) {
-      mapView.post(() -> {
-        internalUpdateSource();
-        isSourceUpToDate.set(true);
+      mapView.post(new Runnable() {
+        @Override
+        public void run() {
+          internalUpdateSource();
+          isSourceUpToDate.set(true);
+        }
       });
     }
   }

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/AnnotationManager.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/AnnotationManager.java
@@ -45,6 +45,7 @@ public abstract class AnnotationManager<
 
   private static final String TAG = "AnnotationManager";
 
+  private final MapView mapView;
   protected final MapboxMap mapboxMap;
   protected final LongSparseArray<T> annotations = new LongSparseArray<>();
   final Map<String, Boolean> dataDrivenPropertyUsageMap = new HashMap<>();
@@ -64,11 +65,14 @@ public abstract class AnnotationManager<
   protected CoreElementProvider<L> coreElementProvider;
   private DraggableAnnotationController draggableAnnotationController;
 
+  private boolean isSourceUpToDate = true;
+
   @UiThread
   protected AnnotationManager(MapView mapView, final MapboxMap mapboxMap, Style style,
                               CoreElementProvider<L> coreElementProvider,
                               DraggableAnnotationController draggableAnnotationController,
                               String belowLayerId, final GeoJsonOptions geoJsonOptions) {
+    this.mapView = mapView;
     this.mapboxMap = mapboxMap;
     this.style = style;
     this.belowLayerId = belowLayerId;
@@ -222,7 +226,18 @@ public abstract class AnnotationManager<
    */
   public void updateSource() {
     draggableAnnotationController.onSourceUpdated();
-    internalUpdateSource();
+    postUpdateSource();
+  }
+
+  void postUpdateSource() {
+    // Only schedule a new refresh if not already scheduled
+    if (isSourceUpToDate) {
+      isSourceUpToDate = false;
+      mapView.post(() -> {
+        internalUpdateSource();
+        isSourceUpToDate = true;
+      });
+    }
   }
 
   void internalUpdateSource() {

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/AnnotationManager.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/AnnotationManager.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -65,7 +66,7 @@ public abstract class AnnotationManager<
   protected CoreElementProvider<L> coreElementProvider;
   private DraggableAnnotationController draggableAnnotationController;
 
-  private boolean isSourceUpToDate = true;
+  private AtomicBoolean isSourceUpToDate = new AtomicBoolean(true);
 
   @UiThread
   protected AnnotationManager(MapView mapView, final MapboxMap mapboxMap, Style style,
@@ -231,11 +232,10 @@ public abstract class AnnotationManager<
 
   void postUpdateSource() {
     // Only schedule a new refresh if not already scheduled
-    if (isSourceUpToDate) {
-      isSourceUpToDate = false;
+    if (isSourceUpToDate.compareAndSet(true, false)) {
       mapView.post(() -> {
         internalUpdateSource();
-        isSourceUpToDate = true;
+        isSourceUpToDate.set(true);
       });
     }
   }

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/DraggableAnnotationController.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/DraggableAnnotationController.java
@@ -142,7 +142,7 @@ final class DraggableAnnotationController {
         draggedAnnotation.setGeometry(
           shiftedGeometry
         );
-        draggedAnnotationManager.internalUpdateSource();
+        draggedAnnotationManager.postUpdateSource();
         for (OnAnnotationDragListener d : (List<OnAnnotationDragListener>) draggedAnnotationManager.getDragListeners()) {
           d.onAnnotationDrag(draggedAnnotation);
         }


### PR DESCRIPTION

## Motivation

microG is suffering from performance problems when adding a large amount of items to the map (https://github.com/microg/GmsCore/issues/969). The reason is that as each time a marker is added in microG, a call to `SymbolManager.create` is triggered, leading to an overall runtime that is quadratic in the amount of points added.

When adding a single point to `SymbolManager` (a subclass of `AnnotationManager`), the source is being regenerated (as well as [whenever the point is updated](https://github.com/maplibre/maplibre-plugins-android/blob/b3580bccd4bf695ca43840e45a7863315679c686/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/AnnotationManager.java#L195-L205)):

https://github.com/maplibre/maplibre-plugins-android/blob/b3580bccd4bf695ca43840e45a7863315679c686/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/AnnotationManager.java#L123-L136

* The call to `updateSource` takes an amount of time linear in the amount of items → O(n) with _n_ as the amount of markers already added
* `updateSource` is called n times → O(n²) with _n_ as the amount of markers to be added

The same problem occurs for other annotations. Other apps may make the same mistake and loop over `create` , because it is not obvious to them that this leads to bad performance.

## Fix

I believe the best solution to the problem is working around the performance issues for all library users in an elegant way.

With this PR, we only update the GeoJSON source at the next UI draw after a change, i.e. the update is delayed until it is actually needed to display the map. This allows users to add many points with only few re-generations.