### PR TITLE
Do not cancel drag when annotation is updated

### DIFF
--- a/plugin-annotation/scripts/annotation_manager_unit_test.junit.ejs
+++ b/plugin-annotation/scripts/annotation_manager_unit_test.junit.ejs
@@ -71,7 +71,6 @@ public class <%- camelize(type) %>ManagerTest {
         }
         verify(<%- type  %>Layer).setProperties(<%- type  %>Manager.constantPropertyUsageMap.values().toArray(new PropertyValue[0]));
         verify(<%- type  %>Layer, times(0)).setFilter(any(Expression.class));
-        verify(draggableAnnotationController).onSourceUpdated();
     }
 
     @Test
@@ -84,7 +83,6 @@ public class <%- camelize(type) %>ManagerTest {
             assertFalse(value);
         }
         verify(<%- type  %>Layer).setProperties(<%- type  %>Manager.constantPropertyUsageMap.values().toArray(new PropertyValue[0]));
-        verify(draggableAnnotationController).onSourceUpdated();
 
         Expression filter = Expression.literal(false);
         <%- type  %>Manager.setFilter(filter);
@@ -112,7 +110,6 @@ public class <%- camelize(type) %>ManagerTest {
         }
         verify(newLayer).setProperties(<%- type  %>Manager.constantPropertyUsageMap.values().toArray(new PropertyValue[0]));
         verify(<%- type  %>Layer).setFilter(filter);
-        verify(draggableAnnotationController, times(2)).onSourceUpdated();
     }
 
     @Test
@@ -125,7 +122,6 @@ public class <%- camelize(type) %>ManagerTest {
             assertFalse(value);
         }
         verify(<%- type  %>Layer).setProperties(<%- type  %>Manager.constantPropertyUsageMap.values().toArray(new PropertyValue[0]));
-        verify(draggableAnnotationController).onSourceUpdated();
     }
 
     @Test
@@ -139,7 +135,6 @@ public class <%- camelize(type) %>ManagerTest {
         }
         verify(<%- type  %>Layer).setProperties(<%- type  %>Manager.constantPropertyUsageMap.values().toArray(new PropertyValue[0]));
         verify(<%- type  %>Layer, times(0)).setFilter(any(Expression.class));
-        verify(draggableAnnotationController).onSourceUpdated();
     }
 
     @Test

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/AnnotationManager.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/AnnotationManager.java
@@ -231,7 +231,6 @@ public abstract class AnnotationManager<
      * Trigger an update to the underlying source
      */
     public void updateSource() {
-        draggableAnnotationController.onSourceUpdated();
         postUpdateSource();
     }
 

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/AnnotationManager.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/AnnotationManager.java
@@ -170,7 +170,7 @@ public abstract class AnnotationManager<
     @UiThread
     public void delete(T annotation) {
         annotations.remove(annotation.getId());
-        draggableAnnotationController.onAnnotationUpdated(annotation);
+        draggableAnnotationController.onAnnotationDeleted(annotation);
         internalUpdateSource();
     }
 
@@ -183,7 +183,7 @@ public abstract class AnnotationManager<
     public void delete(List<T> annotationList) {
         for (T annotation : annotationList) {
             annotations.remove(annotation.getId());
-            draggableAnnotationController.onAnnotationUpdated(annotation);
+            draggableAnnotationController.onAnnotationDeleted(annotation);
         }
         internalUpdateSource();
     }
