### PR TITLE
Fix deprecated ci action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,20 +1,20 @@
 name: ci
 
-on: 
+on:
   workflow_dispatch:
   push:
     tags-ignore:
       - '**'
     paths-ignore:
-      - ".github/**" 
+      - ".github/**"
       - "README.md"
-      - ".gitignore"      
+      - ".gitignore"
     branches:
       - main
   pull_request:
     branches:
       - main
-  
+
 jobs:
   build:
     runs-on: ubuntu-20.04
@@ -26,7 +26,6 @@ jobs:
       BUILDTYPE: Release
       IS_LOCAL_DEVELOPMENT: false
     steps:
-
       - uses: actions/checkout@v2
         with:
           submodules: recursive
@@ -34,7 +33,7 @@ jobs:
 
       - name: Download Dependencies
         run: ./gradlew androidDependencies
-      
+
       - name: Run nitpick
         run: ./gradlew plugin-annotation:nitpick
 
@@ -42,25 +41,25 @@ jobs:
         run: make checkstyle
 
       - name: Build Plugins SDK
-        run: make build-release        
-      
+        run: make build-release
+
       - name: Run unit tests
         run: make test
-      
+
       - name: Generate Activity Sanity tests
         run: make generate-sanity-test
-      
+
       - name: Build testapp APK
         run: |
           ./gradlew accessToken
           ./gradlew app:assembleDebug
         env:
           MAPBOX_ACCESS_TOKEN: ${{ secrets.MAPBOX_ACCESS_TOKEN }}
-      
+
       - name: Build Test APK
         run: |
           ./gradlew app:assembleAndroidTest
-      
+
       - name: Build release to test ProGuard rules
         run: ./gradlew app:assembleRelease
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       BUILDTYPE: Release
       IS_LOCAL_DEVELOPMENT: false
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: recursive
           fetch-depth: 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,9 +4,9 @@ on:
   workflow_dispatch:
   push:
     tags:
-      - v* 
-    paths-ignore:      
-      - ".github/**"      
+      - v*
+    paths-ignore:
+      - ".github/**"
       - "README.md"
 jobs:
   build:
@@ -15,15 +15,13 @@ jobs:
       image: ghcr.io/maplibre/android-ndk-r21b
     env:
       BUILDTYPE: Release
-      IS_LOCAL_DEVELOPMENT: false      
-    
+      IS_LOCAL_DEVELOPMENT: false
     steps:
-
       - uses: actions/checkout@v2
         with:
           submodules: recursive
           fetch-depth: 0
-  
+
       - name: Build Plugins SDK
         run: make build-release
 
@@ -41,4 +39,4 @@ jobs:
           OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
           SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
           SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
-          SONATYPE_STAGING_PROFILE_ID: ${{ secrets.SONATYPE_STAGING_PROFILE_ID }}         
+          SONATYPE_STAGING_PROFILE_ID: ${{ secrets.SONATYPE_STAGING_PROFILE_ID }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       BUILDTYPE: Release
       IS_LOCAL_DEVELOPMENT: false
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: recursive
           fetch-depth: 0


### PR DESCRIPTION
Update `- uses: actions/checkout@v2` to v3 to remove warning in the GitHub Actions.

Nitpick: fixed the spaces at the same time :see_no_evil: 