### PR TITLE
Add support to insert a layer above a reference layer

### DIFF
--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/ClusterSymbolActivity.java
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/ClusterSymbolActivity.java
@@ -73,7 +73,7 @@ public class ClusterSymbolActivity extends AppCompatActivity {
             });
 
         mapboxMap.setStyle(new Style.Builder().fromUri(Style.getPredefinedStyle("Streets")), style -> {
-            symbolManager = new SymbolManager(mapView, mapboxMap, style, null, clusterOptions);
+            symbolManager = new SymbolManager(mapView, mapboxMap, style, null, null, clusterOptions);
             symbolManager.setIconAllowOverlap(true);
             loadData();
         });

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/FillChangeActivity.java
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/FillChangeActivity.java
@@ -79,7 +79,7 @@ public class FillChangeActivity extends AppCompatActivity implements OnMapReadyC
     @Override
     public void onMapReady(@NonNull MapboxMap map) {
         map.setStyle(new Style.Builder().fromUri(Style.getPredefinedStyle("Streets")), style -> {
-            fillManager = new FillManager(mapView, map, style, "aerialway");
+            fillManager = new FillManager(mapView, map, style, "aerialway", null);
             fillManager.addClickListener(fill -> {
                 Toast.makeText(
                     FillChangeActivity.this,

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/SymbolActivity.java
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/SymbolActivity.java
@@ -82,7 +82,7 @@ public class SymbolActivity extends AppCompatActivity {
 
             // create symbol manager
             GeoJsonOptions geoJsonOptions = new GeoJsonOptions().withTolerance(0.4f);
-            symbolManager = new SymbolManager(mapView, mapboxMap, style, null, geoJsonOptions);
+            symbolManager = new SymbolManager(mapView, mapboxMap, style, null, null, geoJsonOptions);
             symbolManager.addClickListener(symbol -> {
                 Toast.makeText(SymbolActivity.this,
                     String.format("Symbol clicked %s", symbol.getId()),

--- a/plugin-annotation/scripts/annotation_manager.java.ejs
+++ b/plugin-annotation/scripts/annotation_manager.java.ejs
@@ -49,7 +49,7 @@ public class <%- camelize(type) %>Manager extends AnnotationManager<<%- camelize
      */
     @UiThread
     public <%- camelize(type) %>Manager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style) {
-        this(mapView, mapboxMap, style, null, (GeoJsonOptions) null);
+        this(mapView, mapboxMap, style, null, null, (GeoJsonOptions) null);
     }
 
     /**
@@ -57,11 +57,12 @@ public class <%- camelize(type) %>Manager extends AnnotationManager<<%- camelize
      *
      * @param mapboxMap    the map object to add <%- type %>s to
      * @param style        a valid a fully loaded style object
-     * @param belowLayerId the id of the layer above the circle layer
+     * @param belowLayerId the id of the layer above the <%- type %> layer
+     * @param aboveLayerId the id of the layer below the <%- type %> layer
      */
     @UiThread
-    public <%- camelize(type) %>Manager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @Nullable String belowLayerId) {
-        this(mapView, mapboxMap, style, belowLayerId, (GeoJsonOptions) null);
+    public <%- camelize(type) %>Manager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @Nullable String belowLayerId, @Nullable String aboveLayerId) {
+        this(mapView, mapboxMap, style, belowLayerId, aboveLayerId, (GeoJsonOptions) null);
     }
 
     /**
@@ -69,12 +70,13 @@ public class <%- camelize(type) %>Manager extends AnnotationManager<<%- camelize
      *
      * @param mapboxMap      the map object to add <%- type %>s to
      * @param style          a valid a fully loaded style object
-     * @param belowLayerId   the id of the layer above the circle layer
+     * @param belowLayerId   the id of the layer above the <%- type %> layer
+     * @param aboveLayerId   the id of the layer below the <%- type %> layer
      * @param geoJsonOptions options for the internal source
      */
     @UiThread
-    public <%- camelize(type) %>Manager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @Nullable String belowLayerId, @Nullable GeoJsonOptions geoJsonOptions) {
-        this(mapView, mapboxMap, style, new <%- camelize(type) %>ElementProvider(), belowLayerId, geoJsonOptions, DraggableAnnotationController.getInstance(mapView, mapboxMap));
+    public <%- camelize(type) %>Manager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @Nullable String belowLayerId, @Nullable String aboveLayerId, @Nullable GeoJsonOptions geoJsonOptions) {
+        this(mapView, mapboxMap, style, new <%- camelize(type) %>ElementProvider(), belowLayerId, aboveLayerId, geoJsonOptions, DraggableAnnotationController.getInstance(mapView, mapboxMap));
     }
 <% if (type === "symbol") { -%>
 
@@ -83,19 +85,20 @@ public class <%- camelize(type) %>Manager extends AnnotationManager<<%- camelize
      *
      * @param mapboxMap      the map object to add <%- type %>s to
      * @param style          a valid a fully loaded style object
-     * @param belowLayerId   the id of the layer above the circle layer
+     * @param belowLayerId   the id of the layer above the <%- type %> layer
+     * @param aboveLayerId   the id of the layer below the <%- type %> layer
      * @param clusterOptions options for the clustering configuration
      */
     @UiThread
-    public <%- camelize(type) %>Manager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @Nullable String belowLayerId, @NonNull ClusterOptions clusterOptions) {
-        this(mapView, mapboxMap, style, new SymbolElementProvider(), belowLayerId, new GeoJsonOptions().withCluster(true).withClusterRadius(clusterOptions.getClusterRadius()).withClusterMaxZoom(clusterOptions.getClusterMaxZoom()), DraggableAnnotationController.getInstance(mapView, mapboxMap));
+    public <%- camelize(type) %>Manager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @Nullable String belowLayerId, @Nullable String aboveLayerId, @NonNull ClusterOptions clusterOptions) {
+        this(mapView, mapboxMap, style, new SymbolElementProvider(), belowLayerId, aboveLayerId, new GeoJsonOptions().withCluster(true).withClusterRadius(clusterOptions.getClusterRadius()).withClusterMaxZoom(clusterOptions.getClusterMaxZoom()), DraggableAnnotationController.getInstance(mapView, mapboxMap));
         clusterOptions.apply(style, coreElementProvider.getSourceId());
     }
 <% } -%>
 
-    @VisibleForTesting
-    <%- camelize(type) %>Manager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @NonNull CoreElementProvider<<%- camelize(type) %>Layer> coreElementProvider, @Nullable String belowLayerId, @Nullable GeoJsonOptions geoJsonOptions, DraggableAnnotationController draggableAnnotationController) {
-        super(mapView, mapboxMap, style, coreElementProvider, draggableAnnotationController, belowLayerId, geoJsonOptions);
+    @UiThread
+    <%- camelize(type) %>Manager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @NonNull CoreElementProvider<<%- camelize(type) %>Layer> coreElementProvider, @Nullable String belowLayerId, @Nullable String aboveLayerId, @Nullable GeoJsonOptions geoJsonOptions, DraggableAnnotationController draggableAnnotationController) {
+        super(mapView, mapboxMap, style, coreElementProvider, draggableAnnotationController, belowLayerId, aboveLayerId, geoJsonOptions);
     }
 
     @Override

--- a/plugin-annotation/scripts/annotation_manager_unit_test.junit.ejs
+++ b/plugin-annotation/scripts/annotation_manager_unit_test.junit.ejs
@@ -62,7 +62,7 @@ public class <%- camelize(type) %>ManagerTest {
 
     @Test
     public void testInitialization() {
-        <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(style).addSource(geoJsonSource);
         verify(style).addLayer(<%- type  %>Layer);
         assertTrue(<%- type  %>Manager.dataDrivenPropertyUsageMap.size() > 0);
@@ -76,7 +76,7 @@ public class <%- camelize(type) %>ManagerTest {
 
     @Test
     public void testInitializationOnStyleReload() {
-        <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(style).addSource(geoJsonSource);
         verify(style).addLayer(<%- type  %>Layer);
         assertTrue(<%- type  %>Manager.dataDrivenPropertyUsageMap.size() > 0);
@@ -117,7 +117,7 @@ public class <%- camelize(type) %>ManagerTest {
 
     @Test
     public void testLayerBelowInitialization() {
-        <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, "test_layer", null, draggableAnnotationController);
+        <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, "test_layer", null, null, draggableAnnotationController);
         verify(style).addSource(geoJsonSource);
         verify(style).addLayerBelow(<%- type  %>Layer, "test_layer");
         assertTrue(<%- type  %>Manager.dataDrivenPropertyUsageMap.size() > 0);
@@ -130,7 +130,7 @@ public class <%- camelize(type) %>ManagerTest {
 
     @Test
     public void testGeoJsonOptionsInitialization() {
-        <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, geoJsonOptions, draggableAnnotationController);
+        <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, geoJsonOptions, draggableAnnotationController);
         verify(style).addSource(optionedGeoJsonSource);
         verify(style).addLayer(<%- type  %>Layer);
         assertTrue(<%- type  %>Manager.dataDrivenPropertyUsageMap.size() > 0);
@@ -144,13 +144,13 @@ public class <%- camelize(type) %>ManagerTest {
 
     @Test
     public void testLayerId() {
-        <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         assertEquals(layerId, <%- type  %>Manager.getLayerId());
     }
 
     @Test
     public void testAdd<%- camelize(type) %>() {
-        <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
 <% if (type === "circle" || type === "symbol") { -%>
         <%- camelize(type) %> <%- type %> = <%- type %>Manager.create(new <%- camelize(type) %>Options().withLatLng(new LatLng()));
 <% } else if (type === "line") { -%>
@@ -173,7 +173,7 @@ public class <%- camelize(type) %>ManagerTest {
 
     @Test
     public void add<%- camelize(type) %>FromFeatureCollection() {
-        <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
 <% if (type === "circle" || type === "symbol") { -%>
         Geometry geometry = Point.fromLngLat(10, 10);
 <% } else if (type === "line") { -%>
@@ -232,7 +232,7 @@ public class <%- camelize(type) %>ManagerTest {
 
     @Test
     public void add<%- camelize(type) %>s() {
-        <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
 <% if (type === "circle" || type === "symbol") { -%>
         List<LatLng> latLngList = new ArrayList<>();
         latLngList.add(new LatLng());
@@ -292,7 +292,7 @@ public class <%- camelize(type) %>ManagerTest {
 
     @Test
     public void testDelete<%- camelize(type) %>() {
-        <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
 <% if (type === "circle" || type === "symbol") { -%>
         <%- camelize(type) %> <%- type %> = <%- type %>Manager.create(new <%- camelize(type) %>Options().withLatLng(new LatLng()));
 <% } else if (type === "line") { -%>
@@ -315,7 +315,7 @@ public class <%- camelize(type) %>ManagerTest {
 
     @Test
     public void testGeometry<%- camelize(type) %>() {
-        <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
 <% if (type === "circle" || type === "symbol") { -%>
         LatLng latLng = new LatLng(12, 34);
         <%- camelize(type) %>Options options = new <%- camelize(type) %>Options().withLatLng(latLng);
@@ -370,7 +370,7 @@ public class <%- camelize(type) %>ManagerTest {
 
     @Test
     public void testFeatureId<%- camelize(type) %>() {
-        <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
 <% if (type === "circle" || type === "symbol") { -%>
         <%- camelize(type) %> <%- type %>Zero = <%- type %>Manager.create(new <%- camelize(type) %>Options().withLatLng(new LatLng()));
         <%- camelize(type) %> <%- type %>One = <%- type %>Manager.create(new <%- camelize(type) %>Options().withLatLng(new LatLng()));
@@ -396,7 +396,7 @@ public class <%- camelize(type) %>ManagerTest {
 
     @Test
     public void test<%- camelize(type) %>DraggableFlag() {
-        <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
 <% if (type === "circle" || type === "symbol") { -%>
         <%- camelize(type) %> <%- type %>Zero = <%- type %>Manager.create(new <%- camelize(type) %>Options().withLatLng(new LatLng()));
 <% } else if (type === "line") { -%>
@@ -426,7 +426,7 @@ public class <%- camelize(type) %>ManagerTest {
 
     @Test
     public void test<%- camelize(property.name) %>LayerProperty() {
-        <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(<%- type  %>Layer, times(0)).setProperties(argThat(new PropertyValueMatcher(<%- camelizeWithLeadingLowercase(property.name) %>(get("<%- property.name %>")))));
 
 <% if (type === "circle" || type === "symbol") { -%>
@@ -456,7 +456,7 @@ public class <%- camelize(type) %>ManagerTest {
 
     @Test
     public void test<%- camelize(type) %>LayerFilter() {
-        <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         Expression expression = Expression.eq(Expression.get("test"), "selected");
         verify(<%- type %>Layer, times(0)).setFilter(expression);
 
@@ -471,7 +471,7 @@ public class <%- camelize(type) %>ManagerTest {
     @Test
     public void testClickListener() {
         On<%- camelize(type) %>ClickListener listener = mock(On<%- camelize(type) %>ClickListener.class);
-        <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         assertTrue(<%- type  %>Manager.getClickListeners().isEmpty());
         <%- type  %>Manager.addClickListener(listener);
         assertTrue(<%- type  %>Manager.getClickListeners().contains(listener));
@@ -482,7 +482,7 @@ public class <%- camelize(type) %>ManagerTest {
     @Test
     public void testLongClickListener() {
         On<%- camelize(type) %>LongClickListener listener = mock(On<%- camelize(type) %>LongClickListener.class);
-        <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         assertTrue(<%- type  %>Manager.getLongClickListeners().isEmpty());
         <%- type  %>Manager.addLongClickListener(listener);
         assertTrue(<%- type  %>Manager.getLongClickListeners().contains(listener));
@@ -493,7 +493,7 @@ public class <%- camelize(type) %>ManagerTest {
     @Test
     public void testDragListener() {
         On<%- camelize(type) %>DragListener listener = mock(On<%- camelize(type) %>DragListener.class);
-        <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         assertTrue(<%- type  %>Manager.getDragListeners().isEmpty());
         <%- type  %>Manager.addDragListener(listener);
         assertTrue(<%- type  %>Manager.getDragListeners().contains(listener));
@@ -503,7 +503,7 @@ public class <%- camelize(type) %>ManagerTest {
 
     @Test
     public void testCustomData() {
-        <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
 <% if (type === "circle" || type === "symbol") { -%>
         <%- camelize(type) %>Options options = new <%- camelize(type) %>Options().withLatLng(new LatLng());
 <% } else if (type === "line") { -%>
@@ -527,7 +527,7 @@ public class <%- camelize(type) %>ManagerTest {
 
     @Test
     public void testClearAll() {
-        <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
 <% if (type === "circle" || type === "symbol") { -%>
         <%- camelize(type) %>Options options = new <%- camelize(type) %>Options().withLatLng(new LatLng());
 <% } else if (type === "line") { -%>
@@ -552,7 +552,7 @@ public class <%- camelize(type) %>ManagerTest {
 
     @Test
     public void testIgnoreClearedAnnotations() {
-        <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
 <% if (type === "circle" || type === "symbol") { -%>
         <%- camelize(type) %>Options options = new <%- camelize(type) %>Options().withLatLng(new LatLng());
 <% } else if (type === "line") { -%>

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/AnnotationManager.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/AnnotationManager.java
@@ -373,6 +373,11 @@ public abstract class AnnotationManager<
         geoJsonSource = coreElementProvider.getSource(geoJsonOptions);
         layer = coreElementProvider.getLayer();
         style.addSource(geoJsonSource);
+
+        if (belowLayerId != null && aboveLayerId != null) {
+            throw new IllegalArgumentException("At most one of belowLayerId and aboveLayerId can be set, not both!");
+        }
+
         if (belowLayerId != null) {
             style.addLayerBelow(layer, belowLayerId);
         } else if (aboveLayerId != null) {

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/AnnotationManager.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/AnnotationManager.java
@@ -63,6 +63,7 @@ public abstract class AnnotationManager<
     private final MapClickResolver mapClickResolver;
     private Style style;
     private String belowLayerId;
+    private String aboveLayerId;
     protected CoreElementProvider<L> coreElementProvider;
     private DraggableAnnotationController draggableAnnotationController;
 
@@ -72,11 +73,12 @@ public abstract class AnnotationManager<
     protected AnnotationManager(MapView mapView, final MapboxMap mapboxMap, Style style,
                                 CoreElementProvider<L> coreElementProvider,
                                 DraggableAnnotationController draggableAnnotationController,
-                                String belowLayerId, final GeoJsonOptions geoJsonOptions) {
+                                String belowLayerId, String aboveLayerId, final GeoJsonOptions geoJsonOptions) {
         this.mapView = mapView;
         this.mapboxMap = mapboxMap;
         this.style = style;
         this.belowLayerId = belowLayerId;
+        this.aboveLayerId = aboveLayerId;
         this.coreElementProvider = coreElementProvider;
         this.draggableAnnotationController = draggableAnnotationController;
 
@@ -370,12 +372,13 @@ public abstract class AnnotationManager<
     private void initializeSourcesAndLayers(GeoJsonOptions geoJsonOptions) {
         geoJsonSource = coreElementProvider.getSource(geoJsonOptions);
         layer = coreElementProvider.getLayer();
-
         style.addSource(geoJsonSource);
-        if (belowLayerId == null) {
-            style.addLayer(layer);
-        } else {
+        if (belowLayerId != null) {
             style.addLayerBelow(layer, belowLayerId);
+        } else if (aboveLayerId != null) {
+            style.addLayerAbove(layer, aboveLayerId);
+        } else {
+            style.addLayer(layer);
         }
 
         initializeDataDrivenPropertyMap();

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/CircleManager.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/CircleManager.java
@@ -43,7 +43,7 @@ public class CircleManager extends AnnotationManager<CircleLayer, Circle, Circle
      */
     @UiThread
     public CircleManager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style) {
-        this(mapView, mapboxMap, style, null, (GeoJsonOptions) null);
+        this(mapView, mapboxMap, style, null, null, (GeoJsonOptions) null);
     }
 
     /**
@@ -52,10 +52,11 @@ public class CircleManager extends AnnotationManager<CircleLayer, Circle, Circle
      * @param mapboxMap    the map object to add circles to
      * @param style        a valid a fully loaded style object
      * @param belowLayerId the id of the layer above the circle layer
+     * @param aboveLayerId the id of the layer below the circle layer
      */
     @UiThread
-    public CircleManager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @Nullable String belowLayerId) {
-        this(mapView, mapboxMap, style, belowLayerId, (GeoJsonOptions) null);
+    public CircleManager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @Nullable String belowLayerId, @Nullable String aboveLayerId) {
+        this(mapView, mapboxMap, style, belowLayerId, aboveLayerId, (GeoJsonOptions) null);
     }
 
     /**
@@ -64,16 +65,17 @@ public class CircleManager extends AnnotationManager<CircleLayer, Circle, Circle
      * @param mapboxMap      the map object to add circles to
      * @param style          a valid a fully loaded style object
      * @param belowLayerId   the id of the layer above the circle layer
+     * @param aboveLayerId   the id of the layer below the circle layer
      * @param geoJsonOptions options for the internal source
      */
     @UiThread
-    public CircleManager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @Nullable String belowLayerId, @Nullable GeoJsonOptions geoJsonOptions) {
-        this(mapView, mapboxMap, style, new CircleElementProvider(), belowLayerId, geoJsonOptions, DraggableAnnotationController.getInstance(mapView, mapboxMap));
+    public CircleManager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @Nullable String belowLayerId, @Nullable String aboveLayerId, @Nullable GeoJsonOptions geoJsonOptions) {
+        this(mapView, mapboxMap, style, new CircleElementProvider(), belowLayerId, aboveLayerId, geoJsonOptions, DraggableAnnotationController.getInstance(mapView, mapboxMap));
     }
 
-    @VisibleForTesting
-    CircleManager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @NonNull CoreElementProvider<CircleLayer> coreElementProvider, @Nullable String belowLayerId, @Nullable GeoJsonOptions geoJsonOptions, DraggableAnnotationController draggableAnnotationController) {
-        super(mapView, mapboxMap, style, coreElementProvider, draggableAnnotationController, belowLayerId, geoJsonOptions);
+    @UiThread
+    CircleManager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @NonNull CoreElementProvider<CircleLayer> coreElementProvider, @Nullable String belowLayerId, @Nullable String aboveLayerId, @Nullable GeoJsonOptions geoJsonOptions, DraggableAnnotationController draggableAnnotationController) {
+        super(mapView, mapboxMap, style, coreElementProvider, draggableAnnotationController, belowLayerId, aboveLayerId, geoJsonOptions);
     }
 
     @Override

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/FillManager.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/FillManager.java
@@ -42,7 +42,7 @@ public class FillManager extends AnnotationManager<FillLayer, Fill, FillOptions,
      */
     @UiThread
     public FillManager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style) {
-        this(mapView, mapboxMap, style, null, (GeoJsonOptions) null);
+        this(mapView, mapboxMap, style, null, null, (GeoJsonOptions) null);
     }
 
     /**
@@ -50,11 +50,12 @@ public class FillManager extends AnnotationManager<FillLayer, Fill, FillOptions,
      *
      * @param mapboxMap    the map object to add fills to
      * @param style        a valid a fully loaded style object
-     * @param belowLayerId the id of the layer above the circle layer
+     * @param belowLayerId the id of the layer above the fill layer
+     * @param aboveLayerId the id of the layer below the fill layer
      */
     @UiThread
-    public FillManager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @Nullable String belowLayerId) {
-        this(mapView, mapboxMap, style, belowLayerId, (GeoJsonOptions) null);
+    public FillManager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @Nullable String belowLayerId, @Nullable String aboveLayerId) {
+        this(mapView, mapboxMap, style, belowLayerId, aboveLayerId, (GeoJsonOptions) null);
     }
 
     /**
@@ -62,17 +63,18 @@ public class FillManager extends AnnotationManager<FillLayer, Fill, FillOptions,
      *
      * @param mapboxMap      the map object to add fills to
      * @param style          a valid a fully loaded style object
-     * @param belowLayerId   the id of the layer above the circle layer
+     * @param belowLayerId   the id of the layer above the fill layer
+     * @param aboveLayerId   the id of the layer below the fill layer
      * @param geoJsonOptions options for the internal source
      */
     @UiThread
-    public FillManager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @Nullable String belowLayerId, @Nullable GeoJsonOptions geoJsonOptions) {
-        this(mapView, mapboxMap, style, new FillElementProvider(), belowLayerId, geoJsonOptions, DraggableAnnotationController.getInstance(mapView, mapboxMap));
+    public FillManager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @Nullable String belowLayerId, @Nullable String aboveLayerId, @Nullable GeoJsonOptions geoJsonOptions) {
+        this(mapView, mapboxMap, style, new FillElementProvider(), belowLayerId, aboveLayerId, geoJsonOptions, DraggableAnnotationController.getInstance(mapView, mapboxMap));
     }
 
-    @VisibleForTesting
-    FillManager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @NonNull CoreElementProvider<FillLayer> coreElementProvider, @Nullable String belowLayerId, @Nullable GeoJsonOptions geoJsonOptions, DraggableAnnotationController draggableAnnotationController) {
-        super(mapView, mapboxMap, style, coreElementProvider, draggableAnnotationController, belowLayerId, geoJsonOptions);
+    @UiThread
+    FillManager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @NonNull CoreElementProvider<FillLayer> coreElementProvider, @Nullable String belowLayerId, @Nullable String aboveLayerId, @Nullable GeoJsonOptions geoJsonOptions, DraggableAnnotationController draggableAnnotationController) {
+        super(mapView, mapboxMap, style, coreElementProvider, draggableAnnotationController, belowLayerId, aboveLayerId, geoJsonOptions);
     }
 
     @Override

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/LineManager.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/LineManager.java
@@ -45,7 +45,7 @@ public class LineManager extends AnnotationManager<LineLayer, Line, LineOptions,
      */
     @UiThread
     public LineManager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style) {
-        this(mapView, mapboxMap, style, null, (GeoJsonOptions) null);
+        this(mapView, mapboxMap, style, null, null, (GeoJsonOptions) null);
     }
 
     /**
@@ -53,11 +53,12 @@ public class LineManager extends AnnotationManager<LineLayer, Line, LineOptions,
      *
      * @param mapboxMap    the map object to add lines to
      * @param style        a valid a fully loaded style object
-     * @param belowLayerId the id of the layer above the circle layer
+     * @param belowLayerId the id of the layer above the line layer
+     * @param aboveLayerId the id of the layer below the line layer
      */
     @UiThread
-    public LineManager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @Nullable String belowLayerId) {
-        this(mapView, mapboxMap, style, belowLayerId, (GeoJsonOptions) null);
+    public LineManager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @Nullable String belowLayerId, @Nullable String aboveLayerId) {
+        this(mapView, mapboxMap, style, belowLayerId, aboveLayerId, (GeoJsonOptions) null);
     }
 
     /**
@@ -65,17 +66,18 @@ public class LineManager extends AnnotationManager<LineLayer, Line, LineOptions,
      *
      * @param mapboxMap      the map object to add lines to
      * @param style          a valid a fully loaded style object
-     * @param belowLayerId   the id of the layer above the circle layer
+     * @param belowLayerId   the id of the layer above the line layer
+     * @param aboveLayerId   the id of the layer below the line layer
      * @param geoJsonOptions options for the internal source
      */
     @UiThread
-    public LineManager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @Nullable String belowLayerId, @Nullable GeoJsonOptions geoJsonOptions) {
-        this(mapView, mapboxMap, style, new LineElementProvider(), belowLayerId, geoJsonOptions, DraggableAnnotationController.getInstance(mapView, mapboxMap));
+    public LineManager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @Nullable String belowLayerId, @Nullable String aboveLayerId, @Nullable GeoJsonOptions geoJsonOptions) {
+        this(mapView, mapboxMap, style, new LineElementProvider(), belowLayerId, aboveLayerId, geoJsonOptions, DraggableAnnotationController.getInstance(mapView, mapboxMap));
     }
 
-    @VisibleForTesting
-    LineManager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @NonNull CoreElementProvider<LineLayer> coreElementProvider, @Nullable String belowLayerId, @Nullable GeoJsonOptions geoJsonOptions, DraggableAnnotationController draggableAnnotationController) {
-        super(mapView, mapboxMap, style, coreElementProvider, draggableAnnotationController, belowLayerId, geoJsonOptions);
+    @UiThread
+    LineManager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @NonNull CoreElementProvider<LineLayer> coreElementProvider, @Nullable String belowLayerId, @Nullable String aboveLayerId, @Nullable GeoJsonOptions geoJsonOptions, DraggableAnnotationController draggableAnnotationController) {
+        super(mapView, mapboxMap, style, coreElementProvider, draggableAnnotationController, belowLayerId, aboveLayerId, geoJsonOptions);
     }
 
     @Override

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/SymbolManager.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/SymbolManager.java
@@ -65,7 +65,7 @@ public class SymbolManager extends AnnotationManager<SymbolLayer, Symbol, Symbol
      */
     @UiThread
     public SymbolManager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style) {
-        this(mapView, mapboxMap, style, null, (GeoJsonOptions) null);
+        this(mapView, mapboxMap, style, null, null, (GeoJsonOptions) null);
     }
 
     /**
@@ -73,11 +73,12 @@ public class SymbolManager extends AnnotationManager<SymbolLayer, Symbol, Symbol
      *
      * @param mapboxMap    the map object to add symbols to
      * @param style        a valid a fully loaded style object
-     * @param belowLayerId the id of the layer above the circle layer
+     * @param belowLayerId the id of the layer above the symbol layer
+     * @param aboveLayerId the id of the layer below the symbol layer
      */
     @UiThread
-    public SymbolManager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @Nullable String belowLayerId) {
-        this(mapView, mapboxMap, style, belowLayerId, (GeoJsonOptions) null);
+    public SymbolManager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @Nullable String belowLayerId, @Nullable String aboveLayerId) {
+        this(mapView, mapboxMap, style, belowLayerId, aboveLayerId, (GeoJsonOptions) null);
     }
 
     /**
@@ -85,12 +86,13 @@ public class SymbolManager extends AnnotationManager<SymbolLayer, Symbol, Symbol
      *
      * @param mapboxMap      the map object to add symbols to
      * @param style          a valid a fully loaded style object
-     * @param belowLayerId   the id of the layer above the circle layer
+     * @param belowLayerId   the id of the layer above the symbol layer
+     * @param aboveLayerId   the id of the layer below the symbol layer
      * @param geoJsonOptions options for the internal source
      */
     @UiThread
-    public SymbolManager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @Nullable String belowLayerId, @Nullable GeoJsonOptions geoJsonOptions) {
-        this(mapView, mapboxMap, style, new SymbolElementProvider(), belowLayerId, geoJsonOptions, DraggableAnnotationController.getInstance(mapView, mapboxMap));
+    public SymbolManager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @Nullable String belowLayerId, @Nullable String aboveLayerId, @Nullable GeoJsonOptions geoJsonOptions) {
+        this(mapView, mapboxMap, style, new SymbolElementProvider(), belowLayerId, aboveLayerId, geoJsonOptions, DraggableAnnotationController.getInstance(mapView, mapboxMap));
     }
 
     /**
@@ -98,18 +100,19 @@ public class SymbolManager extends AnnotationManager<SymbolLayer, Symbol, Symbol
      *
      * @param mapboxMap      the map object to add symbols to
      * @param style          a valid a fully loaded style object
-     * @param belowLayerId   the id of the layer above the circle layer
+     * @param belowLayerId   the id of the layer above the symbol layer
+     * @param aboveLayerId   the id of the layer below the symbol layer
      * @param clusterOptions options for the clustering configuration
      */
     @UiThread
-    public SymbolManager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @Nullable String belowLayerId, @NonNull ClusterOptions clusterOptions) {
-        this(mapView, mapboxMap, style, new SymbolElementProvider(), belowLayerId, new GeoJsonOptions().withCluster(true).withClusterRadius(clusterOptions.getClusterRadius()).withClusterMaxZoom(clusterOptions.getClusterMaxZoom()), DraggableAnnotationController.getInstance(mapView, mapboxMap));
+    public SymbolManager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @Nullable String belowLayerId, @Nullable String aboveLayerId, @NonNull ClusterOptions clusterOptions) {
+        this(mapView, mapboxMap, style, new SymbolElementProvider(), belowLayerId, aboveLayerId, new GeoJsonOptions().withCluster(true).withClusterRadius(clusterOptions.getClusterRadius()).withClusterMaxZoom(clusterOptions.getClusterMaxZoom()), DraggableAnnotationController.getInstance(mapView, mapboxMap));
         clusterOptions.apply(style, coreElementProvider.getSourceId());
     }
 
-    @VisibleForTesting
-    SymbolManager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @NonNull CoreElementProvider<SymbolLayer> coreElementProvider, @Nullable String belowLayerId, @Nullable GeoJsonOptions geoJsonOptions, DraggableAnnotationController draggableAnnotationController) {
-        super(mapView, mapboxMap, style, coreElementProvider, draggableAnnotationController, belowLayerId, geoJsonOptions);
+    @UiThread
+    SymbolManager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @NonNull CoreElementProvider<SymbolLayer> coreElementProvider, @Nullable String belowLayerId, @Nullable String aboveLayerId, @Nullable GeoJsonOptions geoJsonOptions, DraggableAnnotationController draggableAnnotationController) {
+        super(mapView, mapboxMap, style, coreElementProvider, draggableAnnotationController, belowLayerId, aboveLayerId, geoJsonOptions);
     }
 
     @Override

--- a/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/CircleManagerTest.java
+++ b/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/CircleManagerTest.java
@@ -57,7 +57,7 @@ public class CircleManagerTest {
 
     @Test
     public void testInitialization() {
-        circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(style).addSource(geoJsonSource);
         verify(style).addLayer(circleLayer);
         assertTrue(circleManager.dataDrivenPropertyUsageMap.size() > 0);
@@ -71,7 +71,7 @@ public class CircleManagerTest {
 
     @Test
     public void testInitializationOnStyleReload() {
-        circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(style).addSource(geoJsonSource);
         verify(style).addLayer(circleLayer);
         assertTrue(circleManager.dataDrivenPropertyUsageMap.size() > 0);
@@ -112,7 +112,7 @@ public class CircleManagerTest {
 
     @Test
     public void testLayerBelowInitialization() {
-        circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, "test_layer", null, draggableAnnotationController);
+        circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, "test_layer", null, null, draggableAnnotationController);
         verify(style).addSource(geoJsonSource);
         verify(style).addLayerBelow(circleLayer, "test_layer");
         assertTrue(circleManager.dataDrivenPropertyUsageMap.size() > 0);
@@ -125,7 +125,7 @@ public class CircleManagerTest {
 
     @Test
     public void testGeoJsonOptionsInitialization() {
-        circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, geoJsonOptions, draggableAnnotationController);
+        circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, geoJsonOptions, draggableAnnotationController);
         verify(style).addSource(optionedGeoJsonSource);
         verify(style).addLayer(circleLayer);
         assertTrue(circleManager.dataDrivenPropertyUsageMap.size() > 0);
@@ -139,20 +139,20 @@ public class CircleManagerTest {
 
     @Test
     public void testLayerId() {
-        circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         assertEquals(layerId, circleManager.getLayerId());
     }
 
     @Test
     public void testAddCircle() {
-        circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         Circle circle = circleManager.create(new CircleOptions().withLatLng(new LatLng()));
         assertEquals(circleManager.getAnnotations().get(0), circle);
     }
 
     @Test
     public void addCircleFromFeatureCollection() {
-        circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         Geometry geometry = Point.fromLngLat(10, 10);
 
         Feature feature = Feature.fromGeometry(geometry);
@@ -181,7 +181,7 @@ public class CircleManagerTest {
 
     @Test
     public void addCircles() {
-        circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         List<LatLng> latLngList = new ArrayList<>();
         latLngList.add(new LatLng());
         latLngList.add(new LatLng(1, 1));
@@ -196,7 +196,7 @@ public class CircleManagerTest {
 
     @Test
     public void testDeleteCircle() {
-        circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         Circle circle = circleManager.create(new CircleOptions().withLatLng(new LatLng()));
         circleManager.delete(circle);
         assertTrue(circleManager.getAnnotations().size() == 0);
@@ -204,7 +204,7 @@ public class CircleManagerTest {
 
     @Test
     public void testGeometryCircle() {
-        circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         LatLng latLng = new LatLng(12, 34);
         CircleOptions options = new CircleOptions().withLatLng(latLng);
         Circle circle = circleManager.create(options);
@@ -216,7 +216,7 @@ public class CircleManagerTest {
 
     @Test
     public void testFeatureIdCircle() {
-        circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         Circle circleZero = circleManager.create(new CircleOptions().withLatLng(new LatLng()));
         Circle circleOne = circleManager.create(new CircleOptions().withLatLng(new LatLng()));
         assertEquals(circleZero.getFeature().get(Circle.ID_KEY).getAsLong(), 0);
@@ -225,7 +225,7 @@ public class CircleManagerTest {
 
     @Test
     public void testCircleDraggableFlag() {
-        circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         Circle circleZero = circleManager.create(new CircleOptions().withLatLng(new LatLng()));
 
         assertFalse(circleZero.isDraggable());
@@ -238,7 +238,7 @@ public class CircleManagerTest {
 
     @Test
     public void testCircleRadiusLayerProperty() {
-        circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(circleLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(circleRadius(get("circle-radius")))));
 
         CircleOptions options = new CircleOptions().withLatLng(new LatLng()).withCircleRadius(2.0f);
@@ -251,7 +251,7 @@ public class CircleManagerTest {
 
     @Test
     public void testCircleColorLayerProperty() {
-        circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(circleLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(circleColor(get("circle-color")))));
 
         CircleOptions options = new CircleOptions().withLatLng(new LatLng()).withCircleColor("rgba(0, 0, 0, 1)");
@@ -264,7 +264,7 @@ public class CircleManagerTest {
 
     @Test
     public void testCircleBlurLayerProperty() {
-        circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(circleLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(circleBlur(get("circle-blur")))));
 
         CircleOptions options = new CircleOptions().withLatLng(new LatLng()).withCircleBlur(2.0f);
@@ -277,7 +277,7 @@ public class CircleManagerTest {
 
     @Test
     public void testCircleOpacityLayerProperty() {
-        circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(circleLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(circleOpacity(get("circle-opacity")))));
 
         CircleOptions options = new CircleOptions().withLatLng(new LatLng()).withCircleOpacity(2.0f);
@@ -290,7 +290,7 @@ public class CircleManagerTest {
 
     @Test
     public void testCircleStrokeWidthLayerProperty() {
-        circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(circleLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(circleStrokeWidth(get("circle-stroke-width")))));
 
         CircleOptions options = new CircleOptions().withLatLng(new LatLng()).withCircleStrokeWidth(2.0f);
@@ -303,7 +303,7 @@ public class CircleManagerTest {
 
     @Test
     public void testCircleStrokeColorLayerProperty() {
-        circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(circleLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(circleStrokeColor(get("circle-stroke-color")))));
 
         CircleOptions options = new CircleOptions().withLatLng(new LatLng()).withCircleStrokeColor("rgba(0, 0, 0, 1)");
@@ -316,7 +316,7 @@ public class CircleManagerTest {
 
     @Test
     public void testCircleStrokeOpacityLayerProperty() {
-        circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(circleLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(circleStrokeOpacity(get("circle-stroke-opacity")))));
 
         CircleOptions options = new CircleOptions().withLatLng(new LatLng()).withCircleStrokeOpacity(2.0f);
@@ -329,7 +329,7 @@ public class CircleManagerTest {
 
     @Test
     public void testCircleLayerFilter() {
-        circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         Expression expression = Expression.eq(Expression.get("test"), "selected");
         verify(circleLayer, times(0)).setFilter(expression);
 
@@ -344,7 +344,7 @@ public class CircleManagerTest {
     @Test
     public void testClickListener() {
         OnCircleClickListener listener = mock(OnCircleClickListener.class);
-        circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         assertTrue(circleManager.getClickListeners().isEmpty());
         circleManager.addClickListener(listener);
         assertTrue(circleManager.getClickListeners().contains(listener));
@@ -355,7 +355,7 @@ public class CircleManagerTest {
     @Test
     public void testLongClickListener() {
         OnCircleLongClickListener listener = mock(OnCircleLongClickListener.class);
-        circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         assertTrue(circleManager.getLongClickListeners().isEmpty());
         circleManager.addLongClickListener(listener);
         assertTrue(circleManager.getLongClickListeners().contains(listener));
@@ -366,7 +366,7 @@ public class CircleManagerTest {
     @Test
     public void testDragListener() {
         OnCircleDragListener listener = mock(OnCircleDragListener.class);
-        circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         assertTrue(circleManager.getDragListeners().isEmpty());
         circleManager.addDragListener(listener);
         assertTrue(circleManager.getDragListeners().contains(listener));
@@ -376,7 +376,7 @@ public class CircleManagerTest {
 
     @Test
     public void testCustomData() {
-        circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         CircleOptions options = new CircleOptions().withLatLng(new LatLng());
         options.withData(new JsonPrimitive("hello"));
         Circle circle = circleManager.create(options);
@@ -385,7 +385,7 @@ public class CircleManagerTest {
 
     @Test
     public void testClearAll() {
-        circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         CircleOptions options = new CircleOptions().withLatLng(new LatLng());
         circleManager.create(options);
         assertEquals(1, circleManager.getAnnotations().size());
@@ -395,7 +395,7 @@ public class CircleManagerTest {
 
     @Test
     public void testIgnoreClearedAnnotations() {
-        circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         CircleOptions options = new CircleOptions().withLatLng(new LatLng());
         Circle circle = circleManager.create(options);
         assertEquals(1, circleManager.annotations.size());

--- a/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/FillManagerTest.java
+++ b/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/FillManagerTest.java
@@ -57,7 +57,7 @@ public class FillManagerTest {
 
     @Test
     public void testInitialization() {
-        fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(style).addSource(geoJsonSource);
         verify(style).addLayer(fillLayer);
         assertTrue(fillManager.dataDrivenPropertyUsageMap.size() > 0);
@@ -71,7 +71,7 @@ public class FillManagerTest {
 
     @Test
     public void testInitializationOnStyleReload() {
-        fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(style).addSource(geoJsonSource);
         verify(style).addLayer(fillLayer);
         assertTrue(fillManager.dataDrivenPropertyUsageMap.size() > 0);
@@ -112,7 +112,7 @@ public class FillManagerTest {
 
     @Test
     public void testLayerBelowInitialization() {
-        fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, "test_layer", null, draggableAnnotationController);
+        fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, "test_layer", null, null, draggableAnnotationController);
         verify(style).addSource(geoJsonSource);
         verify(style).addLayerBelow(fillLayer, "test_layer");
         assertTrue(fillManager.dataDrivenPropertyUsageMap.size() > 0);
@@ -125,7 +125,7 @@ public class FillManagerTest {
 
     @Test
     public void testGeoJsonOptionsInitialization() {
-        fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, geoJsonOptions, draggableAnnotationController);
+        fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, geoJsonOptions, draggableAnnotationController);
         verify(style).addSource(optionedGeoJsonSource);
         verify(style).addLayer(fillLayer);
         assertTrue(fillManager.dataDrivenPropertyUsageMap.size() > 0);
@@ -139,13 +139,13 @@ public class FillManagerTest {
 
     @Test
     public void testLayerId() {
-        fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         assertEquals(layerId, fillManager.getLayerId());
     }
 
     @Test
     public void testAddFill() {
-        fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         List<LatLng> innerLatLngs = new ArrayList<>();
         innerLatLngs.add(new LatLng());
         innerLatLngs.add(new LatLng(1, 1));
@@ -159,7 +159,7 @@ public class FillManagerTest {
 
     @Test
     public void addFillFromFeatureCollection() {
-        fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         List<Point> innerPoints = new ArrayList<>();
         innerPoints.add(Point.fromLngLat(0, 0));
         innerPoints.add(Point.fromLngLat(1, 1));
@@ -189,7 +189,7 @@ public class FillManagerTest {
 
     @Test
     public void addFills() {
-        fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         final List<List<LatLng>> latLngListOne = new ArrayList<>();
         latLngListOne.add(new ArrayList<LatLng>() {{
             add(new LatLng(2, 2));
@@ -225,7 +225,7 @@ public class FillManagerTest {
 
     @Test
     public void testDeleteFill() {
-        fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         List<LatLng> innerLatLngs = new ArrayList<>();
         innerLatLngs.add(new LatLng());
         innerLatLngs.add(new LatLng(1, 1));
@@ -239,7 +239,7 @@ public class FillManagerTest {
 
     @Test
     public void testGeometryFill() {
-        fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         List<LatLng> innerLatLngs = new ArrayList<>();
         innerLatLngs.add(new LatLng());
         innerLatLngs.add(new LatLng(1, 1));
@@ -268,7 +268,7 @@ public class FillManagerTest {
 
     @Test
     public void testFeatureIdFill() {
-        fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         List<LatLng> innerLatLngs = new ArrayList<>();
         innerLatLngs.add(new LatLng());
         innerLatLngs.add(new LatLng(1, 1));
@@ -283,7 +283,7 @@ public class FillManagerTest {
 
     @Test
     public void testFillDraggableFlag() {
-        fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         List<LatLng> innerLatLngs = new ArrayList<>();
         innerLatLngs.add(new LatLng());
         innerLatLngs.add(new LatLng(1, 1));
@@ -302,7 +302,7 @@ public class FillManagerTest {
 
     @Test
     public void testFillOpacityLayerProperty() {
-        fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(fillLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(fillOpacity(get("fill-opacity")))));
 
         List<LatLng> innerLatLngs = new ArrayList<>();
@@ -321,7 +321,7 @@ public class FillManagerTest {
 
     @Test
     public void testFillColorLayerProperty() {
-        fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(fillLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(fillColor(get("fill-color")))));
 
         List<LatLng> innerLatLngs = new ArrayList<>();
@@ -340,7 +340,7 @@ public class FillManagerTest {
 
     @Test
     public void testFillOutlineColorLayerProperty() {
-        fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(fillLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(fillOutlineColor(get("fill-outline-color")))));
 
         List<LatLng> innerLatLngs = new ArrayList<>();
@@ -359,7 +359,7 @@ public class FillManagerTest {
 
     @Test
     public void testFillPatternLayerProperty() {
-        fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(fillLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(fillPattern(get("fill-pattern")))));
 
         List<LatLng> innerLatLngs = new ArrayList<>();
@@ -378,7 +378,7 @@ public class FillManagerTest {
 
     @Test
     public void testFillLayerFilter() {
-        fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         Expression expression = Expression.eq(Expression.get("test"), "selected");
         verify(fillLayer, times(0)).setFilter(expression);
 
@@ -393,7 +393,7 @@ public class FillManagerTest {
     @Test
     public void testClickListener() {
         OnFillClickListener listener = mock(OnFillClickListener.class);
-        fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         assertTrue(fillManager.getClickListeners().isEmpty());
         fillManager.addClickListener(listener);
         assertTrue(fillManager.getClickListeners().contains(listener));
@@ -404,7 +404,7 @@ public class FillManagerTest {
     @Test
     public void testLongClickListener() {
         OnFillLongClickListener listener = mock(OnFillLongClickListener.class);
-        fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         assertTrue(fillManager.getLongClickListeners().isEmpty());
         fillManager.addLongClickListener(listener);
         assertTrue(fillManager.getLongClickListeners().contains(listener));
@@ -415,7 +415,7 @@ public class FillManagerTest {
     @Test
     public void testDragListener() {
         OnFillDragListener listener = mock(OnFillDragListener.class);
-        fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         assertTrue(fillManager.getDragListeners().isEmpty());
         fillManager.addDragListener(listener);
         assertTrue(fillManager.getDragListeners().contains(listener));
@@ -425,7 +425,7 @@ public class FillManagerTest {
 
     @Test
     public void testCustomData() {
-        fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         List<LatLng> innerLatLngs = new ArrayList<>();
         innerLatLngs.add(new LatLng());
         innerLatLngs.add(new LatLng(1, 1));
@@ -440,7 +440,7 @@ public class FillManagerTest {
 
     @Test
     public void testClearAll() {
-        fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         List<LatLng> innerLatLngs = new ArrayList<>();
         innerLatLngs.add(new LatLng());
         innerLatLngs.add(new LatLng(1, 1));
@@ -456,7 +456,7 @@ public class FillManagerTest {
 
     @Test
     public void testIgnoreClearedAnnotations() {
-        fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         List<LatLng> innerLatLngs = new ArrayList<>();
         innerLatLngs.add(new LatLng());
         innerLatLngs.add(new LatLng(1, 1));

--- a/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/LineManagerTest.java
+++ b/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/LineManagerTest.java
@@ -57,7 +57,7 @@ public class LineManagerTest {
 
     @Test
     public void testInitialization() {
-        lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(style).addSource(geoJsonSource);
         verify(style).addLayer(lineLayer);
         assertTrue(lineManager.dataDrivenPropertyUsageMap.size() > 0);
@@ -71,7 +71,7 @@ public class LineManagerTest {
 
     @Test
     public void testInitializationOnStyleReload() {
-        lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(style).addSource(geoJsonSource);
         verify(style).addLayer(lineLayer);
         assertTrue(lineManager.dataDrivenPropertyUsageMap.size() > 0);
@@ -112,7 +112,7 @@ public class LineManagerTest {
 
     @Test
     public void testLayerBelowInitialization() {
-        lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, "test_layer", null, draggableAnnotationController);
+        lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, "test_layer", null, null, draggableAnnotationController);
         verify(style).addSource(geoJsonSource);
         verify(style).addLayerBelow(lineLayer, "test_layer");
         assertTrue(lineManager.dataDrivenPropertyUsageMap.size() > 0);
@@ -125,7 +125,7 @@ public class LineManagerTest {
 
     @Test
     public void testGeoJsonOptionsInitialization() {
-        lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, geoJsonOptions, draggableAnnotationController);
+        lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, geoJsonOptions, draggableAnnotationController);
         verify(style).addSource(optionedGeoJsonSource);
         verify(style).addLayer(lineLayer);
         assertTrue(lineManager.dataDrivenPropertyUsageMap.size() > 0);
@@ -139,13 +139,13 @@ public class LineManagerTest {
 
     @Test
     public void testLayerId() {
-        lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         assertEquals(layerId, lineManager.getLayerId());
     }
 
     @Test
     public void testAddLine() {
-        lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         List<LatLng> latLngs = new ArrayList<>();
         latLngs.add(new LatLng());
         latLngs.add(new LatLng(1, 1));
@@ -155,7 +155,7 @@ public class LineManagerTest {
 
     @Test
     public void addLineFromFeatureCollection() {
-        lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         List<Point> points = new ArrayList<>();
         points.add(Point.fromLngLat(0, 0));
         points.add(Point.fromLngLat(1, 1));
@@ -189,7 +189,7 @@ public class LineManagerTest {
 
     @Test
     public void addLines() {
-        lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         List<List<LatLng>> latLngList = new ArrayList<>();
         latLngList.add(new ArrayList<LatLng>() {{
             add(new LatLng(2, 2));
@@ -210,7 +210,7 @@ public class LineManagerTest {
 
     @Test
     public void testDeleteLine() {
-        lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         List<LatLng> latLngs = new ArrayList<>();
         latLngs.add(new LatLng());
         latLngs.add(new LatLng(1, 1));
@@ -221,7 +221,7 @@ public class LineManagerTest {
 
     @Test
     public void testGeometryLine() {
-        lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         List<LatLng> latLngs = new ArrayList<>();
         latLngs.add(new LatLng());
         latLngs.add(new LatLng(1, 1));
@@ -241,7 +241,7 @@ public class LineManagerTest {
 
     @Test
     public void testFeatureIdLine() {
-        lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         List<LatLng> latLngs = new ArrayList<>();
         latLngs.add(new LatLng());
         latLngs.add(new LatLng(1, 1));
@@ -253,7 +253,7 @@ public class LineManagerTest {
 
     @Test
     public void testLineDraggableFlag() {
-        lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         List<LatLng> latLngs = new ArrayList<>();
         latLngs.add(new LatLng());
         latLngs.add(new LatLng(1, 1));
@@ -269,7 +269,7 @@ public class LineManagerTest {
 
     @Test
     public void testLineJoinLayerProperty() {
-        lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(lineLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(lineJoin(get("line-join")))));
 
         List<LatLng> latLngs = new ArrayList<>();
@@ -285,7 +285,7 @@ public class LineManagerTest {
 
     @Test
     public void testLineOpacityLayerProperty() {
-        lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(lineLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(lineOpacity(get("line-opacity")))));
 
         List<LatLng> latLngs = new ArrayList<>();
@@ -301,7 +301,7 @@ public class LineManagerTest {
 
     @Test
     public void testLineColorLayerProperty() {
-        lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(lineLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(lineColor(get("line-color")))));
 
         List<LatLng> latLngs = new ArrayList<>();
@@ -317,7 +317,7 @@ public class LineManagerTest {
 
     @Test
     public void testLineWidthLayerProperty() {
-        lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(lineLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(lineWidth(get("line-width")))));
 
         List<LatLng> latLngs = new ArrayList<>();
@@ -333,7 +333,7 @@ public class LineManagerTest {
 
     @Test
     public void testLineGapWidthLayerProperty() {
-        lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(lineLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(lineGapWidth(get("line-gap-width")))));
 
         List<LatLng> latLngs = new ArrayList<>();
@@ -349,7 +349,7 @@ public class LineManagerTest {
 
     @Test
     public void testLineOffsetLayerProperty() {
-        lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(lineLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(lineOffset(get("line-offset")))));
 
         List<LatLng> latLngs = new ArrayList<>();
@@ -365,7 +365,7 @@ public class LineManagerTest {
 
     @Test
     public void testLineBlurLayerProperty() {
-        lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(lineLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(lineBlur(get("line-blur")))));
 
         List<LatLng> latLngs = new ArrayList<>();
@@ -381,7 +381,7 @@ public class LineManagerTest {
 
     @Test
     public void testLinePatternLayerProperty() {
-        lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(lineLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(linePattern(get("line-pattern")))));
 
         List<LatLng> latLngs = new ArrayList<>();
@@ -397,7 +397,7 @@ public class LineManagerTest {
 
     @Test
     public void testLineLayerFilter() {
-        lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         Expression expression = Expression.eq(Expression.get("test"), "selected");
         verify(lineLayer, times(0)).setFilter(expression);
 
@@ -412,7 +412,7 @@ public class LineManagerTest {
     @Test
     public void testClickListener() {
         OnLineClickListener listener = mock(OnLineClickListener.class);
-        lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         assertTrue(lineManager.getClickListeners().isEmpty());
         lineManager.addClickListener(listener);
         assertTrue(lineManager.getClickListeners().contains(listener));
@@ -423,7 +423,7 @@ public class LineManagerTest {
     @Test
     public void testLongClickListener() {
         OnLineLongClickListener listener = mock(OnLineLongClickListener.class);
-        lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         assertTrue(lineManager.getLongClickListeners().isEmpty());
         lineManager.addLongClickListener(listener);
         assertTrue(lineManager.getLongClickListeners().contains(listener));
@@ -434,7 +434,7 @@ public class LineManagerTest {
     @Test
     public void testDragListener() {
         OnLineDragListener listener = mock(OnLineDragListener.class);
-        lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         assertTrue(lineManager.getDragListeners().isEmpty());
         lineManager.addDragListener(listener);
         assertTrue(lineManager.getDragListeners().contains(listener));
@@ -444,7 +444,7 @@ public class LineManagerTest {
 
     @Test
     public void testCustomData() {
-        lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         List<LatLng> latLngs = new ArrayList<>();
         latLngs.add(new LatLng());
         latLngs.add(new LatLng(1, 1));
@@ -456,7 +456,7 @@ public class LineManagerTest {
 
     @Test
     public void testClearAll() {
-        lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         List<LatLng> latLngs = new ArrayList<>();
         latLngs.add(new LatLng());
         latLngs.add(new LatLng(1, 1));
@@ -469,7 +469,7 @@ public class LineManagerTest {
 
     @Test
     public void testIgnoreClearedAnnotations() {
-        lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         List<LatLng> latLngs = new ArrayList<>();
         latLngs.add(new LatLng());
         latLngs.add(new LatLng(1, 1));

--- a/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/SymbolManagerTest.java
+++ b/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/SymbolManagerTest.java
@@ -57,7 +57,7 @@ public class SymbolManagerTest {
 
     @Test
     public void testInitialization() {
-        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(style).addSource(geoJsonSource);
         verify(style).addLayer(symbolLayer);
         assertTrue(symbolManager.dataDrivenPropertyUsageMap.size() > 0);
@@ -71,7 +71,7 @@ public class SymbolManagerTest {
 
     @Test
     public void testInitializationOnStyleReload() {
-        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(style).addSource(geoJsonSource);
         verify(style).addLayer(symbolLayer);
         assertTrue(symbolManager.dataDrivenPropertyUsageMap.size() > 0);
@@ -112,7 +112,7 @@ public class SymbolManagerTest {
 
     @Test
     public void testLayerBelowInitialization() {
-        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, "test_layer", null, draggableAnnotationController);
+        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, "test_layer", null, null, draggableAnnotationController);
         verify(style).addSource(geoJsonSource);
         verify(style).addLayerBelow(symbolLayer, "test_layer");
         assertTrue(symbolManager.dataDrivenPropertyUsageMap.size() > 0);
@@ -125,7 +125,7 @@ public class SymbolManagerTest {
 
     @Test
     public void testGeoJsonOptionsInitialization() {
-        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, geoJsonOptions, draggableAnnotationController);
+        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, geoJsonOptions, draggableAnnotationController);
         verify(style).addSource(optionedGeoJsonSource);
         verify(style).addLayer(symbolLayer);
         assertTrue(symbolManager.dataDrivenPropertyUsageMap.size() > 0);
@@ -139,20 +139,20 @@ public class SymbolManagerTest {
 
     @Test
     public void testLayerId() {
-        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         assertEquals(layerId, symbolManager.getLayerId());
     }
 
     @Test
     public void testAddSymbol() {
-        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         Symbol symbol = symbolManager.create(new SymbolOptions().withLatLng(new LatLng()));
         assertEquals(symbolManager.getAnnotations().get(0), symbol);
     }
 
     @Test
     public void addSymbolFromFeatureCollection() {
-        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         Geometry geometry = Point.fromLngLat(10, 10);
 
         Feature feature = Feature.fromGeometry(geometry);
@@ -225,7 +225,7 @@ public class SymbolManagerTest {
 
     @Test
     public void addSymbols() {
-        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         List<LatLng> latLngList = new ArrayList<>();
         latLngList.add(new LatLng());
         latLngList.add(new LatLng(1, 1));
@@ -240,7 +240,7 @@ public class SymbolManagerTest {
 
     @Test
     public void testDeleteSymbol() {
-        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         Symbol symbol = symbolManager.create(new SymbolOptions().withLatLng(new LatLng()));
         symbolManager.delete(symbol);
         assertTrue(symbolManager.getAnnotations().size() == 0);
@@ -248,7 +248,7 @@ public class SymbolManagerTest {
 
     @Test
     public void testGeometrySymbol() {
-        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         LatLng latLng = new LatLng(12, 34);
         SymbolOptions options = new SymbolOptions().withLatLng(latLng);
         Symbol symbol = symbolManager.create(options);
@@ -260,7 +260,7 @@ public class SymbolManagerTest {
 
     @Test
     public void testFeatureIdSymbol() {
-        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         Symbol symbolZero = symbolManager.create(new SymbolOptions().withLatLng(new LatLng()));
         Symbol symbolOne = symbolManager.create(new SymbolOptions().withLatLng(new LatLng()));
         assertEquals(symbolZero.getFeature().get(Symbol.ID_KEY).getAsLong(), 0);
@@ -269,7 +269,7 @@ public class SymbolManagerTest {
 
     @Test
     public void testSymbolDraggableFlag() {
-        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         Symbol symbolZero = symbolManager.create(new SymbolOptions().withLatLng(new LatLng()));
 
         assertFalse(symbolZero.isDraggable());
@@ -282,7 +282,7 @@ public class SymbolManagerTest {
 
     @Test
     public void testSymbolSortKeyLayerProperty() {
-        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(symbolLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(symbolSortKey(get("symbol-sort-key")))));
 
         SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withSymbolSortKey(2.0f);
@@ -295,7 +295,7 @@ public class SymbolManagerTest {
 
     @Test
     public void testIconSizeLayerProperty() {
-        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(symbolLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(iconSize(get("icon-size")))));
 
         SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withIconSize(2.0f);
@@ -308,7 +308,7 @@ public class SymbolManagerTest {
 
     @Test
     public void testIconImageLayerProperty() {
-        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(symbolLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(iconImage(get("icon-image")))));
 
         SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withIconImage("undefined");
@@ -321,7 +321,7 @@ public class SymbolManagerTest {
 
     @Test
     public void testIconRotateLayerProperty() {
-        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(symbolLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(iconRotate(get("icon-rotate")))));
 
         SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withIconRotate(2.0f);
@@ -334,7 +334,7 @@ public class SymbolManagerTest {
 
     @Test
     public void testIconOffsetLayerProperty() {
-        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(symbolLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(iconOffset(get("icon-offset")))));
 
         SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withIconOffset(new Float[]{0f, 0f});
@@ -347,7 +347,7 @@ public class SymbolManagerTest {
 
     @Test
     public void testIconAnchorLayerProperty() {
-        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(symbolLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(iconAnchor(get("icon-anchor")))));
 
         SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withIconAnchor(ICON_ANCHOR_CENTER);
@@ -360,7 +360,7 @@ public class SymbolManagerTest {
 
     @Test
     public void testTextFieldLayerProperty() {
-        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(symbolLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(textField(get("text-field")))));
 
         SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withTextField("");
@@ -373,7 +373,7 @@ public class SymbolManagerTest {
 
     @Test
     public void testTextFontLayerProperty() {
-        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(symbolLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(textFont(get("text-font")))));
 
         SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withTextFont(new String[]{"Open Sans Regular", "Arial Unicode MS Regular"});
@@ -386,7 +386,7 @@ public class SymbolManagerTest {
 
     @Test
     public void testTextSizeLayerProperty() {
-        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(symbolLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(textSize(get("text-size")))));
 
         SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withTextSize(2.0f);
@@ -399,7 +399,7 @@ public class SymbolManagerTest {
 
     @Test
     public void testTextMaxWidthLayerProperty() {
-        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(symbolLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(textMaxWidth(get("text-max-width")))));
 
         SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withTextMaxWidth(2.0f);
@@ -412,7 +412,7 @@ public class SymbolManagerTest {
 
     @Test
     public void testTextLetterSpacingLayerProperty() {
-        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(symbolLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(textLetterSpacing(get("text-letter-spacing")))));
 
         SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withTextLetterSpacing(2.0f);
@@ -425,7 +425,7 @@ public class SymbolManagerTest {
 
     @Test
     public void testTextJustifyLayerProperty() {
-        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(symbolLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(textJustify(get("text-justify")))));
 
         SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withTextJustify(TEXT_JUSTIFY_AUTO);
@@ -438,7 +438,7 @@ public class SymbolManagerTest {
 
     @Test
     public void testTextRadialOffsetLayerProperty() {
-        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(symbolLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(textRadialOffset(get("text-radial-offset")))));
 
         SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withTextRadialOffset(2.0f);
@@ -451,7 +451,7 @@ public class SymbolManagerTest {
 
     @Test
     public void testTextAnchorLayerProperty() {
-        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(symbolLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(textAnchor(get("text-anchor")))));
 
         SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withTextAnchor(TEXT_ANCHOR_CENTER);
@@ -464,7 +464,7 @@ public class SymbolManagerTest {
 
     @Test
     public void testTextRotateLayerProperty() {
-        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(symbolLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(textRotate(get("text-rotate")))));
 
         SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withTextRotate(2.0f);
@@ -477,7 +477,7 @@ public class SymbolManagerTest {
 
     @Test
     public void testTextTransformLayerProperty() {
-        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(symbolLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(textTransform(get("text-transform")))));
 
         SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withTextTransform(TEXT_TRANSFORM_NONE);
@@ -490,7 +490,7 @@ public class SymbolManagerTest {
 
     @Test
     public void testTextOffsetLayerProperty() {
-        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(symbolLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(textOffset(get("text-offset")))));
 
         SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withTextOffset(new Float[]{0f, 0f});
@@ -503,7 +503,7 @@ public class SymbolManagerTest {
 
     @Test
     public void testIconOpacityLayerProperty() {
-        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(symbolLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(iconOpacity(get("icon-opacity")))));
 
         SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withIconOpacity(2.0f);
@@ -516,7 +516,7 @@ public class SymbolManagerTest {
 
     @Test
     public void testIconColorLayerProperty() {
-        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(symbolLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(iconColor(get("icon-color")))));
 
         SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withIconColor("rgba(0, 0, 0, 1)");
@@ -529,7 +529,7 @@ public class SymbolManagerTest {
 
     @Test
     public void testIconHaloColorLayerProperty() {
-        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(symbolLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(iconHaloColor(get("icon-halo-color")))));
 
         SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withIconHaloColor("rgba(0, 0, 0, 1)");
@@ -542,7 +542,7 @@ public class SymbolManagerTest {
 
     @Test
     public void testIconHaloWidthLayerProperty() {
-        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(symbolLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(iconHaloWidth(get("icon-halo-width")))));
 
         SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withIconHaloWidth(2.0f);
@@ -555,7 +555,7 @@ public class SymbolManagerTest {
 
     @Test
     public void testIconHaloBlurLayerProperty() {
-        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(symbolLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(iconHaloBlur(get("icon-halo-blur")))));
 
         SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withIconHaloBlur(2.0f);
@@ -568,7 +568,7 @@ public class SymbolManagerTest {
 
     @Test
     public void testTextOpacityLayerProperty() {
-        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(symbolLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(textOpacity(get("text-opacity")))));
 
         SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withTextOpacity(2.0f);
@@ -581,7 +581,7 @@ public class SymbolManagerTest {
 
     @Test
     public void testTextColorLayerProperty() {
-        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(symbolLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(textColor(get("text-color")))));
 
         SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withTextColor("rgba(0, 0, 0, 1)");
@@ -594,7 +594,7 @@ public class SymbolManagerTest {
 
     @Test
     public void testTextHaloColorLayerProperty() {
-        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(symbolLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(textHaloColor(get("text-halo-color")))));
 
         SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withTextHaloColor("rgba(0, 0, 0, 1)");
@@ -607,7 +607,7 @@ public class SymbolManagerTest {
 
     @Test
     public void testTextHaloWidthLayerProperty() {
-        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(symbolLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(textHaloWidth(get("text-halo-width")))));
 
         SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withTextHaloWidth(2.0f);
@@ -620,7 +620,7 @@ public class SymbolManagerTest {
 
     @Test
     public void testTextHaloBlurLayerProperty() {
-        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(symbolLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(textHaloBlur(get("text-halo-blur")))));
 
         SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withTextHaloBlur(2.0f);
@@ -633,7 +633,7 @@ public class SymbolManagerTest {
 
     @Test
     public void testSymbolLayerFilter() {
-        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         Expression expression = Expression.eq(Expression.get("test"), "selected");
         verify(symbolLayer, times(0)).setFilter(expression);
 
@@ -648,7 +648,7 @@ public class SymbolManagerTest {
     @Test
     public void testClickListener() {
         OnSymbolClickListener listener = mock(OnSymbolClickListener.class);
-        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         assertTrue(symbolManager.getClickListeners().isEmpty());
         symbolManager.addClickListener(listener);
         assertTrue(symbolManager.getClickListeners().contains(listener));
@@ -659,7 +659,7 @@ public class SymbolManagerTest {
     @Test
     public void testLongClickListener() {
         OnSymbolLongClickListener listener = mock(OnSymbolLongClickListener.class);
-        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         assertTrue(symbolManager.getLongClickListeners().isEmpty());
         symbolManager.addLongClickListener(listener);
         assertTrue(symbolManager.getLongClickListeners().contains(listener));
@@ -670,7 +670,7 @@ public class SymbolManagerTest {
     @Test
     public void testDragListener() {
         OnSymbolDragListener listener = mock(OnSymbolDragListener.class);
-        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         assertTrue(symbolManager.getDragListeners().isEmpty());
         symbolManager.addDragListener(listener);
         assertTrue(symbolManager.getDragListeners().contains(listener));
@@ -680,7 +680,7 @@ public class SymbolManagerTest {
 
     @Test
     public void testCustomData() {
-        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         SymbolOptions options = new SymbolOptions().withLatLng(new LatLng());
         options.withData(new JsonPrimitive("hello"));
         Symbol symbol = symbolManager.create(options);
@@ -689,7 +689,7 @@ public class SymbolManagerTest {
 
     @Test
     public void testClearAll() {
-        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         SymbolOptions options = new SymbolOptions().withLatLng(new LatLng());
         symbolManager.create(options);
         assertEquals(1, symbolManager.getAnnotations().size());
@@ -699,7 +699,7 @@ public class SymbolManagerTest {
 
     @Test
     public void testIgnoreClearedAnnotations() {
-        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         SymbolOptions options = new SymbolOptions().withLatLng(new LatLng());
         Symbol symbol = symbolManager.create(options);
         assertEquals(1, symbolManager.annotations.size());


### PR DESCRIPTION
Right now, only the below layer is exposed. This exposes the above layer as well.

I do realise that there is some code generation setup in the repo (see [scripts](https://github.com/maplibre/maplibre-plugins-android/tree/main/plugin-annotation/scripts)), but I don't really know how to use them, or even if you are planning on keeping them (the repo does not seem very active to be honest).

Are the changes fine like this, or should I try to get them through the codegen? For the latter, how do you run the codegen?

@RomanBapst: FYI