@@ -206,7 +206,6 @@ public abstract class AnnotationManager<
     public void update(T annotation) {
         if (annotations.containsValue(annotation)) {
             annotations.put(annotation.getId(), annotation);
-            draggableAnnotationController.onAnnotationUpdated(annotation);
             internalUpdateSource();
         } else {
             Logger.e(TAG, "Can't update annotation: "
@@ -224,7 +223,6 @@ public abstract class AnnotationManager<
     public void update(List<T> annotationList) {
         for (T annotation : annotationList) {
             annotations.put(annotation.getId(), annotation);
-            draggableAnnotationController.onAnnotationUpdated(annotation);
         }
         internalUpdateSource();
     }

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/DraggableAnnotationController.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/DraggableAnnotationController.java
@@ -97,14 +97,13 @@ final class DraggableAnnotationController {
         }
     }
 
-    void onAnnotationUpdated(Annotation annotation) {
+    void onAnnotationDeleted(Annotation annotation) {
         if (annotation == draggedAnnotation) {
             stopDragging(draggedAnnotation, draggedAnnotationManager);
         }
     }
 
     void onSourceUpdated() {
-        stopDragging(draggedAnnotation, draggedAnnotationManager);
     }
 
     boolean onMoveBegin(MoveGestureDetector detector) {

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/DraggableAnnotationController.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/DraggableAnnotationController.java
@@ -103,9 +103,6 @@ final class DraggableAnnotationController {
         }
     }
 
-    void onSourceUpdated() {
-    }
-
     boolean onMoveBegin(MoveGestureDetector detector) {
         for (AnnotationManager annotationManager : annotationManagers) {
             if (detector.getPointersCount() == 1) {

--- a/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/CircleManagerTest.java
+++ b/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/CircleManagerTest.java
@@ -66,7 +66,6 @@ public class CircleManagerTest {
         }
         verify(circleLayer).setProperties(circleManager.constantPropertyUsageMap.values().toArray(new PropertyValue[0]));
         verify(circleLayer, times(0)).setFilter(any(Expression.class));
-        verify(draggableAnnotationController).onSourceUpdated();
     }
 
     @Test
@@ -79,7 +78,6 @@ public class CircleManagerTest {
             assertFalse(value);
         }
         verify(circleLayer).setProperties(circleManager.constantPropertyUsageMap.values().toArray(new PropertyValue[0]));
-        verify(draggableAnnotationController).onSourceUpdated();
 
         Expression filter = Expression.literal(false);
         circleManager.setFilter(filter);
@@ -107,7 +105,6 @@ public class CircleManagerTest {
         }
         verify(newLayer).setProperties(circleManager.constantPropertyUsageMap.values().toArray(new PropertyValue[0]));
         verify(circleLayer).setFilter(filter);
-        verify(draggableAnnotationController, times(2)).onSourceUpdated();
     }
 
     @Test
@@ -120,7 +117,6 @@ public class CircleManagerTest {
             assertFalse(value);
         }
         verify(circleLayer).setProperties(circleManager.constantPropertyUsageMap.values().toArray(new PropertyValue[0]));
-        verify(draggableAnnotationController).onSourceUpdated();
     }
 
     @Test
@@ -134,7 +130,6 @@ public class CircleManagerTest {
         }
         verify(circleLayer).setProperties(circleManager.constantPropertyUsageMap.values().toArray(new PropertyValue[0]));
         verify(circleLayer, times(0)).setFilter(any(Expression.class));
-        verify(draggableAnnotationController).onSourceUpdated();
     }
 
     @Test

--- a/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/DraggableAnnotationControllerTest.java
+++ b/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/DraggableAnnotationControllerTest.java
@@ -126,7 +126,6 @@ public class DraggableAnnotationControllerTest {
         when(annotation.isDraggable()).thenReturn(true);
         when(annotationManager.getDragListeners()).thenReturn(dragListenerList);
         draggableAnnotationController.startDragging(annotation, annotationManager);
-        draggableAnnotationController.onSourceUpdated();
         verify(dragListener, times(1)).onAnnotationDragFinished(annotation);
     }
 

--- a/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/DraggableAnnotationControllerTest.java
+++ b/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/DraggableAnnotationControllerTest.java
@@ -122,10 +122,11 @@ public class DraggableAnnotationControllerTest {
     }
 
     @Test
-    public void annotationDragStopSourceUpdateTest() {
+    public void annotationDragStopOnDeleteTest() {
         when(annotation.isDraggable()).thenReturn(true);
         when(annotationManager.getDragListeners()).thenReturn(dragListenerList);
         draggableAnnotationController.startDragging(annotation, annotationManager);
+        draggableAnnotationController.onAnnotationDeleted(annotation);
         verify(dragListener, times(1)).onAnnotationDragFinished(annotation);
     }
 

--- a/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/FillManagerTest.java
+++ b/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/FillManagerTest.java
@@ -66,7 +66,6 @@ public class FillManagerTest {
         }
         verify(fillLayer).setProperties(fillManager.constantPropertyUsageMap.values().toArray(new PropertyValue[0]));
         verify(fillLayer, times(0)).setFilter(any(Expression.class));
-        verify(draggableAnnotationController).onSourceUpdated();
     }
 
     @Test
@@ -79,7 +78,6 @@ public class FillManagerTest {
             assertFalse(value);
         }
         verify(fillLayer).setProperties(fillManager.constantPropertyUsageMap.values().toArray(new PropertyValue[0]));
-        verify(draggableAnnotationController).onSourceUpdated();
 
         Expression filter = Expression.literal(false);
         fillManager.setFilter(filter);
@@ -107,7 +105,6 @@ public class FillManagerTest {
         }
         verify(newLayer).setProperties(fillManager.constantPropertyUsageMap.values().toArray(new PropertyValue[0]));
         verify(fillLayer).setFilter(filter);
-        verify(draggableAnnotationController, times(2)).onSourceUpdated();
     }
 
     @Test
@@ -120,7 +117,6 @@ public class FillManagerTest {
             assertFalse(value);
         }
         verify(fillLayer).setProperties(fillManager.constantPropertyUsageMap.values().toArray(new PropertyValue[0]));
-        verify(draggableAnnotationController).onSourceUpdated();
     }
 
     @Test
