### PR TITLE
Fixed annotation dragging behavior

### DIFF
--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/AnnotationManager.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/AnnotationManager.java
@@ -136,7 +136,7 @@ public abstract class AnnotationManager<
     T t = options.build(currentId, this);
     annotations.put(t.getId(), t);
     currentId++;
-    updateSource();
+    internalUpdateSource();
     return t;
   }
 
@@ -155,7 +155,7 @@ public abstract class AnnotationManager<
       annotations.put(annotation.getId(), annotation);
       currentId++;
     }
-    updateSource();
+    internalUpdateSource();
     return annotationList;
   }
 
@@ -167,7 +167,8 @@ public abstract class AnnotationManager<
   @UiThread
   public void delete(T annotation) {
     annotations.remove(annotation.getId());
-    updateSource();
+    draggableAnnotationController.onAnnotationUpdated(annotation);
+    internalUpdateSource();
   }
 
   /**
@@ -179,8 +180,9 @@ public abstract class AnnotationManager<
   public void delete(List<T> annotationList) {
     for (T annotation : annotationList) {
       annotations.remove(annotation.getId());
+      draggableAnnotationController.onAnnotationUpdated(annotation);
     }
-    updateSource();
+    internalUpdateSource();
   }
 
   /**
@@ -201,7 +203,8 @@ public abstract class AnnotationManager<
   public void update(T annotation) {
     if (annotations.containsValue(annotation)) {
       annotations.put(annotation.getId(), annotation);
-      updateSource();
+      draggableAnnotationController.onAnnotationUpdated(annotation);
+      internalUpdateSource();
     } else {
       Logger.e(TAG, "Can't update annotation: "
         + annotation.toString()
@@ -218,8 +221,9 @@ public abstract class AnnotationManager<
   public void update(List<T> annotationList) {
     for (T annotation : annotationList) {
       annotations.put(annotation.getId(), annotation);
+      draggableAnnotationController.onAnnotationUpdated(annotation);
     }
-    updateSource();
+    internalUpdateSource();
   }
 
   /**

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/DraggableAnnotationController.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/DraggableAnnotationController.java
@@ -97,6 +97,12 @@ final class DraggableAnnotationController {
     }
   }
 
+  void onAnnotationUpdated(Annotation annotation) {
+    if (annotation == draggedAnnotation) {
+      stopDragging(draggedAnnotation, draggedAnnotationManager);
+    }
+  }
+
   void onSourceUpdated() {
     stopDragging(draggedAnnotation, draggedAnnotationManager);
   }


### PR DESCRIPTION
**Problem encountered without this change**
Updating the position of any annotation on the map would cause dragging of another annotation to be stopped. We encountered this issue when trying to implement a polygon with draggable vertices.

**Solution**
Only stop the drag if the updated annotation is also the dragged annotation.