@@ -134,7 +130,6 @@ public class FillManagerTest {
         }
         verify(fillLayer).setProperties(fillManager.constantPropertyUsageMap.values().toArray(new PropertyValue[0]));
         verify(fillLayer, times(0)).setFilter(any(Expression.class));
-        verify(draggableAnnotationController).onSourceUpdated();
     }
 
     @Test

--- a/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/LineManagerTest.java
+++ b/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/LineManagerTest.java
@@ -66,7 +66,6 @@ public class LineManagerTest {
         }
         verify(lineLayer).setProperties(lineManager.constantPropertyUsageMap.values().toArray(new PropertyValue[0]));
         verify(lineLayer, times(0)).setFilter(any(Expression.class));
-        verify(draggableAnnotationController).onSourceUpdated();
     }
 
     @Test
@@ -79,7 +78,6 @@ public class LineManagerTest {
             assertFalse(value);
         }
         verify(lineLayer).setProperties(lineManager.constantPropertyUsageMap.values().toArray(new PropertyValue[0]));
-        verify(draggableAnnotationController).onSourceUpdated();
 
         Expression filter = Expression.literal(false);
         lineManager.setFilter(filter);
@@ -107,7 +105,6 @@ public class LineManagerTest {
         }
         verify(newLayer).setProperties(lineManager.constantPropertyUsageMap.values().toArray(new PropertyValue[0]));
         verify(lineLayer).setFilter(filter);
-        verify(draggableAnnotationController, times(2)).onSourceUpdated();
     }
 
     @Test
@@ -120,7 +117,6 @@ public class LineManagerTest {
             assertFalse(value);
         }
         verify(lineLayer).setProperties(lineManager.constantPropertyUsageMap.values().toArray(new PropertyValue[0]));
-        verify(draggableAnnotationController).onSourceUpdated();
     }
 
     @Test
@@ -134,7 +130,6 @@ public class LineManagerTest {
         }
         verify(lineLayer).setProperties(lineManager.constantPropertyUsageMap.values().toArray(new PropertyValue[0]));
         verify(lineLayer, times(0)).setFilter(any(Expression.class));
-        verify(draggableAnnotationController).onSourceUpdated();
     }
 
     @Test

--- a/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/SymbolManagerTest.java
+++ b/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/SymbolManagerTest.java
@@ -66,7 +66,6 @@ public class SymbolManagerTest {
         }
         verify(symbolLayer).setProperties(symbolManager.constantPropertyUsageMap.values().toArray(new PropertyValue[0]));
         verify(symbolLayer, times(0)).setFilter(any(Expression.class));
-        verify(draggableAnnotationController).onSourceUpdated();
     }
 
     @Test
@@ -79,7 +78,6 @@ public class SymbolManagerTest {
             assertFalse(value);
         }
         verify(symbolLayer).setProperties(symbolManager.constantPropertyUsageMap.values().toArray(new PropertyValue[0]));
-        verify(draggableAnnotationController).onSourceUpdated();
 
         Expression filter = Expression.literal(false);
         symbolManager.setFilter(filter);
@@ -107,7 +105,6 @@ public class SymbolManagerTest {
         }
         verify(newLayer).setProperties(symbolManager.constantPropertyUsageMap.values().toArray(new PropertyValue[0]));
         verify(symbolLayer).setFilter(filter);
-        verify(draggableAnnotationController, times(2)).onSourceUpdated();
     }
 
     @Test
@@ -120,7 +117,6 @@ public class SymbolManagerTest {
             assertFalse(value);
         }
         verify(symbolLayer).setProperties(symbolManager.constantPropertyUsageMap.values().toArray(new PropertyValue[0]));
-        verify(draggableAnnotationController).onSourceUpdated();
     }
 
     @Test
@@ -134,7 +130,6 @@ public class SymbolManagerTest {
         }
         verify(symbolLayer).setProperties(symbolManager.constantPropertyUsageMap.values().toArray(new PropertyValue[0]));
         verify(symbolLayer, times(0)).setFilter(any(Expression.class));
-        verify(draggableAnnotationController).onSourceUpdated();
     }
 
     @Test


### PR DESCRIPTION
This is currently a problem when moving annotations. It is not really clear to us why `stopDragging()` is being called in those two places, we have not had issues after removing them.

@RomanBapst: FYI