### PR TITLE
Fix indentation in code generation scripts

### DIFF
--- a/plugin-annotation/scripts/annotation.java.ejs
+++ b/plugin-annotation/scripts/annotation.java.ejs
@@ -32,375 +32,375 @@ import static com.mapbox.mapboxsdk.constants.GeometryConstants.MIN_MERCATOR_LATI
 @UiThread
 public class <%- camelize(type) %> extends Annotation<<%- geometryType(type) %>> {
 
-  private final AnnotationManager<?, <%- camelize(type) %>, ?, ?, ?, ?> annotationManager;
+    private final AnnotationManager<?, <%- camelize(type) %>, ?, ?, ?, ?> annotationManager;
 
-  /**
-   * Create a <%- type %>.
-   *
-   * @param id            the id of the <%- type %>
-   * @param jsonObject the features of the annotation
-   * @param geometry the geometry of the annotation
-   */
-  <%- camelize(type) %>(long id, AnnotationManager<?, <%- camelize(type) %>, ?, ?, ?, ?> annotationManager, JsonObject jsonObject, <%- geometryType(type) %> geometry) {
-    super(id, jsonObject, geometry);
-    this.annotationManager = annotationManager;
-  }
+    /**
+     * Create a <%- type %>.
+     *
+     * @param id         the id of the <%- type %>
+     * @param jsonObject the features of the annotation
+     * @param geometry   the geometry of the annotation
+     */
+    <%- camelize(type) %>(long id, AnnotationManager<?, <%- camelize(type) %>, ?, ?, ?, ?> annotationManager, JsonObject jsonObject, <%- geometryType(type) %> geometry) {
+        super(id, jsonObject, geometry);
+        this.annotationManager = annotationManager;
+    }
 
-  @Override
-  void setUsedDataDrivenProperties() {
+    @Override
+    void setUsedDataDrivenProperties() {
 <% for (const property of properties) { -%>
 <% if (supportsPropertyFunction(property)) { -%>
-    if (!(jsonObject.get(<%- camelize(type) %>Options.PROPERTY_<%- snakeCaseUpper(property.name) %>) instanceof JsonNull)) {
-      annotationManager.enableDataDrivenProperty(<%- camelize(type) %>Options.PROPERTY_<%- snakeCaseUpper(property.name) %>);
+        if (!(jsonObject.get(<%- camelize(type) %>Options.PROPERTY_<%- snakeCaseUpper(property.name) %>) instanceof JsonNull)) {
+            annotationManager.enableDataDrivenProperty(<%- camelize(type) %>Options.PROPERTY_<%- snakeCaseUpper(property.name) %>);
+        }
+<% } -%>
+<% } -%>
     }
-<% } -%>
-<% } -%>
-  }
 <% if (type === "circle" || type === "symbol") { -%>
 
-  /**
-   * Set the LatLng of the <%- type %>, which represents the location of the <%- type %> on the map
-   * <p>
-   * To update the <%- type %> on the map use {@link <%- camelize(type) %>Manager#update(Annotation)}.
-   * <p>
-   *
-   * @param latLng the location of the <%- type %> in a latitude and longitude pair
-   */
-  public void setLatLng(LatLng latLng) {
-    geometry = Point.fromLngLat(latLng.getLongitude(), latLng.getLatitude());
-  }
+    /**
+     * Set the LatLng of the <%- type %>, which represents the location of the <%- type %> on the map
+     * <p>
+     * To update the <%- type %> on the map use {@link <%- camelize(type) %>Manager#update(Annotation)}.
+     * <p>
+     *
+     * @param latLng the location of the <%- type %> in a latitude and longitude pair
+     */
+    public void setLatLng(LatLng latLng) {
+        geometry = Point.fromLngLat(latLng.getLongitude(), latLng.getLatitude());
+    }
 
-  /**
-   * Get the LatLng of the <%- type %>, which represents the location of the <%- type %> on the map
-   *
-   * @return the location of the <%- type %>
-   */
-  @NonNull
-  public LatLng getLatLng() {
-    return new LatLng(geometry.latitude(), geometry.longitude());
-  }
+    /**
+     * Get the LatLng of the <%- type %>, which represents the location of the <%- type %> on the map
+     *
+     * @return the location of the <%- type %>
+     */
+    @NonNull
+    public LatLng getLatLng() {
+        return new LatLng(geometry.latitude(), geometry.longitude());
+    }
 <% } else if (type === "line") { -%>
 
-  /**
-   * Set a list of LatLng for the line, which represents the locations of the line on the map
-   * <p>
-   * To update the <%- type %> on the map use {@link <%- camelize(type) %>Manager#update(Annotation)}.
-   * <p>
-   *
-   * @param latLngs a list of the locations of the line in a longitude and latitude pairs
-   */
-  public void setLatLngs(List<LatLng> latLngs) {
-    List<Point>points = new ArrayList<>();
-    for (LatLng latLng : latLngs) {
-      points.add(Point.fromLngLat(latLng.getLongitude(), latLng.getLatitude()));
+    /**
+     * Set a list of LatLng for the line, which represents the locations of the line on the map
+     * <p>
+     * To update the <%- type %> on the map use {@link <%- camelize(type) %>Manager#update(Annotation)}.
+     * <p>
+     *
+     * @param latLngs a list of the locations of the line in a longitude and latitude pairs
+     */
+    public void setLatLngs(List<LatLng> latLngs) {
+        List<Point>points = new ArrayList<>();
+        for (LatLng latLng : latLngs) {
+            points.add(Point.fromLngLat(latLng.getLongitude(), latLng.getLatitude()));
+        }
+        geometry = LineString.fromLngLats(points);
     }
-    geometry = LineString.fromLngLats(points);
-  }
 
-  /**
-   * Get a list of LatLng for the line, which represents the locations of the line on the map
-   *
-   * @return a list of the locations of the line in a latitude and longitude pairs
-   */
-  @NonNull
-  public List<LatLng> getLatLngs() {
-    LineString lineString = (LineString) geometry;
-    List<LatLng> latLngs = new ArrayList<>();
-    for (Point point: lineString.coordinates()) {
-      latLngs.add(new LatLng(point.latitude(), point.longitude()));
+    /**
+     * Get a list of LatLng for the line, which represents the locations of the line on the map
+     *
+     * @return a list of the locations of the line in a latitude and longitude pairs
+     */
+    @NonNull
+    public List<LatLng> getLatLngs() {
+        LineString lineString = (LineString) geometry;
+        List<LatLng> latLngs = new ArrayList<>();
+        for (Point point: lineString.coordinates()) {
+            latLngs.add(new LatLng(point.latitude(), point.longitude()));
+        }
+        return latLngs;
     }
-    return latLngs;
-  }
 <% } else { -%>
 
-  /**
-   * Set a list of lists of LatLng for the fill, which represents the locations of the fill on the map
-   * <p>
-   * To update the <%- type %> on the map use {@link <%- camelize(type) %>Manager#update(Annotation)}.
-   * <p>
-   *
-   * @param latLngs a list of a lists of the locations of the polygon in a latitude and longitude pairs
-   */
-  public void setLatLngs(List<List<LatLng>> latLngs) {
-    List<List<Point>> points = new ArrayList<>();
-    for (List<LatLng> innerLatLngs : latLngs) {
-      List<Point>innerList = new ArrayList<>();
-      for (LatLng latLng : innerLatLngs) {
-        innerList.add(Point.fromLngLat(latLng.getLongitude(), latLng.getLatitude()));
-      }
-      points.add(innerList);
-    }
-    geometry = Polygon.fromLngLats(points);
-  }
-
-  /**
-   * Get a list of lists of LatLng for the fill, which represents the locations of the fill on the map
-   *
-   * @return a list of a lists of the locations of the polygon in a latitude and longitude pairs
-   */
-  @NonNull
-  public List<List<LatLng>> getLatLngs() {
-    Polygon polygon = (Polygon) geometry;
-    List<List<LatLng>> latLngs = new ArrayList<>();
-    List<List<Point>> coordinates = polygon.coordinates();
-    if (coordinates != null) {
-      for (List<Point> innerPoints : coordinates) {
-        List<LatLng> innerList = new ArrayList<>();
-        for (Point point : innerPoints) {
-          innerList.add(new LatLng(point.latitude(), point.longitude()));
+    /**
+     * Set a list of lists of LatLng for the fill, which represents the locations of the fill on the map
+     * <p>
+     * To update the <%- type %> on the map use {@link <%- camelize(type) %>Manager#update(Annotation)}.
+     * <p>
+     *
+     * @param latLngs a list of a lists of the locations of the polygon in a latitude and longitude pairs
+     */
+    public void setLatLngs(List<List<LatLng>> latLngs) {
+        List<List<Point>> points = new ArrayList<>();
+        for (List<LatLng> innerLatLngs : latLngs) {
+            List<Point>innerList = new ArrayList<>();
+            for (LatLng latLng : innerLatLngs) {
+                innerList.add(Point.fromLngLat(latLng.getLongitude(), latLng.getLatitude()));
+            }
+            points.add(innerList);
         }
-        latLngs.add(innerList);
-      }
+        geometry = Polygon.fromLngLats(points);
     }
-    return latLngs;
-  }
+
+    /**
+     * Get a list of lists of LatLng for the fill, which represents the locations of the fill on the map
+     *
+     * @return a list of a lists of the locations of the polygon in a latitude and longitude pairs
+     */
+    @NonNull
+    public List<List<LatLng>> getLatLngs() {
+        Polygon polygon = (Polygon) geometry;
+        List<List<LatLng>> latLngs = new ArrayList<>();
+        List<List<Point>> coordinates = polygon.coordinates();
+        if (coordinates != null) {
+            for (List<Point> innerPoints : coordinates) {
+                List<LatLng> innerList = new ArrayList<>();
+                for (Point point : innerPoints) {
+                    innerList.add(new LatLng(point.latitude(), point.longitude()));
+                }
+                latLngs.add(innerList);
+            }
+        }
+        return latLngs;
+    }
 <% } -%>
 
-  // Property accessors
+    // Property accessors
 <% for (const property of properties) { -%>
 <% if (supportsPropertyFunction(property)) { -%>
 <% if (propertyType(property).endsWith("[]")) { -%>
 <% if (propertyType(property).endsWith("Float[]")) { -%>
 
-  /**
-   * Get the <%- camelize(property.name) %> property
-   * <p>
-   * <%- propertyFactoryMethodDoc(property) %>
-   * </p>
-   *
-   * @return PointF value for <%- propertyType(property) %>
-   */
-  public PointF get<%- camelize(property.name) %>() {
-    JsonArray jsonArray = jsonObject.getAsJsonArray(<%- camelize(type) %>Options.PROPERTY_<%- snakeCaseUpper(property.name) %>);
-    return new PointF(jsonArray.get(0).getAsFloat(), jsonArray.get(1).getAsFloat());
-  }
+    /**
+     * Get the <%- camelize(property.name) %> property
+     * <p>
+     * <%- propertyFactoryMethodDoc(property) %>
+     * </p>
+     *
+     * @return PointF value for <%- propertyType(property) %>
+     */
+    public PointF get<%- camelize(property.name) %>() {
+        JsonArray jsonArray = jsonObject.getAsJsonArray(<%- camelize(type) %>Options.PROPERTY_<%- snakeCaseUpper(property.name) %>);
+        return new PointF(jsonArray.get(0).getAsFloat(), jsonArray.get(1).getAsFloat());
+    }
 
-  /**
-   * Set the <%- camelize(property.name) %> property.
-   * <p>
-   * <%- propertyFactoryMethodDoc(property) %>
-   * </p>
-   * <p>
-   * To update the <%- type %> on the map use {@link <%- camelize(type) %>Manager#update(Annotation)}.
-   * <p>
-   *
-   * @param pointF value for <%- propertyType(property) %>
-   */
-  public void set<%- camelize(property.name) %>(PointF pointF) {
-    JsonArray jsonArray = new JsonArray();
-    jsonArray.add(pointF.x);
-    jsonArray.add(pointF.y);
-    jsonObject.add(<%- camelize(type) %>Options.PROPERTY_<%- snakeCaseUpper(property.name) %>, jsonArray);
-  }
+    /**
+     * Set the <%- camelize(property.name) %> property.
+     * <p>
+     * <%- propertyFactoryMethodDoc(property) %>
+     * </p>
+     * <p>
+     * To update the <%- type %> on the map use {@link <%- camelize(type) %>Manager#update(Annotation)}.
+     * <p>
+     *
+     * @param pointF value for <%- propertyType(property) %>
+     */
+    public void set<%- camelize(property.name) %>(PointF pointF) {
+        JsonArray jsonArray = new JsonArray();
+        jsonArray.add(pointF.x);
+        jsonArray.add(pointF.y);
+        jsonObject.add(<%- camelize(type) %>Options.PROPERTY_<%- snakeCaseUpper(property.name) %>, jsonArray);
+    }
 <% } else { -%>
 
-  /**
-   * Get the <%- camelize(property.name) %> property
-   * <p>
-   * <%- propertyFactoryMethodDoc(property) %>
-   * </p>
-   *
-   * @return property wrapper value around <%- propertyType(property) %>
-   */
-  public <%- propertyType(property) %> get<%- camelize(property.name) %>() {
-    JsonArray jsonArray = jsonObject.getAsJsonArray(<%- camelize(type) %>Options.PROPERTY_<%- snakeCaseUpper(property.name) %>);
-    <%- propertyType(property) %> value = new <%- propertyType(property).substring(0, propertyType(property).length-1) %>jsonArray.size()];
-    for (int i = 0; i < jsonArray.size(); i++) {
-      value[i] = jsonArray.get(i).getAs<%- propertyType(property).substring(0, propertyType(property).length-2) %>();
+    /**
+     * Get the <%- camelize(property.name) %> property
+     * <p>
+     * <%- propertyFactoryMethodDoc(property) %>
+     * </p>
+     *
+     * @return property wrapper value around <%- propertyType(property) %>
+     */
+    public <%- propertyType(property) %> get<%- camelize(property.name) %>() {
+        JsonArray jsonArray = jsonObject.getAsJsonArray(<%- camelize(type) %>Options.PROPERTY_<%- snakeCaseUpper(property.name) %>);
+        <%- propertyType(property) %> value = new <%- propertyType(property).substring(0, propertyType(property).length-1) %>jsonArray.size()];
+        for (int i = 0; i < jsonArray.size(); i++) {
+            value[i] = jsonArray.get(i).getAs<%- propertyType(property).substring(0, propertyType(property).length-2) %>();
+        }
+        return value;
     }
-    return value;
-  }
 
-  /**
-   * Set the <%- camelize(property.name) %> property.
-   * <p>
-   * <%- propertyFactoryMethodDoc(property) %>
-   * </p>
-   * <p>
-   * To update the <%- type %> on the map use {@link <%- camelize(type) %>Manager#update(Annotation)}.
-   * <p>
-   *
-   * @param value constant property value for <%- propertyType(property) %>
-   */
-  public void set<%- camelize(property.name) %>(<%- propertyTypeAnnotation(property) %><%- iff(() => propertyTypeAnnotation(property), " ") %><%- propertyType(property) %> value) {
-    JsonArray jsonArray = new JsonArray();
-    for (<%- propertyType(property).substring(0, propertyType(property).length-2) %> element : value) {
-      jsonArray.add(element);
+    /**
+     * Set the <%- camelize(property.name) %> property.
+     * <p>
+     * <%- propertyFactoryMethodDoc(property) %>
+     * </p>
+     * <p>
+     * To update the <%- type %> on the map use {@link <%- camelize(type) %>Manager#update(Annotation)}.
+     * <p>
+     *
+     * @param value constant property value for <%- propertyType(property) %>
+     */
+    public void set<%- camelize(property.name) %>(<%- propertyTypeAnnotation(property) %><%- iff(() => propertyTypeAnnotation(property), " ") %><%- propertyType(property) %> value) {
+        JsonArray jsonArray = new JsonArray();
+        for (<%- propertyType(property).substring(0, propertyType(property).length-2) %> element : value) {
+            jsonArray.add(element);
+        }
+        jsonObject.add(<%- camelize(type) %>Options.PROPERTY_<%- snakeCaseUpper(property.name) %>, jsonArray);
     }
-    jsonObject.add(<%- camelize(type) %>Options.PROPERTY_<%- snakeCaseUpper(property.name) %>, jsonArray);
-  }
 <% } -%>
 <% } else if (property.type == 'color') { -%>
 
-  /**
-   * Get the <%- camelize(property.name) %> property
-   * <p>
-   * <%- propertyFactoryMethodDoc(property) %>
-   * </p>
-   *
-   * @return color value for <%- propertyType(property) %>
-   */
-  @ColorInt
-  public int get<%- camelize(property.name) %>AsInt() {
-    return ColorUtils.rgbaToColor(jsonObject.get(<%- camelize(type) %>Options.PROPERTY_<%- snakeCaseUpper(property.name) %>).getAs<%- propertyType(property) %>());
-  }
+    /**
+     * Get the <%- camelize(property.name) %> property
+     * <p>
+     * <%- propertyFactoryMethodDoc(property) %>
+     * </p>
+     *
+     * @return color value for <%- propertyType(property) %>
+     */
+    @ColorInt
+    public int get<%- camelize(property.name) %>AsInt() {
+        return ColorUtils.rgbaToColor(jsonObject.get(<%- camelize(type) %>Options.PROPERTY_<%- snakeCaseUpper(property.name) %>).getAs<%- propertyType(property) %>());
+    }
 
-  /**
-   * Get the <%- camelize(property.name) %> property
-   * <p>
-   * <%- propertyFactoryMethodDoc(property) %>
-   * </p>
-   *
-   * @return color value for <%- propertyType(property) %>
-   */
-  public String get<%- camelize(property.name) %>() {
-    return jsonObject.get(<%- camelize(type) %>Options.PROPERTY_<%- snakeCaseUpper(property.name) %>).getAs<%- propertyType(property) %>();
-  }
+    /**
+     * Get the <%- camelize(property.name) %> property
+     * <p>
+     * <%- propertyFactoryMethodDoc(property) %>
+     * </p>
+     *
+     * @return color value for <%- propertyType(property) %>
+     */
+    public String get<%- camelize(property.name) %>() {
+        return jsonObject.get(<%- camelize(type) %>Options.PROPERTY_<%- snakeCaseUpper(property.name) %>).getAs<%- propertyType(property) %>();
+    }
 
-  /**
-   * Set the <%- camelize(property.name) %> property
-   * <p>
-   * <%- propertyFactoryMethodDoc(property) %>
-   * </p>
-   * <p>
-   * To update the <%- type %> on the map use {@link <%- camelize(type) %>Manager#update(Annotation)}.
-   * <p>
-   *
-   * @param color value for <%- propertyType(property) %>
-   */
-  public void set<%- camelize(property.name) %>(@ColorInt int color) {
-    jsonObject.addProperty(<%- camelize(type) %>Options.PROPERTY_<%- snakeCaseUpper(property.name) %>, ColorUtils.colorToRgbaString(color));
-  }
+    /**
+     * Set the <%- camelize(property.name) %> property
+     * <p>
+     * <%- propertyFactoryMethodDoc(property) %>
+     * </p>
+     * <p>
+     * To update the <%- type %> on the map use {@link <%- camelize(type) %>Manager#update(Annotation)}.
+     * <p>
+     *
+     * @param color value for <%- propertyType(property) %>
+     */
+    public void set<%- camelize(property.name) %>(@ColorInt int color) {
+        jsonObject.addProperty(<%- camelize(type) %>Options.PROPERTY_<%- snakeCaseUpper(property.name) %>, ColorUtils.colorToRgbaString(color));
+    }
 
-  /**
-   * Set the <%- camelize(property.name) %> property
-   * <p>
-   * <%- propertyFactoryMethodDoc(property) %>
-   * </p>
-   * <p>
-   * To update the <%- type %> on the map use {@link <%- camelize(type) %>Manager#update(Annotation)}.
-   * <p>
-   *
-   * @param color value for <%- propertyType(property) %>
-   */
-  public void set<%- camelize(property.name) %>(@NonNull String color) {
-    jsonObject.addProperty("<%- property.name %>", color);
-  }
+    /**
+     * Set the <%- camelize(property.name) %> property
+     * <p>
+     * <%- propertyFactoryMethodDoc(property) %>
+     * </p>
+     * <p>
+     * To update the <%- type %> on the map use {@link <%- camelize(type) %>Manager#update(Annotation)}.
+     * <p>
+     *
+     * @param color value for <%- propertyType(property) %>
+     */
+    public void set<%- camelize(property.name) %>(@NonNull String color) {
+        jsonObject.addProperty("<%- property.name %>", color);
+    }
 <% } else { -%>
 
-  /**
-   * Get the <%- camelize(property.name) %> property
-   * <p>
-   * <%- propertyFactoryMethodDoc(property) %>
-   * </p>
-   *
-   * @return property wrapper value around <%- propertyType(property) %>
-   */
-  public <%- propertyType(property) %> get<%- camelize(property.name) %>() {
-    return jsonObject.get(<%- camelize(type) %>Options.PROPERTY_<%- snakeCaseUpper(property.name) %>).getAs<%- propertyType(property) %>();
-  }
+    /**
+     * Get the <%- camelize(property.name) %> property
+     * <p>
+     * <%- propertyFactoryMethodDoc(property) %>
+     * </p>
+     *
+     * @return property wrapper value around <%- propertyType(property) %>
+     */
+    public <%- propertyType(property) %> get<%- camelize(property.name) %>() {
+        return jsonObject.get(<%- camelize(type) %>Options.PROPERTY_<%- snakeCaseUpper(property.name) %>).getAs<%- propertyType(property) %>();
+    }
 
-  /**
-   * Set the <%- camelize(property.name) %> property
-   * <p>
-   * <%- propertyFactoryMethodDoc(property) %>
-   * </p>
-   * <p>
-   * To update the <%- type %> on the map use {@link <%- camelize(type) %>Manager#update(Annotation)}.
-   * <p>
-   *
-   * @param value constant property value for <%- propertyType(property) %>
-   */
-  public void set<%- camelize(property.name) %>(<%- propertyTypeAnnotation(property) %><%- iff(() => propertyTypeAnnotation(property), " ") %><%- propertyType(property) %> value) {
-    jsonObject.addProperty(<%- camelize(type) %>Options.PROPERTY_<%- snakeCaseUpper(property.name) %>, value);
-  }
+    /**
+     * Set the <%- camelize(property.name) %> property
+     * <p>
+     * <%- propertyFactoryMethodDoc(property) %>
+     * </p>
+     * <p>
+     * To update the <%- type %> on the map use {@link <%- camelize(type) %>Manager#update(Annotation)}.
+     * <p>
+     *
+     * @param value constant property value for <%- propertyType(property) %>
+     */
+    public void set<%- camelize(property.name) %>(<%- propertyTypeAnnotation(property) %><%- iff(() => propertyTypeAnnotation(property), " ") %><%- propertyType(property) %> value) {
+        jsonObject.addProperty(<%- camelize(type) %>Options.PROPERTY_<%- snakeCaseUpper(property.name) %>, value);
+    }
 <% } -%>
 <% } -%>
 <% } -%>
 <% if (type === "circle" || type === "symbol") { -%>
 
-  @Override
-  @Nullable
-  Geometry getOffsetGeometry(@NonNull Projection projection, @NonNull MoveDistancesObject moveDistancesObject,
-                             float touchAreaShiftX, float touchAreaShiftY) {
-    PointF pointF = new PointF(
-      moveDistancesObject.getCurrentX() - touchAreaShiftX,
-      moveDistancesObject.getCurrentY() - touchAreaShiftY
-    );
+    @Override
+    @Nullable
+    Geometry getOffsetGeometry(@NonNull Projection projection, @NonNull MoveDistancesObject moveDistancesObject,
+                               float touchAreaShiftX, float touchAreaShiftY) {
+        PointF pointF = new PointF(
+            moveDistancesObject.getCurrentX() - touchAreaShiftX,
+            moveDistancesObject.getCurrentY() - touchAreaShiftY
+        );
 
-    LatLng latLng = projection.fromScreenLocation(pointF);
-    if (latLng.getLatitude() > MAX_MERCATOR_LATITUDE || latLng.getLatitude() < MIN_MERCATOR_LATITUDE) {
-      return null;
+        LatLng latLng = projection.fromScreenLocation(pointF);
+        if (latLng.getLatitude() > MAX_MERCATOR_LATITUDE || latLng.getLatitude() < MIN_MERCATOR_LATITUDE) {
+            return null;
+        }
+
+        return Point.fromLngLat(latLng.getLongitude(), latLng.getLatitude());
     }
-
-    return Point.fromLngLat(latLng.getLongitude(), latLng.getLatitude());
-  }
 <% } else if (type === "line") { -%>
 
-  @Override
-  @Nullable
-  Geometry getOffsetGeometry(@NonNull Projection projection, @NonNull MoveDistancesObject moveDistancesObject,
-                             float touchAreaShiftX, float touchAreaShiftY) {
-    List<Point> originalPoints = geometry.coordinates();
-    List<Point> resultingPoints = new ArrayList<>(originalPoints.size());
-    for (Point jsonPoint : originalPoints) {
-      PointF pointF = projection.toScreenLocation(new LatLng(jsonPoint.latitude(), jsonPoint.longitude()));
-      pointF.x -= moveDistancesObject.getDistanceXSinceLast();
-      pointF.y -= moveDistancesObject.getDistanceYSinceLast();
+    @Override
+    @Nullable
+    Geometry getOffsetGeometry(@NonNull Projection projection, @NonNull MoveDistancesObject moveDistancesObject,
+                                                         float touchAreaShiftX, float touchAreaShiftY) {
+        List<Point> originalPoints = geometry.coordinates();
+        List<Point> resultingPoints = new ArrayList<>(originalPoints.size());
+        for (Point jsonPoint : originalPoints) {
+            PointF pointF = projection.toScreenLocation(new LatLng(jsonPoint.latitude(), jsonPoint.longitude()));
+            pointF.x -= moveDistancesObject.getDistanceXSinceLast();
+            pointF.y -= moveDistancesObject.getDistanceYSinceLast();
 
-      LatLng latLng = projection.fromScreenLocation(pointF);
-      if (latLng.getLatitude() > MAX_MERCATOR_LATITUDE || latLng.getLatitude() < MIN_MERCATOR_LATITUDE) {
-        return null;
-      }
-      resultingPoints.add(Point.fromLngLat(latLng.getLongitude(), latLng.getLatitude()));
-    }
-
-    return LineString.fromLngLats(resultingPoints);
-  }
-<% } else { -%>
-
-  @Override
-  @Nullable
-  Geometry getOffsetGeometry(@NonNull Projection projection, @NonNull MoveDistancesObject moveDistancesObject,
-                             float touchAreaShiftX, float touchAreaShiftY) {
-    List<List<Point>> originalPoints = geometry.coordinates();
-    if (originalPoints != null) {
-      List<List<Point>> resultingPoints = new ArrayList<>(originalPoints.size());
-      for (List<Point> points : originalPoints) {
-        List<Point> innerPoints = new ArrayList<>();
-        for (Point jsonPoint : points) {
-          PointF pointF = projection.toScreenLocation(new LatLng(jsonPoint.latitude(), jsonPoint.longitude()));
-          pointF.x -= moveDistancesObject.getDistanceXSinceLast();
-          pointF.y -= moveDistancesObject.getDistanceYSinceLast();
-
-          LatLng latLng = projection.fromScreenLocation(pointF);
-          if (latLng.getLatitude() > MAX_MERCATOR_LATITUDE || latLng.getLatitude() < MIN_MERCATOR_LATITUDE) {
-            return null;
-          }
-          innerPoints.add(Point.fromLngLat(latLng.getLongitude(), latLng.getLatitude()));
+            LatLng latLng = projection.fromScreenLocation(pointF);
+            if (latLng.getLatitude() > MAX_MERCATOR_LATITUDE || latLng.getLatitude() < MIN_MERCATOR_LATITUDE) {
+                return null;
+            }
+            resultingPoints.add(Point.fromLngLat(latLng.getLongitude(), latLng.getLatitude()));
         }
-        resultingPoints.add(innerPoints);
-      }
 
-      return Polygon.fromLngLats(resultingPoints);
+        return LineString.fromLngLats(resultingPoints);
     }
-
-    return null;
-  }
-<% } -%>
-
-  @Override
-  String getName() {
-<% if (type === "symbol") { -%>
-    return "Symbol";
-<% } else if (type === "circle")  { -%>
-    return "Circle";
-<% } else if (type === "fill")  { -%>
-    return "Fill";
-<% } else if (type === "line")  { -%>
-     return "Line";
 <% } else { -%>
-    return "Annotation";
+
+    @Override
+    @Nullable
+    Geometry getOffsetGeometry(@NonNull Projection projection, @NonNull MoveDistancesObject moveDistancesObject,
+                                                         float touchAreaShiftX, float touchAreaShiftY) {
+        List<List<Point>> originalPoints = geometry.coordinates();
+        if (originalPoints != null) {
+            List<List<Point>> resultingPoints = new ArrayList<>(originalPoints.size());
+            for (List<Point> points : originalPoints) {
+                List<Point> innerPoints = new ArrayList<>();
+                for (Point jsonPoint : points) {
+                    PointF pointF = projection.toScreenLocation(new LatLng(jsonPoint.latitude(), jsonPoint.longitude()));
+                    pointF.x -= moveDistancesObject.getDistanceXSinceLast();
+                    pointF.y -= moveDistancesObject.getDistanceYSinceLast();
+
+                    LatLng latLng = projection.fromScreenLocation(pointF);
+                    if (latLng.getLatitude() > MAX_MERCATOR_LATITUDE || latLng.getLatitude() < MIN_MERCATOR_LATITUDE) {
+                        return null;
+                    }
+                    innerPoints.add(Point.fromLngLat(latLng.getLongitude(), latLng.getLatitude()));
+                }
+                resultingPoints.add(innerPoints);
+            }
+
+            return Polygon.fromLngLats(resultingPoints);
+        }
+
+        return null;
+    }
 <% } -%>
-  }
+
+    @Override
+    String getName() {
+<% if (type === "symbol") { -%>
+        return "Symbol";
+<% } else if (type === "circle")    { -%>
+        return "Circle";
+<% } else if (type === "fill")    { -%>
+        return "Fill";
+<% } else if (type === "line")    { -%>
+         return "Line";
+<% } else { -%>
+        return "Annotation";
+<% } -%>
+    }
 }

--- a/plugin-annotation/scripts/annotation_element_provider.java.ejs
+++ b/plugin-annotation/scripts/annotation_element_provider.java.ejs
@@ -19,36 +19,36 @@ import java.util.concurrent.atomic.AtomicLong;
  */
 class <%- camelize(type) %>ElementProvider implements CoreElementProvider<<%- camelize(type) %>Layer>{
 
-  private static final AtomicLong ID_GENERATOR = new AtomicLong(0);
-  private static final String ID_GEOJSON_LAYER = "mapbox-android-<%- type %>-layer-%s";
-  private static final String ID_GEOJSON_SOURCE = "mapbox-android-<%- type %>-source-%s";
+    private static final AtomicLong ID_GENERATOR = new AtomicLong(0);
+    private static final String ID_GEOJSON_LAYER = "mapbox-android-<%- type %>-layer-%s";
+    private static final String ID_GEOJSON_SOURCE = "mapbox-android-<%- type %>-source-%s";
 
-  private final String layerId;
-  private final String sourceId;
+    private final String layerId;
+    private final String sourceId;
 
-  <%- camelize(type) %>ElementProvider() {
-    long id = ID_GENERATOR.incrementAndGet();
-    this.layerId = String.format(ID_GEOJSON_LAYER, id);
-    this.sourceId = String.format(ID_GEOJSON_SOURCE, id);
-  }
+    <%- camelize(type) %>ElementProvider() {
+        long id = ID_GENERATOR.incrementAndGet();
+        this.layerId = String.format(ID_GEOJSON_LAYER, id);
+        this.sourceId = String.format(ID_GEOJSON_SOURCE, id);
+    }
 
-  @Override
-  public String getLayerId() {
-    return layerId;
-  }
+    @Override
+    public String getLayerId() {
+        return layerId;
+    }
 
-  @Override
-  public String getSourceId() {
-    return sourceId;
-  }
+    @Override
+    public String getSourceId() {
+        return sourceId;
+    }
 
-  @Override
-  public <%- camelize(type) %>Layer getLayer() {
-    return new <%- camelize(type) %>Layer(layerId, sourceId);
-  }
+    @Override
+    public <%- camelize(type) %>Layer getLayer() {
+        return new <%- camelize(type) %>Layer(layerId, sourceId);
+    }
 
-  @Override
-  public GeoJsonSource getSource(@Nullable GeoJsonOptions geoJsonOptions) {
-    return new GeoJsonSource(sourceId, geoJsonOptions);
-  }
+    @Override
+    public GeoJsonSource getSource(@Nullable GeoJsonOptions geoJsonOptions) {
+        return new GeoJsonSource(sourceId, geoJsonOptions);
+    }
 }

--- a/plugin-annotation/scripts/annotation_instrumentation_test.junit.ejs
+++ b/plugin-annotation/scripts/annotation_instrumentation_test.junit.ejs
@@ -33,92 +33,92 @@ import java.util.List;
 @RunWith(AndroidJUnit4.class)
 public class <%- camelize(type) %>Test extends BaseActivityTest {
 
-  private <%- camelize(type) %> <%- type %>;
+    private <%- camelize(type) %> <%- type %>;
 
-  @Override
-  protected Class getActivityClass() {
-    return TestActivity.class;
-  }
+    @Override
+    protected Class getActivityClass() {
+        return TestActivity.class;
+    }
 
-  private void setupAnnotation() {
-    Timber.i("Retrieving layer");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      <%- camelize(type) %>Manager <%- type %>Manager = new <%- camelize(type) %>Manager(idlingResource.getMapView(), mapboxMap, Objects.requireNonNull(mapboxMap.getStyle()));
+    private void setupAnnotation() {
+        Timber.i("Retrieving layer");
+        invoke(mapboxMap, (uiController, mapboxMap) -> {
+            <%- camelize(type) %>Manager <%- type %>Manager = new <%- camelize(type) %>Manager(idlingResource.getMapView(), mapboxMap, Objects.requireNonNull(mapboxMap.getStyle()));
 <% if (type === "circle" || type === "symbol") { -%>
-      <%- type %> = <%- type %>Manager.create(new <%- camelize(type) %>Options().withLatLng(new LatLng()));
+            <%- type %> = <%- type %>Manager.create(new <%- camelize(type) %>Options().withLatLng(new LatLng()));
 <% } else if (type === "line") { -%>
-      List<LatLng>latLngs = new ArrayList<>();
-      latLngs.add(new LatLng());
-      latLngs.add(new LatLng(1,1));
-      <%- type %> = <%- type %>Manager.create(new <%- camelize(type) %>Options().withLatLngs(latLngs));
+            List<LatLng>latLngs = new ArrayList<>();
+            latLngs.add(new LatLng());
+            latLngs.add(new LatLng(1,1));
+            <%- type %> = <%- type %>Manager.create(new <%- camelize(type) %>Options().withLatLngs(latLngs));
 <% } else { -%>
-      List<LatLng>innerLatLngs = new ArrayList<>();
-      innerLatLngs.add(new LatLng());
-      innerLatLngs.add(new LatLng(1,1));
-      innerLatLngs.add(new LatLng(-1,-1));
-      List<List<LatLng>>latLngs = new ArrayList<>();
-      latLngs.add(innerLatLngs);
-      <%- type %> = <%- type %>Manager.create(new <%- camelize(type) %>Options().withLatLngs(latLngs));
+            List<LatLng>innerLatLngs = new ArrayList<>();
+            innerLatLngs.add(new LatLng());
+            innerLatLngs.add(new LatLng(1,1));
+            innerLatLngs.add(new LatLng(-1,-1));
+            List<List<LatLng>>latLngs = new ArrayList<>();
+            latLngs.add(innerLatLngs);
+            <%- type %> = <%- type %>Manager.create(new <%- camelize(type) %>Options().withLatLngs(latLngs));
 <% } -%>
-    });
-  }
+        });
+    }
 <% for (const property of properties) { -%>
 <% if (supportsPropertyFunction(property)) { -%>
 <% if (propertyType(property).endsWith("Float[]")) { -%>
 
-  @Test
-  public void test<%- camelize(property.name) %>() {
-    validateTestSetup();
-    setupAnnotation();
-    Timber.i("<%- property.name %>");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(<%- type %>);
+    @Test
+    public void test<%- camelize(property.name) %>() {
+        validateTestSetup();
+        setupAnnotation();
+        Timber.i("<%- property.name %>");
+        invoke(mapboxMap, (uiController, mapboxMap) -> {
+            assertNotNull(<%- type %>);
 
-      <%- type %>.set<%- camelize(property.name) %>(new PointF(1.0f, 1.0f));
-      assertEquals(<%- type %>.get<%- camelize(property.name) %>(), new PointF(1.0f, 1.0f));
-    });
-  }
+            <%- type %>.set<%- camelize(property.name) %>(new PointF(1.0f, 1.0f));
+            assertEquals(<%- type %>.get<%- camelize(property.name) %>(), new PointF(1.0f, 1.0f));
+        });
+    }
 <% } else if (property.type == 'color') { -%>
 
-  @Test
-  public void test<%- camelize(property.name) %>() {
-    validateTestSetup();
-    setupAnnotation();
-    Timber.i("<%- property.name %>");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(<%- type %>);
+    @Test
+    public void test<%- camelize(property.name) %>() {
+        validateTestSetup();
+        setupAnnotation();
+        Timber.i("<%- property.name %>");
+        invoke(mapboxMap, (uiController, mapboxMap) -> {
+            assertNotNull(<%- type %>);
 
-      <%- type %>.set<%- camelize(property.name) %>(<%- defaultValueJava(property) %>);
-      assertEquals(<%- type %>.get<%- camelize(property.name) %>(), <%- defaultValueJava(property) %>);
-    });
-  }
+            <%- type %>.set<%- camelize(property.name) %>(<%- defaultValueJava(property) %>);
+            assertEquals(<%- type %>.get<%- camelize(property.name) %>(), <%- defaultValueJava(property) %>);
+        });
+    }
 
-  @Test
-  public void test<%- camelize(property.name) %>AsInt() {
-    validateTestSetup();
-    setupAnnotation();
-    Timber.i("<%- property.name %>");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(<%- type %>);
-      <%- type %>.set<%- camelize(property.name) %>(ColorUtils.rgbaToColor(<%- defaultValueJava(property) %>));
-      assertEquals(<%- type %>.get<%- camelize(property.name) %>AsInt(), ColorUtils.rgbaToColor(<%- defaultValueJava(property) %>));
-    });
-  }
+    @Test
+    public void test<%- camelize(property.name) %>AsInt() {
+        validateTestSetup();
+        setupAnnotation();
+        Timber.i("<%- property.name %>");
+        invoke(mapboxMap, (uiController, mapboxMap) -> {
+            assertNotNull(<%- type %>);
+            <%- type %>.set<%- camelize(property.name) %>(ColorUtils.rgbaToColor(<%- defaultValueJava(property) %>));
+            assertEquals(<%- type %>.get<%- camelize(property.name) %>AsInt(), ColorUtils.rgbaToColor(<%- defaultValueJava(property) %>));
+        });
+    }
 
 <% } else { -%>
 
-  @Test
-  public void test<%- camelize(property.name) %>() {
-    validateTestSetup();
-    setupAnnotation();
-    Timber.i("<%- property.name %>");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(<%- type %>);
+    @Test
+    public void test<%- camelize(property.name) %>() {
+        validateTestSetup();
+        setupAnnotation();
+        Timber.i("<%- property.name %>");
+        invoke(mapboxMap, (uiController, mapboxMap) -> {
+            assertNotNull(<%- type %>);
 
-      <%- type %>.set<%- camelize(property.name) %>(<%- defaultValueJava(property) %>);
-      assertEquals((<%- propertyType(property) %>) <%- type %>.get<%- camelize(property.name) %>(), (<%- propertyType(property) %>) <%- defaultValueJava(property) %>);
-    });
-  }
+            <%- type %>.set<%- camelize(property.name) %>(<%- defaultValueJava(property) %>);
+            assertEquals((<%- propertyType(property) %>) <%- type %>.get<%- camelize(property.name) %>(), (<%- propertyType(property) %>) <%- defaultValueJava(property) %>);
+        });
+    }
 <% } -%>
 <% } -%>
 <% } -%>

--- a/plugin-annotation/scripts/annotation_manager.java.ejs
+++ b/plugin-annotation/scripts/annotation_manager.java.ejs
@@ -37,206 +37,206 @@ public class <%- camelize(type) %>Manager extends AnnotationManager<<%- camelize
 
 <% for (const property of properties) { -%>
 <% if (!supportsPropertyFunction(property) && property.name !== "line-gradient" && property.name !== "symbol-z-order") { -%>
-  private static final String PROPERTY_<%- snakeCaseUpper(property.name) %> = "<%- property.name %>";
+    private static final String PROPERTY_<%- snakeCaseUpper(property.name) %> = "<%- property.name %>";
 <% } -%>
 <% } -%>
 
-  /**
-   * Create a <%- type %> manager, used to manage <%- type %>s.
-   *
-   * @param mapboxMap the map object to add <%- type %>s to
-   * @param style a valid a fully loaded style object
-   */
-  @UiThread
-  public <%- camelize(type) %>Manager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style) {
-    this(mapView, mapboxMap, style, null, (GeoJsonOptions) null);
-  }
+    /**
+     * Create a <%- type %> manager, used to manage <%- type %>s.
+     *
+     * @param mapboxMap the map object to add <%- type %>s to
+     * @param style a valid a fully loaded style object
+     */
+    @UiThread
+    public <%- camelize(type) %>Manager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style) {
+        this(mapView, mapboxMap, style, null, (GeoJsonOptions) null);
+    }
 
-  /**
-   * Create a <%- type %> manager, used to manage <%- type %>s.
-   *
-   * @param mapboxMap the map object to add <%- type %>s to
-   * @param style a valid a fully loaded style object
-   * @param belowLayerId the id of the layer above the circle layer
-   */
-  @UiThread
-  public <%- camelize(type) %>Manager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @Nullable String belowLayerId) {
-    this(mapView, mapboxMap, style, belowLayerId, (GeoJsonOptions) null);
-  }
+    /**
+     * Create a <%- type %> manager, used to manage <%- type %>s.
+     *
+     * @param mapboxMap the map object to add <%- type %>s to
+     * @param style a valid a fully loaded style object
+     * @param belowLayerId the id of the layer above the circle layer
+     */
+    @UiThread
+    public <%- camelize(type) %>Manager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @Nullable String belowLayerId) {
+        this(mapView, mapboxMap, style, belowLayerId, (GeoJsonOptions) null);
+    }
 
-  /**
-   * Create a <%- type %> manager, used to manage <%- type %>s.
-   *
-   * @param mapboxMap the map object to add <%- type %>s to
-   * @param style a valid a fully loaded style object
-   * @param belowLayerId the id of the layer above the circle layer
-   * @param geoJsonOptions options for the internal source
-   */
-  @UiThread
-  public <%- camelize(type) %>Manager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @Nullable String belowLayerId, @Nullable GeoJsonOptions geoJsonOptions) {
-    this(mapView, mapboxMap, style, new <%- camelize(type) %>ElementProvider(), belowLayerId, geoJsonOptions, DraggableAnnotationController.getInstance(mapView, mapboxMap));
-  }
+    /**
+     * Create a <%- type %> manager, used to manage <%- type %>s.
+     *
+     * @param mapboxMap the map object to add <%- type %>s to
+     * @param style a valid a fully loaded style object
+     * @param belowLayerId the id of the layer above the circle layer
+     * @param geoJsonOptions options for the internal source
+     */
+    @UiThread
+    public <%- camelize(type) %>Manager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @Nullable String belowLayerId, @Nullable GeoJsonOptions geoJsonOptions) {
+        this(mapView, mapboxMap, style, new <%- camelize(type) %>ElementProvider(), belowLayerId, geoJsonOptions, DraggableAnnotationController.getInstance(mapView, mapboxMap));
+    }
 <% if (type === "symbol") { -%>
 
-  /**
-   * Create a <%- type %> manager, used to manage <%- type %>s.
-   *
-   * @param mapboxMap the map object to add <%- type %>s to
-   * @param style a valid a fully loaded style object
-   * @param belowLayerId the id of the layer above the circle layer
-   * @param clusterOptions options for the clustering configuration
-   */
-  @UiThread
-  public <%- camelize(type) %>Manager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @Nullable String belowLayerId, @NonNull ClusterOptions clusterOptions) {
-    this(mapView, mapboxMap, style, new SymbolElementProvider(), belowLayerId, new GeoJsonOptions().withCluster(true).withClusterRadius(clusterOptions.getClusterRadius()).withClusterMaxZoom(clusterOptions.getClusterMaxZoom()), DraggableAnnotationController.getInstance(mapView, mapboxMap));
-    clusterOptions.apply(style, coreElementProvider.getSourceId());
-  }
+    /**
+     * Create a <%- type %> manager, used to manage <%- type %>s.
+     *
+     * @param mapboxMap the map object to add <%- type %>s to
+     * @param style a valid a fully loaded style object
+     * @param belowLayerId the id of the layer above the circle layer
+     * @param clusterOptions options for the clustering configuration
+     */
+    @UiThread
+    public <%- camelize(type) %>Manager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @Nullable String belowLayerId, @NonNull ClusterOptions clusterOptions) {
+        this(mapView, mapboxMap, style, new SymbolElementProvider(), belowLayerId, new GeoJsonOptions().withCluster(true).withClusterRadius(clusterOptions.getClusterRadius()).withClusterMaxZoom(clusterOptions.getClusterMaxZoom()), DraggableAnnotationController.getInstance(mapView, mapboxMap));
+        clusterOptions.apply(style, coreElementProvider.getSourceId());
+    }
 <% } -%>
 
-  @VisibleForTesting
-  <%- camelize(type) %>Manager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @NonNull CoreElementProvider<<%- camelize(type) %>Layer> coreElementProvider, @Nullable String belowLayerId, @Nullable GeoJsonOptions geoJsonOptions, DraggableAnnotationController draggableAnnotationController) {
-    super(mapView, mapboxMap, style, coreElementProvider, draggableAnnotationController, belowLayerId, geoJsonOptions);
-  }
+    @VisibleForTesting
+    <%- camelize(type) %>Manager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @NonNull CoreElementProvider<<%- camelize(type) %>Layer> coreElementProvider, @Nullable String belowLayerId, @Nullable GeoJsonOptions geoJsonOptions, DraggableAnnotationController draggableAnnotationController) {
+        super(mapView, mapboxMap, style, coreElementProvider, draggableAnnotationController, belowLayerId, geoJsonOptions);
+    }
 
-  @Override
-  void initializeDataDrivenPropertyMap() {
+    @Override
+    void initializeDataDrivenPropertyMap() {
 <% for (const property of properties) { -%>
 <% if (supportsPropertyFunction(property)) { -%>
-    dataDrivenPropertyUsageMap.put(<%- camelize(type) %>Options.PROPERTY_<%- snakeCaseUpper(property.name) %>, false);
-<% } -%>
-<% } -%>
-  }
-
-  @Override
-  protected void setDataDrivenPropertyIsUsed(@NonNull String property) {
-    switch (property) {
-<% for (const property of properties) { -%>
-<% if (supportsPropertyFunction(property)) { -%>
-      case <%- camelize(type) %>Options.PROPERTY_<%- snakeCaseUpper(property.name) %>:
-        layer.setProperties(<%- camelizeWithLeadingLowercase(property.name) %>(get(<%- camelize(type) %>Options.PROPERTY_<%- snakeCaseUpper(property.name) %>)));
-        break;
+        dataDrivenPropertyUsageMap.put(<%- camelize(type) %>Options.PROPERTY_<%- snakeCaseUpper(property.name) %>, false);
 <% } -%>
 <% } -%>
     }
-  }
 
-  /**
-   * Create a list of <%- type %>s on the map.
-   * <p>
-   * <%- camelize(type) %>s are going to be created only for features with a matching geometry.
-   * <p>
-   * All supported properties are:<br>
+    @Override
+    protected void setDataDrivenPropertyIsUsed(@NonNull String property) {
+        switch (property) {
 <% for (const property of properties) { -%>
 <% if (supportsPropertyFunction(property)) { -%>
-   * <%- camelize(type) %>Options.PROPERTY_<%- snakeCaseUpper(property.name) %> - <%- propertyType(property) -%><br>
+            case <%- camelize(type) %>Options.PROPERTY_<%- snakeCaseUpper(property.name) %>:
+                layer.setProperties(<%- camelizeWithLeadingLowercase(property.name) %>(get(<%- camelize(type) %>Options.PROPERTY_<%- snakeCaseUpper(property.name) %>)));
+                break;
 <% } -%>
 <% } -%>
-   * Learn more about above properties in the <a href="https://www.mapbox.com/mapbox-gl-js/style-spec/">Style specification</a>.
-   * <p>
-   * Out of spec properties:<br>
-   * "is-draggable" - Boolean, true if the <%- type %> should be draggable, false otherwise
-   *
-   * @param json the GeoJSON defining the list of <%- type %>s to build
-   * @return the list of built <%- type %>s
-   */
-  @UiThread
-  public List<<%- camelize(type) %>> create(@NonNull String json) {
-    return create(FeatureCollection.fromJson(json));
-  }
-
-  /**
-   * Create a list of <%- type %>s on the map.
-   * <p>
-   * <%- camelize(type) %>s are going to be created only for features with a matching geometry.
-   * <p>
-   * All supported properties are:<br>
-<% for (const property of properties) { -%>
-<% if (supportsPropertyFunction(property)) { -%>
-   * <%- camelize(type) %>Options.PROPERTY_<%- snakeCaseUpper(property.name) %> - <%- propertyType(property) -%><br>
-<% } -%>
-<% } -%>
-   * Learn more about above properties in the <a href="https://www.mapbox.com/mapbox-gl-js/style-spec/">Style specification</a>.
-   * <p>
-   * Out of spec properties:<br>
-   * "is-draggable" - Boolean, true if the <%- type %> should be draggable, false otherwise
-   *
-   * @param featureCollection the featureCollection defining the list of <%- type %>s to build
-   * @return the list of built <%- type %>s
-   */
-  @UiThread
-  public List<<%- camelize(type) %>> create(@NonNull FeatureCollection featureCollection) {
-    List<Feature> features = featureCollection.features();
-    List<<%- camelize(type) %>Options> options = new ArrayList<>();
-    if (features != null) {
-      for (Feature feature : features) {
-        <%- camelize(type) %>Options option = <%- camelize(type) %>Options.fromFeature(feature);
-        if (option != null) {
-          options.add(option);
         }
-      }
     }
-    return create(options);
-  }
 
-  /**
-   * Get the key of the id of the annotation.
-   *
-   * @return the key of the id of the annotation
-   */
-  @Override
-  String getAnnotationIdKey() {
-    return <%- camelize(type) %>.ID_KEY;
-  }
+    /**
+     * Create a list of <%- type %>s on the map.
+     * <p>
+     * <%- camelize(type) %>s are going to be created only for features with a matching geometry.
+     * <p>
+     * All supported properties are:<br>
+<% for (const property of properties) { -%>
+<% if (supportsPropertyFunction(property)) { -%>
+     * <%- camelize(type) %>Options.PROPERTY_<%- snakeCaseUpper(property.name) %> - <%- propertyType(property) -%><br>
+<% } -%>
+<% } -%>
+     * Learn more about above properties in the <a href="https://www.mapbox.com/mapbox-gl-js/style-spec/">Style specification</a>.
+     * <p>
+     * Out of spec properties:<br>
+     * "is-draggable" - Boolean, true if the <%- type %> should be draggable, false otherwise
+     *
+     * @param json the GeoJSON defining the list of <%- type %>s to build
+     * @return the list of built <%- type %>s
+     */
+    @UiThread
+    public List<<%- camelize(type) %>> create(@NonNull String json) {
+        return create(FeatureCollection.fromJson(json));
+    }
 
-  // Property accessors
+    /**
+     * Create a list of <%- type %>s on the map.
+     * <p>
+     * <%- camelize(type) %>s are going to be created only for features with a matching geometry.
+     * <p>
+     * All supported properties are:<br>
+<% for (const property of properties) { -%>
+<% if (supportsPropertyFunction(property)) { -%>
+     * <%- camelize(type) %>Options.PROPERTY_<%- snakeCaseUpper(property.name) %> - <%- propertyType(property) -%><br>
+<% } -%>
+<% } -%>
+     * Learn more about above properties in the <a href="https://www.mapbox.com/mapbox-gl-js/style-spec/">Style specification</a>.
+     * <p>
+     * Out of spec properties:<br>
+     * "is-draggable" - Boolean, true if the <%- type %> should be draggable, false otherwise
+     *
+     * @param featureCollection the featureCollection defining the list of <%- type %>s to build
+     * @return the list of built <%- type %>s
+     */
+    @UiThread
+    public List<<%- camelize(type) %>> create(@NonNull FeatureCollection featureCollection) {
+        List<Feature> features = featureCollection.features();
+        List<<%- camelize(type) %>Options> options = new ArrayList<>();
+        if (features != null) {
+            for (Feature feature : features) {
+                <%- camelize(type) %>Options option = <%- camelize(type) %>Options.fromFeature(feature);
+                if (option != null) {
+                    options.add(option);
+                }
+            }
+        }
+        return create(options);
+    }
+
+    /**
+     * Get the key of the id of the annotation.
+     *
+     * @return the key of the id of the annotation
+     */
+    @Override
+    String getAnnotationIdKey() {
+        return <%- camelize(type) %>.ID_KEY;
+    }
+
+    // Property accessors
 <% for (const property of properties) { -%>
 <% if (!supportsPropertyFunction(property) && property.name !== "line-gradient" && property.name !== "symbol-z-order") { -%>
-  /**
-   * Get the <%- camelize(property.name) %> property
-   * <p>
-   * <%- propertyFactoryMethodDoc(property) %>
-   * </p>
-   *
-   * @return property wrapper value around <%- propertyType(property) %>
-   */
-  public <%- propertyType(property) %> get<%- camelize(property.name) %>() {
-    return layer.get<%- camelize(property.name) %>().value;
-  }
+    /**
+     * Get the <%- camelize(property.name) %> property
+     * <p>
+     * <%- propertyFactoryMethodDoc(property) %>
+     * </p>
+     *
+     * @return property wrapper value around <%- propertyType(property) %>
+     */
+    public <%- propertyType(property) %> get<%- camelize(property.name) %>() {
+        return layer.get<%- camelize(property.name) %>().value;
+    }
 
-  /**
-   * Set the <%- camelize(property.name) %> property
-   * <p>
-   * <%- propertyFactoryMethodDoc(property) %>
-   * </p>
-   *
-   * @param value property wrapper value around <%- propertyType(property) %>
-   */
-  public void set<%- camelize(property.name) %>(<%- propertyTypeAnnotation(property) %><%- iff(() => propertyTypeAnnotation(property), "") %> <%- propertyType(property) %> value) {
-    PropertyValue propertyValue = <%- camelizeWithLeadingLowercase(property.name) %>(value);
-    constantPropertyUsageMap.put(PROPERTY_<%- snakeCaseUpper(property.name) %>, propertyValue);
-    layer.setProperties(propertyValue);
-  }
+    /**
+     * Set the <%- camelize(property.name) %> property
+     * <p>
+     * <%- propertyFactoryMethodDoc(property) %>
+     * </p>
+     *
+     * @param value property wrapper value around <%- propertyType(property) %>
+     */
+    public void set<%- camelize(property.name) %>(<%- propertyTypeAnnotation(property) %><%- iff(() => propertyTypeAnnotation(property), "") %> <%- propertyType(property) %> value) {
+        PropertyValue propertyValue = <%- camelizeWithLeadingLowercase(property.name) %>(value);
+        constantPropertyUsageMap.put(PROPERTY_<%- snakeCaseUpper(property.name) %>, propertyValue);
+        layer.setProperties(propertyValue);
+    }
 
 <% } -%>
 <% } -%>
-  /**
-   * Set filter on the managed <%- type %>s.
-   *
-   * @param expression expression
-   */
-   @Override
-  public void setFilter(@NonNull Expression expression) {
-    layerFilter = expression;
-    layer.setFilter(layerFilter);
-  }
+    /**
+     * Set filter on the managed <%- type %>s.
+     *
+     * @param expression expression
+     */
+     @Override
+    public void setFilter(@NonNull Expression expression) {
+        layerFilter = expression;
+        layer.setFilter(layerFilter);
+    }
 
-  /**
-   * Get filter of the managed <%- type %>s.
-   *
-   * @return expression
-   */
-  @Nullable
-  public Expression getFilter() {
-    return layer.getFilter();
-  }
+    /**
+     * Get filter of the managed <%- type %>s.
+     *
+     * @return expression
+     */
+    @Nullable
+    public Expression getFilter() {
+        return layer.getFilter();
+    }
 }

--- a/plugin-annotation/scripts/annotation_manager_instrumentation_test.junit.ejs
+++ b/plugin-annotation/scripts/annotation_manager_instrumentation_test.junit.ejs
@@ -28,34 +28,34 @@ import static com.mapbox.mapboxsdk.style.layers.Property.*;
 @RunWith(AndroidJUnit4.class)
 public class <%- camelize(type) %>ManagerTest extends BaseActivityTest {
 
-  private <%- camelize(type) %>Manager <%- type %>Manager;
+    private <%- camelize(type) %>Manager <%- type %>Manager;
 
-  @Override
-  protected Class getActivityClass() {
-    return TestActivity.class;
-  }
+    @Override
+    protected Class getActivityClass() {
+        return TestActivity.class;
+    }
 
-  private void setup<%- camelize(type) %>Manager() {
-    Timber.i("Retrieving layer");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      <%- type %>Manager = new <%- camelize(type) %>Manager(idlingResource.getMapView(), mapboxMap, Objects.requireNonNull(mapboxMap.getStyle()));
-    });
-  }
+    private void setup<%- camelize(type) %>Manager() {
+        Timber.i("Retrieving layer");
+        invoke(mapboxMap, (uiController, mapboxMap) -> {
+            <%- type %>Manager = new <%- camelize(type) %>Manager(idlingResource.getMapView(), mapboxMap, Objects.requireNonNull(mapboxMap.getStyle()));
+        });
+    }
 <% for (const property of properties) { -%>
 <% if (!supportsPropertyFunction(property) && property.name !== "line-gradient" && property.name !== "symbol-z-order") { -%>
 
-  @Test
-  public void test<%- camelize(property.name) %>AsConstant() {
-    validateTestSetup();
-    setup<%- camelize(type) %>Manager();
-    Timber.i("<%- property.name %>");
-    invoke(mapboxMap, (uiController, mapboxMap) -> {
-      assertNotNull(<%- type %>Manager);
+    @Test
+    public void test<%- camelize(property.name) %>AsConstant() {
+        validateTestSetup();
+        setup<%- camelize(type) %>Manager();
+        Timber.i("<%- property.name %>");
+        invoke(mapboxMap, (uiController, mapboxMap) -> {
+            assertNotNull(<%- type %>Manager);
 
-      <%- type %>Manager.set<%- camelize(property.name) %>(<%- defaultValueJava(property) %>);
-      assertEquals((<%- propertyType(property) %>) <%- type %>Manager.get<%- camelize(property.name) %>(), (<%- propertyType(property) %>) <%- defaultValueJava(property) %>);
-    });
-  }
+            <%- type %>Manager.set<%- camelize(property.name) %>(<%- defaultValueJava(property) %>);
+            assertEquals((<%- propertyType(property) %>) <%- type %>Manager.get<%- camelize(property.name) %>(), (<%- propertyType(property) %>) <%- defaultValueJava(property) %>);
+        });
+    }
 <% } -%>
 <% } -%>
 }

--- a/plugin-annotation/scripts/annotation_manager_unit_test.junit.ejs
+++ b/plugin-annotation/scripts/annotation_manager_unit_test.junit.ejs
@@ -37,560 +37,560 @@ import static org.mockito.Mockito.*;
 
 public class <%- camelize(type) %>ManagerTest {
 
-  private DraggableAnnotationController draggableAnnotationController = mock(DraggableAnnotationController.class);
-  private MapView mapView = mock(MapView.class);
-  private MapboxMap mapboxMap = mock(MapboxMap.class);
-  private Style style = mock(Style.class);
-  private GeoJsonSource geoJsonSource = mock(GeoJsonSource.class);
-  private GeoJsonSource optionedGeoJsonSource = mock(GeoJsonSource.class);
-  private String layerId = "annotation_layer";
-  private <%- camelize(type) %>Layer <%- type  %>Layer = mock(<%- camelize(type) %>Layer.class);
-  private <%- camelize(type) %>Manager <%- type  %>Manager;
-  private CoreElementProvider<<%- camelize(type) %>Layer> coreElementProvider = mock(CoreElementProvider.class);
-  private GeoJsonOptions geoJsonOptions = mock(GeoJsonOptions.class);
+    private DraggableAnnotationController draggableAnnotationController = mock(DraggableAnnotationController.class);
+    private MapView mapView = mock(MapView.class);
+    private MapboxMap mapboxMap = mock(MapboxMap.class);
+    private Style style = mock(Style.class);
+    private GeoJsonSource geoJsonSource = mock(GeoJsonSource.class);
+    private GeoJsonSource optionedGeoJsonSource = mock(GeoJsonSource.class);
+    private String layerId = "annotation_layer";
+    private <%- camelize(type) %>Layer <%- type  %>Layer = mock(<%- camelize(type) %>Layer.class);
+    private <%- camelize(type) %>Manager <%- type  %>Manager;
+    private CoreElementProvider<<%- camelize(type) %>Layer> coreElementProvider = mock(CoreElementProvider.class);
+    private GeoJsonOptions geoJsonOptions = mock(GeoJsonOptions.class);
 
-  @Before
-  public void beforeTest() {
-    when(<%- type  %>Layer.getId()).thenReturn(layerId);
-    when(coreElementProvider.getLayer()).thenReturn(<%- type  %>Layer);
-    when(coreElementProvider.getSource(null)).thenReturn(geoJsonSource);
-    when(coreElementProvider.getSource(geoJsonOptions)).thenReturn(optionedGeoJsonSource);
-    when(style.isFullyLoaded()).thenReturn(true);
-  }
-
-  @Test
-  public void testInitialization() {
-    <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
-    verify(style).addSource(geoJsonSource);
-    verify(style).addLayer(<%- type  %>Layer);
-    assertTrue(<%- type  %>Manager.dataDrivenPropertyUsageMap.size() > 0);
-    for (Boolean value : <%- type  %>Manager.dataDrivenPropertyUsageMap.values()) {
-      assertFalse(value);
+    @Before
+    public void beforeTest() {
+        when(<%- type  %>Layer.getId()).thenReturn(layerId);
+        when(coreElementProvider.getLayer()).thenReturn(<%- type  %>Layer);
+        when(coreElementProvider.getSource(null)).thenReturn(geoJsonSource);
+        when(coreElementProvider.getSource(geoJsonOptions)).thenReturn(optionedGeoJsonSource);
+        when(style.isFullyLoaded()).thenReturn(true);
     }
-    verify(<%- type  %>Layer).setProperties(<%- type  %>Manager.constantPropertyUsageMap.values().toArray(new PropertyValue[0]));
-    verify(<%- type  %>Layer, times(0)).setFilter(any(Expression.class));
-    verify(draggableAnnotationController).onSourceUpdated();
-    verify(geoJsonSource).setGeoJson(any(FeatureCollection.class));
-  }
 
-  @Test
-  public void testInitializationOnStyleReload() {
-    <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
-    verify(style).addSource(geoJsonSource);
-    verify(style).addLayer(<%- type  %>Layer);
-    assertTrue(<%- type  %>Manager.dataDrivenPropertyUsageMap.size() > 0);
-    for (Boolean value : <%- type  %>Manager.dataDrivenPropertyUsageMap.values()) {
-      assertFalse(value);
+    @Test
+    public void testInitialization() {
+        <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        verify(style).addSource(geoJsonSource);
+        verify(style).addLayer(<%- type  %>Layer);
+        assertTrue(<%- type  %>Manager.dataDrivenPropertyUsageMap.size() > 0);
+        for (Boolean value : <%- type  %>Manager.dataDrivenPropertyUsageMap.values()) {
+            assertFalse(value);
+        }
+        verify(<%- type  %>Layer).setProperties(<%- type  %>Manager.constantPropertyUsageMap.values().toArray(new PropertyValue[0]));
+        verify(<%- type  %>Layer, times(0)).setFilter(any(Expression.class));
+        verify(draggableAnnotationController).onSourceUpdated();
+        verify(geoJsonSource).setGeoJson(any(FeatureCollection.class));
     }
-    verify(<%- type  %>Layer).setProperties(<%- type  %>Manager.constantPropertyUsageMap.values().toArray(new PropertyValue[0]));
-    verify(draggableAnnotationController).onSourceUpdated();
-    verify(geoJsonSource).setGeoJson(any(FeatureCollection.class));
 
-    Expression filter = Expression.literal(false);
-    <%- type  %>Manager.setFilter(filter);
+    @Test
+    public void testInitializationOnStyleReload() {
+        <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        verify(style).addSource(geoJsonSource);
+        verify(style).addLayer(<%- type  %>Layer);
+        assertTrue(<%- type  %>Manager.dataDrivenPropertyUsageMap.size() > 0);
+        for (Boolean value : <%- type  %>Manager.dataDrivenPropertyUsageMap.values()) {
+            assertFalse(value);
+        }
+        verify(<%- type  %>Layer).setProperties(<%- type  %>Manager.constantPropertyUsageMap.values().toArray(new PropertyValue[0]));
+        verify(draggableAnnotationController).onSourceUpdated();
+        verify(geoJsonSource).setGeoJson(any(FeatureCollection.class));
 
-    ArgumentCaptor<MapView.OnDidFinishLoadingStyleListener> loadingArgumentCaptor = ArgumentCaptor.forClass(MapView.OnDidFinishLoadingStyleListener.class);
-    verify(mapView).addOnDidFinishLoadingStyleListener(loadingArgumentCaptor.capture());
-    loadingArgumentCaptor.getValue().onDidFinishLoadingStyle();
+        Expression filter = Expression.literal(false);
+        <%- type  %>Manager.setFilter(filter);
 
-    ArgumentCaptor<Style.OnStyleLoaded> styleLoadedArgumentCaptor = ArgumentCaptor.forClass(Style.OnStyleLoaded.class);
-    verify(mapboxMap).getStyle(styleLoadedArgumentCaptor.capture());
+        ArgumentCaptor<MapView.OnDidFinishLoadingStyleListener> loadingArgumentCaptor = ArgumentCaptor.forClass(MapView.OnDidFinishLoadingStyleListener.class);
+        verify(mapView).addOnDidFinishLoadingStyleListener(loadingArgumentCaptor.capture());
+        loadingArgumentCaptor.getValue().onDidFinishLoadingStyle();
 
-    Style newStyle = mock(Style.class);
-    when(newStyle.isFullyLoaded()).thenReturn(true);
-    GeoJsonSource newSource = mock(GeoJsonSource.class);
-    when(coreElementProvider.getSource(null)).thenReturn(newSource);
-    <%- camelize(type)  %>Layer newLayer = mock(<%- camelize(type)  %>Layer.class);
-    when(coreElementProvider.getLayer()).thenReturn(newLayer);
-    styleLoadedArgumentCaptor.getValue().onStyleLoaded(newStyle);
+        ArgumentCaptor<Style.OnStyleLoaded> styleLoadedArgumentCaptor = ArgumentCaptor.forClass(Style.OnStyleLoaded.class);
+        verify(mapboxMap).getStyle(styleLoadedArgumentCaptor.capture());
 
-    verify(newStyle).addSource(newSource);
-    verify(newStyle).addLayer(newLayer);
-    assertTrue(<%- type  %>Manager.dataDrivenPropertyUsageMap.size() > 0);
-    for (Boolean value : <%- type  %>Manager.dataDrivenPropertyUsageMap.values()) {
-      assertFalse(value);
+        Style newStyle = mock(Style.class);
+        when(newStyle.isFullyLoaded()).thenReturn(true);
+        GeoJsonSource newSource = mock(GeoJsonSource.class);
+        when(coreElementProvider.getSource(null)).thenReturn(newSource);
+        <%- camelize(type)  %>Layer newLayer = mock(<%- camelize(type)  %>Layer.class);
+        when(coreElementProvider.getLayer()).thenReturn(newLayer);
+        styleLoadedArgumentCaptor.getValue().onStyleLoaded(newStyle);
+
+        verify(newStyle).addSource(newSource);
+        verify(newStyle).addLayer(newLayer);
+        assertTrue(<%- type  %>Manager.dataDrivenPropertyUsageMap.size() > 0);
+        for (Boolean value : <%- type  %>Manager.dataDrivenPropertyUsageMap.values()) {
+            assertFalse(value);
+        }
+        verify(newLayer).setProperties(<%- type  %>Manager.constantPropertyUsageMap.values().toArray(new PropertyValue[0]));
+        verify(<%- type  %>Layer).setFilter(filter);
+        verify(draggableAnnotationController, times(2)).onSourceUpdated();
+        verify(newSource).setGeoJson(any(FeatureCollection.class));
     }
-    verify(newLayer).setProperties(<%- type  %>Manager.constantPropertyUsageMap.values().toArray(new PropertyValue[0]));
-    verify(<%- type  %>Layer).setFilter(filter);
-    verify(draggableAnnotationController, times(2)).onSourceUpdated();
-    verify(newSource).setGeoJson(any(FeatureCollection.class));
-  }
 
-  @Test
-  public void testLayerBelowInitialization() {
-    <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, "test_layer", null, draggableAnnotationController);
-    verify(style).addSource(geoJsonSource);
-    verify(style).addLayerBelow(<%- type  %>Layer, "test_layer");
-    assertTrue(<%- type  %>Manager.dataDrivenPropertyUsageMap.size() > 0);
-    for (Boolean value : <%- type  %>Manager.dataDrivenPropertyUsageMap.values()) {
-      assertFalse(value);
+    @Test
+    public void testLayerBelowInitialization() {
+        <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, "test_layer", null, draggableAnnotationController);
+        verify(style).addSource(geoJsonSource);
+        verify(style).addLayerBelow(<%- type  %>Layer, "test_layer");
+        assertTrue(<%- type  %>Manager.dataDrivenPropertyUsageMap.size() > 0);
+        for (Boolean value : <%- type  %>Manager.dataDrivenPropertyUsageMap.values()) {
+            assertFalse(value);
+        }
+        verify(<%- type  %>Layer).setProperties(<%- type  %>Manager.constantPropertyUsageMap.values().toArray(new PropertyValue[0]));
+        verify(draggableAnnotationController).onSourceUpdated();
+        verify(geoJsonSource).setGeoJson(any(FeatureCollection.class));
     }
-    verify(<%- type  %>Layer).setProperties(<%- type  %>Manager.constantPropertyUsageMap.values().toArray(new PropertyValue[0]));
-    verify(draggableAnnotationController).onSourceUpdated();
-    verify(geoJsonSource).setGeoJson(any(FeatureCollection.class));
-  }
 
-  @Test
-  public void testGeoJsonOptionsInitialization() {
-    <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, geoJsonOptions, draggableAnnotationController);
-    verify(style).addSource(optionedGeoJsonSource);
-    verify(style).addLayer(<%- type  %>Layer);
-    assertTrue(<%- type  %>Manager.dataDrivenPropertyUsageMap.size() > 0);
-    for (Boolean value : <%- type  %>Manager.dataDrivenPropertyUsageMap.values()) {
-      assertFalse(value);
+    @Test
+    public void testGeoJsonOptionsInitialization() {
+        <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, geoJsonOptions, draggableAnnotationController);
+        verify(style).addSource(optionedGeoJsonSource);
+        verify(style).addLayer(<%- type  %>Layer);
+        assertTrue(<%- type  %>Manager.dataDrivenPropertyUsageMap.size() > 0);
+        for (Boolean value : <%- type  %>Manager.dataDrivenPropertyUsageMap.values()) {
+            assertFalse(value);
+        }
+        verify(<%- type  %>Layer).setProperties(<%- type  %>Manager.constantPropertyUsageMap.values().toArray(new PropertyValue[0]));
+        verify(<%- type  %>Layer, times(0)).setFilter(any(Expression.class));
+        verify(draggableAnnotationController).onSourceUpdated();
+        verify(optionedGeoJsonSource).setGeoJson(any(FeatureCollection.class));
     }
-    verify(<%- type  %>Layer).setProperties(<%- type  %>Manager.constantPropertyUsageMap.values().toArray(new PropertyValue[0]));
-    verify(<%- type  %>Layer, times(0)).setFilter(any(Expression.class));
-    verify(draggableAnnotationController).onSourceUpdated();
-    verify(optionedGeoJsonSource).setGeoJson(any(FeatureCollection.class));
-  }
 
-  @Test
-  public void testNoUpdateOnStyleReload() {
-    <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, "test_layer", null, draggableAnnotationController);
-    verify(geoJsonSource, times(1)).setGeoJson(any(FeatureCollection.class));
+    @Test
+    public void testNoUpdateOnStyleReload() {
+        <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, "test_layer", null, draggableAnnotationController);
+        verify(geoJsonSource, times(1)).setGeoJson(any(FeatureCollection.class));
 
-    when(style.isFullyLoaded()).thenReturn(false);
-    <%- type  %>Manager.updateSource();
-    verify(geoJsonSource, times(1)).setGeoJson(any(FeatureCollection.class));
-  }
+        when(style.isFullyLoaded()).thenReturn(false);
+        <%- type  %>Manager.updateSource();
+        verify(geoJsonSource, times(1)).setGeoJson(any(FeatureCollection.class));
+    }
 
-  @Test
-  public void testLayerId() {
-    <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
-    assertEquals(layerId, <%- type  %>Manager.getLayerId());
-  }
+    @Test
+    public void testLayerId() {
+        <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        assertEquals(layerId, <%- type  %>Manager.getLayerId());
+    }
 
-  @Test
-  public void testAdd<%- camelize(type) %>() {
-    <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    @Test
+    public void testAdd<%- camelize(type) %>() {
+        <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
 <% if (type === "circle" || type === "symbol") { -%>
-    <%- camelize(type) %> <%- type %> = <%- type %>Manager.create(new <%- camelize(type) %>Options().withLatLng(new LatLng()));
+        <%- camelize(type) %> <%- type %> = <%- type %>Manager.create(new <%- camelize(type) %>Options().withLatLng(new LatLng()));
 <% } else if (type === "line") { -%>
-    List<LatLng>latLngs = new ArrayList<>();
-    latLngs.add(new LatLng());
-    latLngs.add(new LatLng(1,1));
-    <%- camelize(type) %> <%- type %> = <%- type %>Manager.create(new <%- camelize(type) %>Options().withLatLngs(latLngs));
+        List<LatLng>latLngs = new ArrayList<>();
+        latLngs.add(new LatLng());
+        latLngs.add(new LatLng(1,1));
+        <%- camelize(type) %> <%- type %> = <%- type %>Manager.create(new <%- camelize(type) %>Options().withLatLngs(latLngs));
 <% } else { -%>
-    List<LatLng>innerLatLngs = new ArrayList<>();
-    innerLatLngs.add(new LatLng());
-    innerLatLngs.add(new LatLng(1,1));
-    innerLatLngs.add(new LatLng(-1,-1));
-    innerLatLngs.add(new LatLng());
-    List<List<LatLng>>latLngs = new ArrayList<>();
-    latLngs.add(innerLatLngs);
-    <%- camelize(type) %> <%- type %> = <%- type %>Manager.create(new <%- camelize(type) %>Options().withLatLngs(latLngs));
+        List<LatLng>innerLatLngs = new ArrayList<>();
+        innerLatLngs.add(new LatLng());
+        innerLatLngs.add(new LatLng(1,1));
+        innerLatLngs.add(new LatLng(-1,-1));
+        innerLatLngs.add(new LatLng());
+        List<List<LatLng>>latLngs = new ArrayList<>();
+        latLngs.add(innerLatLngs);
+        <%- camelize(type) %> <%- type %> = <%- type %>Manager.create(new <%- camelize(type) %>Options().withLatLngs(latLngs));
 <% } -%>
-    assertEquals(<%- type  %>Manager.getAnnotations().get(0), <%- type  %>);
-  }
+        assertEquals(<%- type  %>Manager.getAnnotations().get(0), <%- type  %>);
+    }
 
-  @Test
-  public void add<%- camelize(type) %>FromFeatureCollection() {
-    <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    @Test
+    public void add<%- camelize(type) %>FromFeatureCollection() {
+        <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
 <% if (type === "circle" || type === "symbol") { -%>
-    Geometry geometry = Point.fromLngLat(10, 10);
+        Geometry geometry = Point.fromLngLat(10, 10);
 <% } else if (type === "line") { -%>
-    List<Point> points = new ArrayList<>();
-    points.add(Point.fromLngLat(0, 0));
-    points.add(Point.fromLngLat(1, 1));
-    Geometry geometry = LineString.fromLngLats(points);
+        List<Point> points = new ArrayList<>();
+        points.add(Point.fromLngLat(0, 0));
+        points.add(Point.fromLngLat(1, 1));
+        Geometry geometry = LineString.fromLngLats(points);
 <% } else { -%>
-    List<Point> innerPoints = new ArrayList<>();
-    innerPoints.add(Point.fromLngLat(0, 0));
-    innerPoints.add(Point.fromLngLat(1, 1));
-    innerPoints.add(Point.fromLngLat(-1, -1));
-    innerPoints.add(Point.fromLngLat(0, 0));
-    List<List<Point>> points = new ArrayList<>();
-    points.add(innerPoints);
-    Geometry geometry = Polygon.fromLngLats(points);
+        List<Point> innerPoints = new ArrayList<>();
+        innerPoints.add(Point.fromLngLat(0, 0));
+        innerPoints.add(Point.fromLngLat(1, 1));
+        innerPoints.add(Point.fromLngLat(-1, -1));
+        innerPoints.add(Point.fromLngLat(0, 0));
+        List<List<Point>> points = new ArrayList<>();
+        points.add(innerPoints);
+        Geometry geometry = Polygon.fromLngLats(points);
 <% } -%>
 
-    Feature feature = Feature.fromGeometry(geometry);
+        Feature feature = Feature.fromGeometry(geometry);
 <% for (const property of properties) { -%>
 <% if (supportsPropertyFunction(property)) { -%>
 <% if (propertyType(property).endsWith("[]")) { -%>
-    feature.addProperty("<%- property.name %>", convertArray(<%- defaultValueJava(property) %>));
+        feature.addProperty("<%- property.name %>", convertArray(<%- defaultValueJava(property) %>));
 <% } else if (propertyType(property) === "Float") { -%>
-    feature.addNumberProperty("<%- property.name %>", <%- defaultValueJava(property) %>);
+        feature.addNumberProperty("<%- property.name %>", <%- defaultValueJava(property) %>);
 <% } else { -%>
-    feature.add<%- propertyType(property) -%>Property("<%- property.name %>", <%- defaultValueJava(property) %>);
+        feature.add<%- propertyType(property) -%>Property("<%- property.name %>", <%- defaultValueJava(property) %>);
 <% } -%>
 <% } -%>
 <% } -%>
-    feature.addBooleanProperty("is-draggable", true);
+        feature.addBooleanProperty("is-draggable", true);
 
-    List<<%- camelize(type) %>> <%- type %>s = <%- type %>Manager.create(FeatureCollection.fromFeature(feature));
-    <%- camelize(type) %> <%- type %> = <%- type %>s.get(0);
+        List<<%- camelize(type) %>> <%- type %>s = <%- type %>Manager.create(FeatureCollection.fromFeature(feature));
+        <%- camelize(type) %> <%- type %> = <%- type %>s.get(0);
 
-    assertEquals(<%- type %>.geometry, geometry);
+        assertEquals(<%- type %>.geometry, geometry);
 <% for (const property of properties) { -%>
 <% if (supportsPropertyFunction(property)) { -%>
 <% if (propertyType(property).endsWith("[]")) { -%>
 <% if (propertyType(property).endsWith("Float[]")) { -%>
-    PointF <%- camelizeWithLeadingLowercase(property.name) %>Expected = new PointF(<%- defaultValueJava(property) %>[0], <%- defaultValueJava(property) %>[1]);
-    assertEquals(<%- camelizeWithLeadingLowercase(property.name) %>Expected.x, <%- type %>.get<%- camelize(property.name) %>().x);
-    assertEquals(<%- camelizeWithLeadingLowercase(property.name) %>Expected.y, <%- type %>.get<%- camelize(property.name) %>().y);
+        PointF <%- camelizeWithLeadingLowercase(property.name) %>Expected = new PointF(<%- defaultValueJava(property) %>[0], <%- defaultValueJava(property) %>[1]);
+        assertEquals(<%- camelizeWithLeadingLowercase(property.name) %>Expected.x, <%- type %>.get<%- camelize(property.name) %>().x);
+        assertEquals(<%- camelizeWithLeadingLowercase(property.name) %>Expected.y, <%- type %>.get<%- camelize(property.name) %>().y);
 <% } else { -%>
-    assertTrue(Arrays.equals(<%- type %>.get<%- camelize(property.name) %>(), <%- defaultValueJava(property) %>));
+        assertTrue(Arrays.equals(<%- type %>.get<%- camelize(property.name) %>(), <%- defaultValueJava(property) %>));
 <% } -%>
 <% } else if (property.type == 'color') { -%>
-    assertEquals(<%- type %>.get<%- camelize(property.name) %>(), <%- defaultValueJava(property) %>);
+        assertEquals(<%- type %>.get<%- camelize(property.name) %>(), <%- defaultValueJava(property) %>);
 <% } else { -%>
-    assertEquals(<%- type %>.get<%- camelize(property.name) %>(), <%- defaultValueJava(property) %>);
+        assertEquals(<%- type %>.get<%- camelize(property.name) %>(), <%- defaultValueJava(property) %>);
 <% } -%>
 <% } -%>
 <% } -%>
-    assertTrue(<%- type %>.isDraggable());
-  }
-
-  @Test
-  public void add<%- camelize(type) %>s() {
-    <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
-<% if (type === "circle" || type === "symbol") { -%>
-    List<LatLng> latLngList = new ArrayList<>();
-    latLngList.add(new LatLng());
-    latLngList.add(new LatLng(1, 1));
-    List< <%- camelize(type) %>Options> options = new ArrayList<>();
-    for (LatLng latLng : latLngList) {
-      options.add(new  <%- camelize(type) %>Options().withLatLng(latLng));
+        assertTrue(<%- type %>.isDraggable());
     }
+
+    @Test
+    public void add<%- camelize(type) %>s() {
+        <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+<% if (type === "circle" || type === "symbol") { -%>
+        List<LatLng> latLngList = new ArrayList<>();
+        latLngList.add(new LatLng());
+        latLngList.add(new LatLng(1, 1));
+        List< <%- camelize(type) %>Options> options = new ArrayList<>();
+        for (LatLng latLng : latLngList) {
+            options.add(new  <%- camelize(type) %>Options().withLatLng(latLng));
+        }
 <% } else if (type === "line") { -%>
-    List<List<LatLng>> latLngList = new ArrayList<>();
-    latLngList.add(new ArrayList<LatLng>() {{
-      add(new LatLng(2, 2));
-      add(new LatLng(2, 3));
-    }});
-    latLngList.add(new ArrayList<LatLng>() {{
-      add(new LatLng(1, 1));
-      add(new LatLng(2, 3));
-    }});
-    List<LineOptions> options = new ArrayList<>();
-    for (List<LatLng> latLngs : latLngList) {
-      options.add(new LineOptions().withLatLngs(latLngs));
+        List<List<LatLng>> latLngList = new ArrayList<>();
+        latLngList.add(new ArrayList<LatLng>() {{
+            add(new LatLng(2, 2));
+            add(new LatLng(2, 3));
+        }});
+        latLngList.add(new ArrayList<LatLng>() {{
+            add(new LatLng(1, 1));
+            add(new LatLng(2, 3));
+        }});
+        List<LineOptions> options = new ArrayList<>();
+        for (List<LatLng> latLngs : latLngList) {
+            options.add(new LineOptions().withLatLngs(latLngs));
+        }
+<% } else { -%>
+        final List<List<LatLng>> latLngListOne = new ArrayList<>();
+        latLngListOne.add(new ArrayList<LatLng>() {{
+            add(new LatLng(2, 2));
+            add(new LatLng(2, 3));
+        }});
+        latLngListOne.add(new ArrayList<LatLng>() {{
+            add(new LatLng(1, 1));
+            add(new LatLng(2, 3));
+        }});
+
+        final List<List<LatLng>> latLngListTwo = new ArrayList<>();
+        latLngListTwo.add(new ArrayList<LatLng>() {{
+            add(new LatLng(5, 7));
+            add(new LatLng(2, 3));
+        }});
+        latLngListTwo.add(new ArrayList<LatLng>() {{
+            add(new LatLng(1, 1));
+            add(new LatLng(3, 9));
+        }});
+
+        List<List<List<LatLng>>> latLngList = new ArrayList<List<List<LatLng>>>(){{
+            add(latLngListOne);
+            add(latLngListTwo);
+        }};
+        List<FillOptions> options = new ArrayList<>();
+        for (List<List<LatLng>> lists : latLngList) {
+            options.add(new FillOptions().withLatLngs(lists));
+        }
+<% } -%>
+        List<<%- camelize(type) %>> <%- type %>s = <%- type %>Manager.create(options);
+        assertTrue("Returned value size should match", <%- type  %>s.size() == 2);
+        assertTrue("Annotations size should match", <%- type  %>Manager.getAnnotations().size() == 2);
     }
+
+    @Test
+    public void testDelete<%- camelize(type) %>() {
+        <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+<% if (type === "circle" || type === "symbol") { -%>
+        <%- camelize(type) %> <%- type %> = <%- type %>Manager.create(new <%- camelize(type) %>Options().withLatLng(new LatLng()));
+<% } else if (type === "line") { -%>
+        List<LatLng>latLngs = new ArrayList<>();
+        latLngs.add(new LatLng());
+        latLngs.add(new LatLng(1,1));
+        <%- camelize(type) %> <%- type %> = <%- type %>Manager.create(new <%- camelize(type) %>Options().withLatLngs(latLngs));
 <% } else { -%>
-    final List<List<LatLng>> latLngListOne = new ArrayList<>();
-    latLngListOne.add(new ArrayList<LatLng>() {{
-      add(new LatLng(2, 2));
-      add(new LatLng(2, 3));
-    }});
-    latLngListOne.add(new ArrayList<LatLng>() {{
-      add(new LatLng(1, 1));
-      add(new LatLng(2, 3));
-    }});
-
-    final List<List<LatLng>> latLngListTwo = new ArrayList<>();
-    latLngListTwo.add(new ArrayList<LatLng>() {{
-      add(new LatLng(5, 7));
-      add(new LatLng(2, 3));
-    }});
-    latLngListTwo.add(new ArrayList<LatLng>() {{
-      add(new LatLng(1, 1));
-      add(new LatLng(3, 9));
-    }});
-
-    List<List<List<LatLng>>> latLngList = new ArrayList<List<List<LatLng>>>(){{
-      add(latLngListOne);
-      add(latLngListTwo);
-    }};
-    List<FillOptions> options = new ArrayList<>();
-    for (List<List<LatLng>> lists : latLngList) {
-      options.add(new FillOptions().withLatLngs(lists));
+        List<LatLng>innerLatLngs = new ArrayList<>();
+        innerLatLngs.add(new LatLng());
+        innerLatLngs.add(new LatLng(1,1));
+        innerLatLngs.add(new LatLng(-1,-1));
+        List<List<LatLng>>latLngs = new ArrayList<>();
+        latLngs.add(innerLatLngs);
+        <%- camelize(type) %> <%- type %> = <%- type %>Manager.create(new <%- camelize(type) %>Options().withLatLngs(latLngs));
+<% } -%>
+        <%- type  %>Manager.delete(<%- type  %>);
+        assertTrue(<%- type  %>Manager.getAnnotations().size() == 0);
     }
-<% } -%>
-    List<<%- camelize(type) %>> <%- type %>s = <%- type %>Manager.create(options);
-    assertTrue("Returned value size should match", <%- type  %>s.size() == 2);
-    assertTrue("Annotations size should match", <%- type  %>Manager.getAnnotations().size() == 2);
-  }
 
-  @Test
-  public void testDelete<%- camelize(type) %>() {
-    <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    @Test
+    public void testGeometry<%- camelize(type) %>() {
+        <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
 <% if (type === "circle" || type === "symbol") { -%>
-    <%- camelize(type) %> <%- type %> = <%- type %>Manager.create(new <%- camelize(type) %>Options().withLatLng(new LatLng()));
+        LatLng latLng = new LatLng(12, 34);
+        <%- camelize(type) %>Options options = new <%- camelize(type) %>Options().withLatLng(latLng);
+        <%- camelize(type) %> <%- type %> = <%- type %>Manager.create(options);
+        assertEquals(options.getLatLng(), latLng);
+        assertEquals(<%- type %>.getLatLng(), latLng);
+        assertEquals(options.getGeometry(), Point.fromLngLat(34, 12));
+        assertEquals(<%- type  %>.getGeometry(), Point.fromLngLat(34, 12));
 <% } else if (type === "line") { -%>
-    List<LatLng>latLngs = new ArrayList<>();
-    latLngs.add(new LatLng());
-    latLngs.add(new LatLng(1,1));
-    <%- camelize(type) %> <%- type %> = <%- type %>Manager.create(new <%- camelize(type) %>Options().withLatLngs(latLngs));
+        List<LatLng>latLngs = new ArrayList<>();
+        latLngs.add(new LatLng());
+        latLngs.add(new LatLng(1,1));
+        <%- camelize(type) %>Options options = new <%- camelize(type) %>Options().withLatLngs(latLngs);
+        <%- camelize(type) %> <%- type %> = <%- type %>Manager.create(options);
+        assertEquals(options.getLatLngs(), latLngs);
+        assertEquals(line.getLatLngs(), latLngs);
+        assertEquals(options.getGeometry(), LineString.fromLngLats(new ArrayList<Point>() {{
+                    add(Point.fromLngLat(0, 0));
+                    add(Point.fromLngLat(1, 1));
+        }}));
+        assertEquals(line.getGeometry(), LineString.fromLngLats(new ArrayList<Point>() {{
+            add(Point.fromLngLat(0, 0));
+            add(Point.fromLngLat(1, 1));
+        }}));
 <% } else { -%>
-    List<LatLng>innerLatLngs = new ArrayList<>();
-    innerLatLngs.add(new LatLng());
-    innerLatLngs.add(new LatLng(1,1));
-    innerLatLngs.add(new LatLng(-1,-1));
-    List<List<LatLng>>latLngs = new ArrayList<>();
-    latLngs.add(innerLatLngs);
-    <%- camelize(type) %> <%- type %> = <%- type %>Manager.create(new <%- camelize(type) %>Options().withLatLngs(latLngs));
+        List<LatLng>innerLatLngs = new ArrayList<>();
+        innerLatLngs.add(new LatLng());
+        innerLatLngs.add(new LatLng(1,1));
+        innerLatLngs.add(new LatLng(-1,-1));
+        List<List<LatLng>>latLngs = new ArrayList<>();
+        latLngs.add(innerLatLngs);
+        <%- camelize(type) %>Options options = new <%- camelize(type) %>Options().withLatLngs(latLngs);
+        Fill fill = fillManager.create(options);
+        assertEquals(options.getLatLngs(), latLngs);
+        assertEquals(fill.getLatLngs(), latLngs);
+        assertEquals(options.getGeometry(), Polygon.fromLngLats(new ArrayList<List<Point>>() {{
+            add(new ArrayList<Point>() {{
+                add(Point.fromLngLat(0, 0));
+                add(Point.fromLngLat(1, 1));
+                add(Point.fromLngLat(-1, -1));
+            }});
+        }}));
+        assertEquals(fill.getGeometry(), Polygon.fromLngLats(new ArrayList<List<Point>>() {{
+            add(new ArrayList<Point>() {{
+                add(Point.fromLngLat(0, 0));
+                add(Point.fromLngLat(1, 1));
+                add(Point.fromLngLat(-1, -1));
+            }});
+        }}));
 <% } -%>
-    <%- type  %>Manager.delete(<%- type  %>);
-    assertTrue(<%- type  %>Manager.getAnnotations().size() == 0);
-  }
+    }
 
-  @Test
-  public void testGeometry<%- camelize(type) %>() {
-    <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    @Test
+    public void testFeatureId<%- camelize(type) %>() {
+        <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
 <% if (type === "circle" || type === "symbol") { -%>
-    LatLng latLng = new LatLng(12, 34);
-    <%- camelize(type) %>Options options = new <%- camelize(type) %>Options().withLatLng(latLng);
-    <%- camelize(type) %> <%- type %> = <%- type %>Manager.create(options);
-    assertEquals(options.getLatLng(), latLng);
-    assertEquals(<%- type %>.getLatLng(), latLng);
-    assertEquals(options.getGeometry(), Point.fromLngLat(34, 12));
-    assertEquals(<%- type  %>.getGeometry(), Point.fromLngLat(34, 12));
+        <%- camelize(type) %> <%- type %>Zero = <%- type %>Manager.create(new <%- camelize(type) %>Options().withLatLng(new LatLng()));
+        <%- camelize(type) %> <%- type %>One = <%- type %>Manager.create(new <%- camelize(type) %>Options().withLatLng(new LatLng()));
 <% } else if (type === "line") { -%>
-    List<LatLng>latLngs = new ArrayList<>();
-    latLngs.add(new LatLng());
-    latLngs.add(new LatLng(1,1));
-    <%- camelize(type) %>Options options = new <%- camelize(type) %>Options().withLatLngs(latLngs);
-    <%- camelize(type) %> <%- type %> = <%- type %>Manager.create(options);
-    assertEquals(options.getLatLngs(), latLngs);
-    assertEquals(line.getLatLngs(), latLngs);
-    assertEquals(options.getGeometry(), LineString.fromLngLats(new ArrayList<Point>() {{
-          add(Point.fromLngLat(0, 0));
-          add(Point.fromLngLat(1, 1));
-    }}));
-    assertEquals(line.getGeometry(), LineString.fromLngLats(new ArrayList<Point>() {{
-      add(Point.fromLngLat(0, 0));
-      add(Point.fromLngLat(1, 1));
-    }}));
+        List<LatLng>latLngs = new ArrayList<>();
+        latLngs.add(new LatLng());
+        latLngs.add(new LatLng(1,1));
+        <%- camelize(type) %> <%- type %>Zero = <%- type %>Manager.create(new <%- camelize(type) %>Options().withLatLngs(latLngs));
+        <%- camelize(type) %> <%- type %>One = <%- type %>Manager.create(new <%- camelize(type) %>Options().withLatLngs(latLngs));
 <% } else { -%>
-    List<LatLng>innerLatLngs = new ArrayList<>();
-    innerLatLngs.add(new LatLng());
-    innerLatLngs.add(new LatLng(1,1));
-    innerLatLngs.add(new LatLng(-1,-1));
-    List<List<LatLng>>latLngs = new ArrayList<>();
-    latLngs.add(innerLatLngs);
-    <%- camelize(type) %>Options options = new <%- camelize(type) %>Options().withLatLngs(latLngs);
-    Fill fill = fillManager.create(options);
-    assertEquals(options.getLatLngs(), latLngs);
-    assertEquals(fill.getLatLngs(), latLngs);
-    assertEquals(options.getGeometry(), Polygon.fromLngLats(new ArrayList<List<Point>>() {{
-      add(new ArrayList<Point>() {{
-        add(Point.fromLngLat(0, 0));
-        add(Point.fromLngLat(1, 1));
-        add(Point.fromLngLat(-1, -1));
-      }});
-    }}));
-    assertEquals(fill.getGeometry(), Polygon.fromLngLats(new ArrayList<List<Point>>() {{
-      add(new ArrayList<Point>() {{
-        add(Point.fromLngLat(0, 0));
-        add(Point.fromLngLat(1, 1));
-        add(Point.fromLngLat(-1, -1));
-      }});
-    }}));
+        List<LatLng>innerLatLngs = new ArrayList<>();
+        innerLatLngs.add(new LatLng());
+        innerLatLngs.add(new LatLng(1,1));
+        innerLatLngs.add(new LatLng(-1,-1));
+        List<List<LatLng>>latLngs = new ArrayList<>();
+        latLngs.add(innerLatLngs);
+        <%- camelize(type) %> <%- type %>Zero = <%- type %>Manager.create(new <%- camelize(type) %>Options().withLatLngs(latLngs));
+        <%- camelize(type) %> <%- type %>One = <%- type %>Manager.create(new <%- camelize(type) %>Options().withLatLngs(latLngs));
 <% } -%>
-  }
+        assertEquals(<%- type  %>Zero.getFeature().get(<%- camelize(type) %>.ID_KEY).getAsLong(), 0);
+        assertEquals(<%- type  %>One.getFeature().get(<%- camelize(type) %>.ID_KEY).getAsLong(), 1);
+    }
 
-  @Test
-  public void testFeatureId<%- camelize(type) %>() {
-    <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    @Test
+    public void test<%- camelize(type) %>DraggableFlag() {
+        <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
 <% if (type === "circle" || type === "symbol") { -%>
-    <%- camelize(type) %> <%- type %>Zero = <%- type %>Manager.create(new <%- camelize(type) %>Options().withLatLng(new LatLng()));
-    <%- camelize(type) %> <%- type %>One = <%- type %>Manager.create(new <%- camelize(type) %>Options().withLatLng(new LatLng()));
+        <%- camelize(type) %> <%- type %>Zero = <%- type %>Manager.create(new <%- camelize(type) %>Options().withLatLng(new LatLng()));
 <% } else if (type === "line") { -%>
-    List<LatLng>latLngs = new ArrayList<>();
-    latLngs.add(new LatLng());
-    latLngs.add(new LatLng(1,1));
-    <%- camelize(type) %> <%- type %>Zero = <%- type %>Manager.create(new <%- camelize(type) %>Options().withLatLngs(latLngs));
-    <%- camelize(type) %> <%- type %>One = <%- type %>Manager.create(new <%- camelize(type) %>Options().withLatLngs(latLngs));
+        List<LatLng>latLngs = new ArrayList<>();
+        latLngs.add(new LatLng());
+        latLngs.add(new LatLng(1,1));
+        <%- camelize(type) %> <%- type %>Zero = <%- type %>Manager.create(new <%- camelize(type) %>Options().withLatLngs(latLngs));
 <% } else { -%>
-    List<LatLng>innerLatLngs = new ArrayList<>();
-    innerLatLngs.add(new LatLng());
-    innerLatLngs.add(new LatLng(1,1));
-    innerLatLngs.add(new LatLng(-1,-1));
-    List<List<LatLng>>latLngs = new ArrayList<>();
-    latLngs.add(innerLatLngs);
-    <%- camelize(type) %> <%- type %>Zero = <%- type %>Manager.create(new <%- camelize(type) %>Options().withLatLngs(latLngs));
-    <%- camelize(type) %> <%- type %>One = <%- type %>Manager.create(new <%- camelize(type) %>Options().withLatLngs(latLngs));
-<% } -%>
-    assertEquals(<%- type  %>Zero.getFeature().get(<%- camelize(type) %>.ID_KEY).getAsLong(), 0);
-    assertEquals(<%- type  %>One.getFeature().get(<%- camelize(type) %>.ID_KEY).getAsLong(), 1);
-  }
-
-  @Test
-  public void test<%- camelize(type) %>DraggableFlag() {
-    <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
-<% if (type === "circle" || type === "symbol") { -%>
-    <%- camelize(type) %> <%- type %>Zero = <%- type %>Manager.create(new <%- camelize(type) %>Options().withLatLng(new LatLng()));
-<% } else if (type === "line") { -%>
-    List<LatLng>latLngs = new ArrayList<>();
-    latLngs.add(new LatLng());
-    latLngs.add(new LatLng(1,1));
-    <%- camelize(type) %> <%- type %>Zero = <%- type %>Manager.create(new <%- camelize(type) %>Options().withLatLngs(latLngs));
-<% } else { -%>
-    List<LatLng>innerLatLngs = new ArrayList<>();
-    innerLatLngs.add(new LatLng());
-    innerLatLngs.add(new LatLng(1,1));
-    innerLatLngs.add(new LatLng(-1,-1));
-    List<List<LatLng>>latLngs = new ArrayList<>();
-    latLngs.add(innerLatLngs);
-    <%- camelize(type) %> <%- type %>Zero = <%- type %>Manager.create(new <%- camelize(type) %>Options().withLatLngs(latLngs));
+        List<LatLng>innerLatLngs = new ArrayList<>();
+        innerLatLngs.add(new LatLng());
+        innerLatLngs.add(new LatLng(1,1));
+        innerLatLngs.add(new LatLng(-1,-1));
+        List<List<LatLng>>latLngs = new ArrayList<>();
+        latLngs.add(innerLatLngs);
+        <%- camelize(type) %> <%- type %>Zero = <%- type %>Manager.create(new <%- camelize(type) %>Options().withLatLngs(latLngs));
 <% } -%>
 
-    assertFalse(<%- type %>Zero.isDraggable());
-    <%- type %>Zero.setDraggable(true);
-    assertTrue(<%- type %>Zero.isDraggable());
-    <%- type %>Zero.setDraggable(false);
-    assertFalse(<%- type %>Zero.isDraggable());
-  }
+        assertFalse(<%- type %>Zero.isDraggable());
+        <%- type %>Zero.setDraggable(true);
+        assertTrue(<%- type %>Zero.isDraggable());
+        <%- type %>Zero.setDraggable(false);
+        assertFalse(<%- type %>Zero.isDraggable());
+    }
 
 <% for (const property of properties) { -%>
 <% if (supportsPropertyFunction(property)) { -%>
 
-  @Test
-  public void test<%- camelize(property.name) %>LayerProperty() {
-    <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
-    verify(<%- type  %>Layer, times(0)).setProperties(argThat(new PropertyValueMatcher(<%- camelizeWithLeadingLowercase(property.name) %>(get("<%- property.name %>")))));
+    @Test
+    public void test<%- camelize(property.name) %>LayerProperty() {
+        <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        verify(<%- type  %>Layer, times(0)).setProperties(argThat(new PropertyValueMatcher(<%- camelizeWithLeadingLowercase(property.name) %>(get("<%- property.name %>")))));
 
 <% if (type === "circle" || type === "symbol") { -%>
-    <%- camelize(type) %>Options options = new <%- camelize(type) %>Options().withLatLng(new LatLng()).with<%- camelize(property.name) %>(<%- defaultValueJava(property) %>);
+        <%- camelize(type) %>Options options = new <%- camelize(type) %>Options().withLatLng(new LatLng()).with<%- camelize(property.name) %>(<%- defaultValueJava(property) %>);
 <% } else if (type === "line") { -%>
-    List<LatLng>latLngs = new ArrayList<>();
-    latLngs.add(new LatLng());
-    latLngs.add(new LatLng(1,1));
-    <%- camelize(type) %>Options options = new <%- camelize(type) %>Options().withLatLngs(latLngs).with<%- camelize(property.name) %>(<%- defaultValueJava(property) %>);
+        List<LatLng>latLngs = new ArrayList<>();
+        latLngs.add(new LatLng());
+        latLngs.add(new LatLng(1,1));
+        <%- camelize(type) %>Options options = new <%- camelize(type) %>Options().withLatLngs(latLngs).with<%- camelize(property.name) %>(<%- defaultValueJava(property) %>);
 <% } else { -%>
-    List<LatLng>innerLatLngs = new ArrayList<>();
-    innerLatLngs.add(new LatLng());
-    innerLatLngs.add(new LatLng(1,1));
-    innerLatLngs.add(new LatLng(-1,-1));
-    List<List<LatLng>>latLngs = new ArrayList<>();
-    latLngs.add(innerLatLngs);
-    <%- camelize(type) %>Options options = new <%- camelize(type) %>Options().withLatLngs(latLngs).with<%- camelize(property.name) %>(<%- defaultValueJava(property) %>);
+        List<LatLng>innerLatLngs = new ArrayList<>();
+        innerLatLngs.add(new LatLng());
+        innerLatLngs.add(new LatLng(1,1));
+        innerLatLngs.add(new LatLng(-1,-1));
+        List<List<LatLng>>latLngs = new ArrayList<>();
+        latLngs.add(innerLatLngs);
+        <%- camelize(type) %>Options options = new <%- camelize(type) %>Options().withLatLngs(latLngs).with<%- camelize(property.name) %>(<%- defaultValueJava(property) %>);
 <% } -%>
-    <%- type  %>Manager.create(options);
-    verify(<%- type  %>Layer, times(1)).setProperties(argThat(new PropertyValueMatcher(<%- camelizeWithLeadingLowercase(property.name) %>(get("<%- property.name %>")))));
+        <%- type  %>Manager.create(options);
+        verify(<%- type  %>Layer, times(1)).setProperties(argThat(new PropertyValueMatcher(<%- camelizeWithLeadingLowercase(property.name) %>(get("<%- property.name %>")))));
 
-    <%- type  %>Manager.create(options);
-    verify(<%- type  %>Layer, times(1)).setProperties(argThat(new PropertyValueMatcher(<%- camelizeWithLeadingLowercase(property.name) %>(get("<%- property.name %>")))));
-  }
+        <%- type  %>Manager.create(options);
+        verify(<%- type  %>Layer, times(1)).setProperties(argThat(new PropertyValueMatcher(<%- camelizeWithLeadingLowercase(property.name) %>(get("<%- property.name %>")))));
+    }
 <% } -%>
 <% } -%>
 
-  @Test
-  public void test<%- camelize(type) %>LayerFilter() {
-    <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
-    Expression expression = Expression.eq(Expression.get("test"), "selected");
-    verify(<%- type %>Layer, times(0)).setFilter(expression);
+    @Test
+    public void test<%- camelize(type) %>LayerFilter() {
+        <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        Expression expression = Expression.eq(Expression.get("test"), "selected");
+        verify(<%- type %>Layer, times(0)).setFilter(expression);
 
-    <%- type %>Manager.setFilter(expression);
-    verify(<%- type %>Layer, times(1)).setFilter(expression);
+        <%- type %>Manager.setFilter(expression);
+        verify(<%- type %>Layer, times(1)).setFilter(expression);
 
-    when(<%- type %>Layer.getFilter()).thenReturn(expression);
-    assertEquals(expression, <%- type %>Manager.getFilter());
-    assertEquals(expression, <%- type %>Manager.layerFilter);
-  }
+        when(<%- type %>Layer.getFilter()).thenReturn(expression);
+        assertEquals(expression, <%- type %>Manager.getFilter());
+        assertEquals(expression, <%- type %>Manager.layerFilter);
+    }
 
-  @Test
-  public void testClickListener() {
-    On<%- camelize(type) %>ClickListener listener = mock(On<%- camelize(type) %>ClickListener.class);
-    <%- type  %>Manager = new  <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
-    assertTrue(<%- type  %>Manager.getClickListeners().isEmpty());
-    <%- type  %>Manager.addClickListener(listener);
-    assertTrue(<%- type  %>Manager.getClickListeners().contains(listener));
-    <%- type  %>Manager.removeClickListener(listener);
-    assertTrue( <%- type  %>Manager.getClickListeners().isEmpty());
-  }
+    @Test
+    public void testClickListener() {
+        On<%- camelize(type) %>ClickListener listener = mock(On<%- camelize(type) %>ClickListener.class);
+        <%- type  %>Manager = new  <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        assertTrue(<%- type  %>Manager.getClickListeners().isEmpty());
+        <%- type  %>Manager.addClickListener(listener);
+        assertTrue(<%- type  %>Manager.getClickListeners().contains(listener));
+        <%- type  %>Manager.removeClickListener(listener);
+        assertTrue( <%- type  %>Manager.getClickListeners().isEmpty());
+    }
 
-  @Test
-  public void testLongClickListener() {
-    On<%- camelize(type) %>LongClickListener listener = mock(On<%- camelize(type) %>LongClickListener.class);
-    <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
-    assertTrue(<%- type  %>Manager.getLongClickListeners().isEmpty());
-    <%- type  %>Manager.addLongClickListener(listener);
-    assertTrue(<%- type  %>Manager.getLongClickListeners().contains(listener));
-    <%- type  %>Manager.removeLongClickListener(listener);
-    assertTrue(<%- type  %>Manager.getLongClickListeners().isEmpty());
-  }
+    @Test
+    public void testLongClickListener() {
+        On<%- camelize(type) %>LongClickListener listener = mock(On<%- camelize(type) %>LongClickListener.class);
+        <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        assertTrue(<%- type  %>Manager.getLongClickListeners().isEmpty());
+        <%- type  %>Manager.addLongClickListener(listener);
+        assertTrue(<%- type  %>Manager.getLongClickListeners().contains(listener));
+        <%- type  %>Manager.removeLongClickListener(listener);
+        assertTrue(<%- type  %>Manager.getLongClickListeners().isEmpty());
+    }
 
-  @Test
-  public void testDragListener() {
-    On<%- camelize(type) %>DragListener listener = mock(On<%- camelize(type) %>DragListener.class);
-    <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
-    assertTrue(<%- type  %>Manager.getDragListeners().isEmpty());
-    <%- type  %>Manager.addDragListener(listener);
-    assertTrue(<%- type  %>Manager.getDragListeners().contains(listener));
-    <%- type  %>Manager.removeDragListener(listener);
-    assertTrue(<%- type  %>Manager.getDragListeners().isEmpty());
-  }
+    @Test
+    public void testDragListener() {
+        On<%- camelize(type) %>DragListener listener = mock(On<%- camelize(type) %>DragListener.class);
+        <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        assertTrue(<%- type  %>Manager.getDragListeners().isEmpty());
+        <%- type  %>Manager.addDragListener(listener);
+        assertTrue(<%- type  %>Manager.getDragListeners().contains(listener));
+        <%- type  %>Manager.removeDragListener(listener);
+        assertTrue(<%- type  %>Manager.getDragListeners().isEmpty());
+    }
 
-  @Test
-  public void testCustomData() {
-    <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    @Test
+    public void testCustomData() {
+        <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
 <% if (type === "circle" || type === "symbol") { -%>
-    <%- camelize(type) %>Options options = new <%- camelize(type) %>Options().withLatLng(new LatLng());
+        <%- camelize(type) %>Options options = new <%- camelize(type) %>Options().withLatLng(new LatLng());
 <% } else if (type === "line") { -%>
-    List<LatLng>latLngs = new ArrayList<>();
-    latLngs.add(new LatLng());
-    latLngs.add(new LatLng(1,1));
-    <%- camelize(type) %>Options options = new <%- camelize(type) %>Options().withLatLngs(latLngs);
+        List<LatLng>latLngs = new ArrayList<>();
+        latLngs.add(new LatLng());
+        latLngs.add(new LatLng(1,1));
+        <%- camelize(type) %>Options options = new <%- camelize(type) %>Options().withLatLngs(latLngs);
 <% } else { -%>
-    List<LatLng>innerLatLngs = new ArrayList<>();
-    innerLatLngs.add(new LatLng());
-    innerLatLngs.add(new LatLng(1,1));
-    innerLatLngs.add(new LatLng(-1,-1));
-    List<List<LatLng>>latLngs = new ArrayList<>();
-    latLngs.add(innerLatLngs);
-    <%- camelize(type) %>Options options = new <%- camelize(type) %>Options().withLatLngs(latLngs);
+        List<LatLng>innerLatLngs = new ArrayList<>();
+        innerLatLngs.add(new LatLng());
+        innerLatLngs.add(new LatLng(1,1));
+        innerLatLngs.add(new LatLng(-1,-1));
+        List<List<LatLng>>latLngs = new ArrayList<>();
+        latLngs.add(innerLatLngs);
+        <%- camelize(type) %>Options options = new <%- camelize(type) %>Options().withLatLngs(latLngs);
 <% } -%>
-    options.withData(new JsonPrimitive("hello"));
-    <%- camelize(type) %> <%- type  %> = <%- type  %>Manager.create(options);
-    assertEquals(new JsonPrimitive("hello"), <%- type  %>.getData());
-  }
+        options.withData(new JsonPrimitive("hello"));
+        <%- camelize(type) %> <%- type  %> = <%- type  %>Manager.create(options);
+        assertEquals(new JsonPrimitive("hello"), <%- type  %>.getData());
+    }
 
-  @Test
-  public void testClearAll() {
-    <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    @Test
+    public void testClearAll() {
+        <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
 <% if (type === "circle" || type === "symbol") { -%>
-    <%- camelize(type) %>Options options = new <%- camelize(type) %>Options().withLatLng(new LatLng());
+        <%- camelize(type) %>Options options = new <%- camelize(type) %>Options().withLatLng(new LatLng());
 <% } else if (type === "line") { -%>
-    List<LatLng>latLngs = new ArrayList<>();
-    latLngs.add(new LatLng());
-    latLngs.add(new LatLng(1,1));
-    <%- camelize(type) %>Options options = new <%- camelize(type) %>Options().withLatLngs(latLngs);
+        List<LatLng>latLngs = new ArrayList<>();
+        latLngs.add(new LatLng());
+        latLngs.add(new LatLng(1,1));
+        <%- camelize(type) %>Options options = new <%- camelize(type) %>Options().withLatLngs(latLngs);
 <% } else { -%>
-    List<LatLng>innerLatLngs = new ArrayList<>();
-    innerLatLngs.add(new LatLng());
-    innerLatLngs.add(new LatLng(1,1));
-    innerLatLngs.add(new LatLng(-1,-1));
-    List<List<LatLng>>latLngs = new ArrayList<>();
-    latLngs.add(innerLatLngs);
-    <%- camelize(type) %>Options options = new <%- camelize(type) %>Options().withLatLngs(latLngs);
+        List<LatLng>innerLatLngs = new ArrayList<>();
+        innerLatLngs.add(new LatLng());
+        innerLatLngs.add(new LatLng(1,1));
+        innerLatLngs.add(new LatLng(-1,-1));
+        List<List<LatLng>>latLngs = new ArrayList<>();
+        latLngs.add(innerLatLngs);
+        <%- camelize(type) %>Options options = new <%- camelize(type) %>Options().withLatLngs(latLngs);
 <% } -%>
-    <%- type  %>Manager.create(options);
-    assertEquals(1, <%- type  %>Manager.getAnnotations().size());
-    <%- type  %>Manager.deleteAll();
-    assertEquals(0, <%- type  %>Manager.getAnnotations().size());
-  }
+        <%- type  %>Manager.create(options);
+        assertEquals(1, <%- type  %>Manager.getAnnotations().size());
+        <%- type  %>Manager.deleteAll();
+        assertEquals(0, <%- type  %>Manager.getAnnotations().size());
+    }
 
-  @Test
-  public void testIgnoreClearedAnnotations() {
-    <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+    @Test
+    public void testIgnoreClearedAnnotations() {
+        <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
 <% if (type === "circle" || type === "symbol") { -%>
-    <%- camelize(type) %>Options options = new <%- camelize(type) %>Options().withLatLng(new LatLng());
+        <%- camelize(type) %>Options options = new <%- camelize(type) %>Options().withLatLng(new LatLng());
 <% } else if (type === "line") { -%>
-    List<LatLng>latLngs = new ArrayList<>();
-    latLngs.add(new LatLng());
-    latLngs.add(new LatLng(1,1));
-    <%- camelize(type) %>Options options = new <%- camelize(type) %>Options().withLatLngs(latLngs);
+        List<LatLng>latLngs = new ArrayList<>();
+        latLngs.add(new LatLng());
+        latLngs.add(new LatLng(1,1));
+        <%- camelize(type) %>Options options = new <%- camelize(type) %>Options().withLatLngs(latLngs);
 <% } else { -%>
-    List<LatLng>innerLatLngs = new ArrayList<>();
-    innerLatLngs.add(new LatLng());
-    innerLatLngs.add(new LatLng(1,1));
-    innerLatLngs.add(new LatLng(-1,-1));
-    List<List<LatLng>>latLngs = new ArrayList<>();
-    latLngs.add(innerLatLngs);
-    <%- camelize(type) %>Options options = new <%- camelize(type) %>Options().withLatLngs(latLngs);
+        List<LatLng>innerLatLngs = new ArrayList<>();
+        innerLatLngs.add(new LatLng());
+        innerLatLngs.add(new LatLng(1,1));
+        innerLatLngs.add(new LatLng(-1,-1));
+        List<List<LatLng>>latLngs = new ArrayList<>();
+        latLngs.add(innerLatLngs);
+        <%- camelize(type) %>Options options = new <%- camelize(type) %>Options().withLatLngs(latLngs);
 <% } -%>
-     <%- camelize(type) %>  <%- type %> = <%- type  %>Manager.create(options);
-    assertEquals(1, <%- type  %>Manager.annotations.size());
+         <%- camelize(type) %>  <%- type %> = <%- type  %>Manager.create(options);
+        assertEquals(1, <%- type  %>Manager.annotations.size());
 
-    <%- type  %>Manager.getAnnotations().clear();
-    <%- type  %>Manager.updateSource();
-    assertTrue(<%- type  %>Manager.getAnnotations().isEmpty());
+        <%- type  %>Manager.getAnnotations().clear();
+        <%- type  %>Manager.updateSource();
+        assertTrue(<%- type  %>Manager.getAnnotations().isEmpty());
 
-    <%- type  %>Manager.update(<%- type  %>);
-    assertTrue(<%- type  %>Manager.getAnnotations().isEmpty());
-  }
+        <%- type  %>Manager.update(<%- type  %>);
+        assertTrue(<%- type  %>Manager.getAnnotations().isEmpty());
+    }
 
 }

--- a/plugin-annotation/scripts/annotation_options.java.ejs
+++ b/plugin-annotation/scripts/annotation_options.java.ejs
@@ -30,303 +30,303 @@ import static com.mapbox.mapboxsdk.plugins.annotation.ConvertUtils.toStringArray
  */
 public class <%- camelize(type) %>Options extends Options<<%- camelize(type) %>> {
 
-  private boolean isDraggable;
-  private JsonElement data;
-  private <%- geometryType(type) %> geometry;
+    private boolean isDraggable;
+    private JsonElement data;
+    private <%- geometryType(type) %> geometry;
 <% for (const property of properties) { -%>
 <% if (supportsPropertyFunction(property)) { -%>
-  private <%- propertyType(property) %> <%- camelizeWithLeadingLowercase(property.name) %>;
+    private <%- propertyType(property) %> <%- camelizeWithLeadingLowercase(property.name) %>;
 <% } -%>
 <% } -%>
 
 <% for (const property of properties) { -%>
 <% if (supportsPropertyFunction(property)) { -%>
-  static final String PROPERTY_<%- snakeCaseUpper(property.name) %> = "<%- property.name %>";
+    static final String PROPERTY_<%- snakeCaseUpper(property.name) %> = "<%- property.name %>";
 <% } -%>
 <% } -%>
-  private static final String PROPERTY_IS_DRAGGABLE = "is-draggable";
+    private static final String PROPERTY_IS_DRAGGABLE = "is-draggable";
 <% for (const property of properties) { -%>
 <% if (supportsPropertyFunction(property)) { -%>
 
-  /**
-   * Set <%- property.name %> to initialise the <%- type %> with.
-   * <p>
-   * <%- propertyFactoryMethodDoc(property) %>
-   * </p>
-   * @param <%- camelizeWithLeadingLowercase(property.name) %> the <%- property.name %> value
-   * @return this
-   */
-  public <%- camelize(type) %>Options with<%- camelize(property.name) %>(<%- propertyTypeAnnotation(property) %><%- iff(() => propertyTypeAnnotation(property), " ") %><%- propertyType(property) %> <%- camelizeWithLeadingLowercase(property.name) %>) {
-    this.<%- camelizeWithLeadingLowercase(property.name) %> =  <%- camelizeWithLeadingLowercase(property.name) %>;
-    return this;
-  }
+    /**
+     * Set <%- property.name %> to initialise the <%- type %> with.
+     * <p>
+     * <%- propertyFactoryMethodDoc(property) %>
+     * </p>
+     * @param <%- camelizeWithLeadingLowercase(property.name) %> the <%- property.name %> value
+     * @return this
+     */
+    public <%- camelize(type) %>Options with<%- camelize(property.name) %>(<%- propertyTypeAnnotation(property) %><%- iff(() => propertyTypeAnnotation(property), " ") %><%- propertyType(property) %> <%- camelizeWithLeadingLowercase(property.name) %>) {
+        this.<%- camelizeWithLeadingLowercase(property.name) %> =  <%- camelizeWithLeadingLowercase(property.name) %>;
+        return this;
+    }
 
-  /**
-   * Get the current configured  <%- property.name %> for the <%- type %>
-   * <p>
-   * <%- propertyFactoryMethodDoc(property) %>
-   * </p>
-   * @return <%- camelizeWithLeadingLowercase(property.name) %> value
-   */
-  public <%- propertyType(property) %> get<%- camelize(property.name) %>() {
-    return <%- camelizeWithLeadingLowercase(property.name) %>;
-  }
+    /**
+     * Get the current configured  <%- property.name %> for the <%- type %>
+     * <p>
+     * <%- propertyFactoryMethodDoc(property) %>
+     * </p>
+     * @return <%- camelizeWithLeadingLowercase(property.name) %> value
+     */
+    public <%- propertyType(property) %> get<%- camelize(property.name) %>() {
+        return <%- camelizeWithLeadingLowercase(property.name) %>;
+    }
 <% } -%>
 <% } -%>
 <% if (type === "circle" || type === "symbol") { -%>
 
-  /**
-   * Set the LatLng of the <%- type %>, which represents the location of the <%- type %> on the map
-   *
-   * @param latLng the location of the <%- type %> in a longitude and latitude pair
-   * @return this
-   */
-  public <%- camelize(type) %>Options withLatLng(LatLng latLng) {
-    geometry = Point.fromLngLat(latLng.getLongitude(), latLng.getLatitude());
-    return this;
-  }
-
-  /**
-   * Get the LatLng of the <%- type %>, which represents the location of the <%- type %> on the map
-   *
-   * @return the location of the <%- type %> in a longitude and latitude pair
-   */
-  public LatLng getLatLng() {
-    if (geometry == null) {
-      return null;
+    /**
+     * Set the LatLng of the <%- type %>, which represents the location of the <%- type %> on the map
+     *
+     * @param latLng the location of the <%- type %> in a longitude and latitude pair
+     * @return this
+     */
+    public <%- camelize(type) %>Options withLatLng(LatLng latLng) {
+        geometry = Point.fromLngLat(latLng.getLongitude(), latLng.getLatitude());
+        return this;
     }
-    return new LatLng(geometry.latitude(), geometry.longitude());
-  }
 
-  /**
-   * Set the geometry of the <%- type %>, which represents the location of the <%- type %> on the map
-   *
-   * @param geometry the location of the <%- type %>
-   * @return this
-   */
-  public <%- camelize(type) %>Options withGeometry(<%- geometryType(type) %> geometry) {
-    this.geometry = geometry;
-    return this;
-  }
-
-  /**
-   * Get the geometry of the <%- type %>, which represents the location of the <%- type %> on the map
-   *
-   * @return the location of the <%- type %>
-   */
-  public Point getGeometry() {
-    return geometry;
-  }
-<% } else if (type === "line") { -%>
-
-  /**
-   * Set a list of LatLng for the line, which represents the locations of the line on the map
-   *
-   * @param latLngs a list of the locations of the line in a longitude and latitude pairs
-   * @return this
-   */
-  public <%- camelize(type) %>Options withLatLngs(List<LatLng> latLngs) {
-    List<Point>points = new ArrayList<>();
-    for (LatLng latLng : latLngs) {
-      points.add(Point.fromLngLat(latLng.getLongitude(), latLng.getLatitude()));
-    }
-    geometry = LineString.fromLngLats(points);
-    return this;
-  }
-
-  /**
-   * Get a list of LatLng for the line, which represents the locations of the line on the map
-   *
-   * @return a list of the locations of the line in a longitude and latitude pairs
-   */
-  public List<LatLng> getLatLngs() {
-    List<LatLng>latLngs = new ArrayList<>();
-    if (geometry!=null) {
-      for (Point coordinate : geometry.coordinates()) {
-        latLngs.add(new LatLng(coordinate.latitude(), coordinate.longitude()));
-      }
-    }
-    return latLngs;
-  }
-
-  /**
-   * Set the geometry of the <%- type %>, which represents the location of the <%- type %> on the map
-   *
-   * @param geometry the location of the <%- type %>
-   * @return this
-   */
-  public <%- camelize(type) %>Options withGeometry(LineString geometry) {
-    this.geometry = geometry;
-    return this;
-  }
-
-  /**
-   * Get the geometry of the <%- type %>, which represents the location of the <%- type %> on the map
-   *
-   * @return the location of the <%- type %>
-   */
-  public LineString getGeometry() {
-    return geometry;
-  }
-<% } else { -%>
-
-  /**
-   * Set a list of lists of LatLng for the fill, which represents the locations of the fill on the map
-   *
-   * @param latLngs a list of a lists of the locations of the line in a longitude and latitude pairs
-   * @return this
-   */
-  public <%- camelize(type) %>Options withLatLngs(List<List<LatLng>> latLngs) {
-    List<List<Point>> points = new ArrayList<>();
-    for (List<LatLng> innerLatLngs : latLngs) {
-      List<Point>innerList = new ArrayList<>();
-      for (LatLng latLng : innerLatLngs) {
-        innerList.add(Point.fromLngLat(latLng.getLongitude(), latLng.getLatitude()));
-      }
-      points.add(innerList);
-    }
-    geometry = Polygon.fromLngLats(points);
-    return this;
-  }
-
-  /**
-   * Get a list of lists of LatLng for the fill, which represents the locations of the fill on the map
-   *
-   * @return a list of a lists of the locations of the line in a longitude and latitude pairs
-   */
-  public List<List<LatLng>> getLatLngs() {
-    List<List<LatLng>> points = new ArrayList<>();
-    if (geometry != null) {
-      for (List<Point> coordinates : geometry.coordinates()) {
-        List<LatLng> innerList = new ArrayList<>();
-        for (Point point : coordinates) {
-          innerList.add(new LatLng(point.latitude(), point.longitude()));
+    /**
+     * Get the LatLng of the <%- type %>, which represents the location of the <%- type %> on the map
+     *
+     * @return the location of the <%- type %> in a longitude and latitude pair
+     */
+    public LatLng getLatLng() {
+        if (geometry == null) {
+            return null;
         }
-        points.add(innerList);
-      }
+        return new LatLng(geometry.latitude(), geometry.longitude());
     }
-    return points;
-  }
 
-  /**
-   * Set the geometry of the <%- type %>, which represents the location of the <%- type %> on the map
-   *
-   * @param geometry the location of the <%- type %>
-   * @return this
-   */
-  public <%- camelize(type) %>Options withGeometry(Polygon geometry) {
-    this.geometry = geometry;
-    return this;
-  }
-
-  /**
-   * Get the geometry of the <%- type %>, which represents the location of the <%- type %> on the map
-   *
-   * @return the location of the <%- type %>
-   */
-  public Polygon getGeometry() {
-    return geometry;
-  }
-<% } -%>
-
-  /**
-   * Returns whether this <%- type %> is draggable, meaning it can be dragged across the screen when touched and moved.
-   *
-   * @return draggable when touched
-   */
-  public boolean getDraggable() {
-    return isDraggable;
-  }
-
-  /**
-   * Set whether this <%- type %> should be draggable,
-   * meaning it can be dragged across the screen when touched and moved.
-   *
-   * @param draggable should be draggable
-   */
-  public <%- camelize(type) %>Options withDraggable(boolean draggable) {
-    isDraggable = draggable;
-    return this;
-  }
-
-  /**
-   * Set the arbitrary json data of the annotation.
-   *
-   * @param jsonElement the arbitrary json element data
-   */
-  public <%- camelize(type) %>Options withData(@Nullable JsonElement jsonElement) {
-    this.data = jsonElement;
-    return this;
-  }
-
-  /**
-   * Get the arbitrary json data of the annotation.
-   *
-   * @return the arbitrary json object data if set, else null
-   */
-  @Nullable
-  public JsonElement getData() {
-    return data;
-  }
-
-  @Override
-  <%- camelize(type) %> build(long id, AnnotationManager<?, <%- camelize(type) %>, ?, ?, ?, ?> annotationManager) {
-    if (geometry == null) {
-      throw new RuntimeException("geometry field is required");
+    /**
+     * Set the geometry of the <%- type %>, which represents the location of the <%- type %> on the map
+     *
+     * @param geometry the location of the <%- type %>
+     * @return this
+     */
+    public <%- camelize(type) %>Options withGeometry(<%- geometryType(type) %> geometry) {
+        this.geometry = geometry;
+        return this;
     }
-    JsonObject jsonObject = new JsonObject();
-<% for (const property of properties) { -%>
-<% if (supportsPropertyFunction(property)) { -%>
-<% if (propertyType(property).endsWith("[]")) { -%>
-    jsonObject.add(PROPERTY_<%- snakeCaseUpper(property.name) %>, convertArray(<%- camelizeWithLeadingLowercase(property.name) %>));
-<% } else { -%>
-    jsonObject.addProperty(PROPERTY_<%- snakeCaseUpper(property.name) %>, <%- camelizeWithLeadingLowercase(property.name) %>);
-<% } -%>
-<% } -%>
-<% } -%>
-    <%- camelize(type) %> <%- type %> = new <%- camelize(type) %>(id, annotationManager, jsonObject, geometry);
-    <%- type %>.setDraggable(isDraggable);
-    <%- type %>.setData(data);
-    return <%- type %>;
-  }
 
-  /**
-   * Creates <%- camelize(type) %>Options out of a Feature.
-   *
-   * @param feature feature to be converted
-   */
-  @Nullable
-  static <%- camelize(type) %>Options fromFeature(@NonNull Feature feature) {
-    if (feature.geometry() == null) {
-      throw new RuntimeException("geometry field is required");
+    /**
+     * Get the geometry of the <%- type %>, which represents the location of the <%- type %> on the map
+     *
+     * @return the location of the <%- type %>
+     */
+    public Point getGeometry() {
+        return geometry;
     }
-<% if (type === "circle" || type === "symbol") { -%>
-    if (!(feature.geometry() instanceof Point)) {
 <% } else if (type === "line") { -%>
-    if (!(feature.geometry() instanceof LineString)) {
-<% } else { -%>
-    if (!(feature.geometry() instanceof Polygon)) {<% } -%>
-      return null;
+
+    /**
+     * Set a list of LatLng for the line, which represents the locations of the line on the map
+     *
+     * @param latLngs a list of the locations of the line in a longitude and latitude pairs
+     * @return this
+     */
+    public <%- camelize(type) %>Options withLatLngs(List<LatLng> latLngs) {
+        List<Point>points = new ArrayList<>();
+        for (LatLng latLng : latLngs) {
+            points.add(Point.fromLngLat(latLng.getLongitude(), latLng.getLatitude()));
+        }
+        geometry = LineString.fromLngLats(points);
+        return this;
     }
 
-    <%- camelize(type) %>Options options = new <%- camelize(type) %>Options();
-    options.geometry = (<%- geometryType(type) %>) feature.geometry();
+    /**
+     * Get a list of LatLng for the line, which represents the locations of the line on the map
+     *
+     * @return a list of the locations of the line in a longitude and latitude pairs
+     */
+    public List<LatLng> getLatLngs() {
+        List<LatLng>latLngs = new ArrayList<>();
+        if (geometry!=null) {
+            for (Point coordinate : geometry.coordinates()) {
+                latLngs.add(new LatLng(coordinate.latitude(), coordinate.longitude()));
+            }
+        }
+        return latLngs;
+    }
+
+    /**
+     * Set the geometry of the <%- type %>, which represents the location of the <%- type %> on the map
+     *
+     * @param geometry the location of the <%- type %>
+     * @return this
+     */
+    public <%- camelize(type) %>Options withGeometry(LineString geometry) {
+        this.geometry = geometry;
+        return this;
+    }
+
+    /**
+     * Get the geometry of the <%- type %>, which represents the location of the <%- type %> on the map
+     *
+     * @return the location of the <%- type %>
+     */
+    public LineString getGeometry() {
+        return geometry;
+    }
+<% } else { -%>
+
+    /**
+     * Set a list of lists of LatLng for the fill, which represents the locations of the fill on the map
+     *
+     * @param latLngs a list of a lists of the locations of the line in a longitude and latitude pairs
+     * @return this
+     */
+    public <%- camelize(type) %>Options withLatLngs(List<List<LatLng>> latLngs) {
+        List<List<Point>> points = new ArrayList<>();
+        for (List<LatLng> innerLatLngs : latLngs) {
+            List<Point>innerList = new ArrayList<>();
+            for (LatLng latLng : innerLatLngs) {
+                innerList.add(Point.fromLngLat(latLng.getLongitude(), latLng.getLatitude()));
+            }
+            points.add(innerList);
+        }
+        geometry = Polygon.fromLngLats(points);
+        return this;
+    }
+
+    /**
+     * Get a list of lists of LatLng for the fill, which represents the locations of the fill on the map
+     *
+     * @return a list of a lists of the locations of the line in a longitude and latitude pairs
+     */
+    public List<List<LatLng>> getLatLngs() {
+        List<List<LatLng>> points = new ArrayList<>();
+        if (geometry != null) {
+            for (List<Point> coordinates : geometry.coordinates()) {
+                List<LatLng> innerList = new ArrayList<>();
+                for (Point point : coordinates) {
+                    innerList.add(new LatLng(point.latitude(), point.longitude()));
+                }
+                points.add(innerList);
+            }
+        }
+        return points;
+    }
+
+    /**
+     * Set the geometry of the <%- type %>, which represents the location of the <%- type %> on the map
+     *
+     * @param geometry the location of the <%- type %>
+     * @return this
+     */
+    public <%- camelize(type) %>Options withGeometry(Polygon geometry) {
+        this.geometry = geometry;
+        return this;
+    }
+
+    /**
+     * Get the geometry of the <%- type %>, which represents the location of the <%- type %> on the map
+     *
+     * @return the location of the <%- type %>
+     */
+    public Polygon getGeometry() {
+        return geometry;
+    }
+<% } -%>
+
+    /**
+     * Returns whether this <%- type %> is draggable, meaning it can be dragged across the screen when touched and moved.
+     *
+     * @return draggable when touched
+     */
+    public boolean getDraggable() {
+        return isDraggable;
+    }
+
+    /**
+     * Set whether this <%- type %> should be draggable,
+     * meaning it can be dragged across the screen when touched and moved.
+     *
+     * @param draggable should be draggable
+     */
+    public <%- camelize(type) %>Options withDraggable(boolean draggable) {
+        isDraggable = draggable;
+        return this;
+    }
+
+    /**
+     * Set the arbitrary json data of the annotation.
+     *
+     * @param jsonElement the arbitrary json element data
+     */
+    public <%- camelize(type) %>Options withData(@Nullable JsonElement jsonElement) {
+        this.data = jsonElement;
+        return this;
+    }
+
+    /**
+     * Get the arbitrary json data of the annotation.
+     *
+     * @return the arbitrary json object data if set, else null
+     */
+    @Nullable
+    public JsonElement getData() {
+        return data;
+    }
+
+    @Override
+    <%- camelize(type) %> build(long id, AnnotationManager<?, <%- camelize(type) %>, ?, ?, ?, ?> annotationManager) {
+        if (geometry == null) {
+            throw new RuntimeException("geometry field is required");
+        }
+        JsonObject jsonObject = new JsonObject();
 <% for (const property of properties) { -%>
 <% if (supportsPropertyFunction(property)) { -%>
 <% if (propertyType(property).endsWith("[]")) { -%>
-    if (feature.hasProperty(PROPERTY_<%- snakeCaseUpper(property.name) %>)) {
-      options.<%- camelizeWithLeadingLowercase(property.name) %> = to<%- propertyType(property).slice(0, -2) -%>Array(feature.getProperty(PROPERTY_<%- snakeCaseUpper(property.name) %>).getAsJsonArray());
-    }
+        jsonObject.add(PROPERTY_<%- snakeCaseUpper(property.name) %>, convertArray(<%- camelizeWithLeadingLowercase(property.name) %>));
 <% } else { -%>
-    if (feature.hasProperty(PROPERTY_<%- snakeCaseUpper(property.name) %>)) {
-      options.<%- camelizeWithLeadingLowercase(property.name) %> = feature.getProperty(PROPERTY_<%- snakeCaseUpper(property.name) %>).getAs<%- propertyType(property) %>();
+        jsonObject.addProperty(PROPERTY_<%- snakeCaseUpper(property.name) %>, <%- camelizeWithLeadingLowercase(property.name) %>);
+<% } -%>
+<% } -%>
+<% } -%>
+        <%- camelize(type) %> <%- type %> = new <%- camelize(type) %>(id, annotationManager, jsonObject, geometry);
+        <%- type %>.setDraggable(isDraggable);
+        <%- type %>.setData(data);
+        return <%- type %>;
     }
+
+    /**
+     * Creates <%- camelize(type) %>Options out of a Feature.
+     *
+     * @param feature feature to be converted
+     */
+    @Nullable
+    static <%- camelize(type) %>Options fromFeature(@NonNull Feature feature) {
+        if (feature.geometry() == null) {
+            throw new RuntimeException("geometry field is required");
+        }
+<% if (type === "circle" || type === "symbol") { -%>
+        if (!(feature.geometry() instanceof Point)) {
+<% } else if (type === "line") { -%>
+        if (!(feature.geometry() instanceof LineString)) {
+<% } else { -%>
+        if (!(feature.geometry() instanceof Polygon)) {<% } -%>
+            return null;
+        }
+
+        <%- camelize(type) %>Options options = new <%- camelize(type) %>Options();
+        options.geometry = (<%- geometryType(type) %>) feature.geometry();
+<% for (const property of properties) { -%>
+<% if (supportsPropertyFunction(property)) { -%>
+<% if (propertyType(property).endsWith("[]")) { -%>
+        if (feature.hasProperty(PROPERTY_<%- snakeCaseUpper(property.name) %>)) {
+            options.<%- camelizeWithLeadingLowercase(property.name) %> = to<%- propertyType(property).slice(0, -2) -%>Array(feature.getProperty(PROPERTY_<%- snakeCaseUpper(property.name) %>).getAsJsonArray());
+        }
+<% } else { -%>
+        if (feature.hasProperty(PROPERTY_<%- snakeCaseUpper(property.name) %>)) {
+            options.<%- camelizeWithLeadingLowercase(property.name) %> = feature.getProperty(PROPERTY_<%- snakeCaseUpper(property.name) %>).getAs<%- propertyType(property) %>();
+        }
 <% } -%>
 <% } -%>
 <% } -%>
-    if (feature.hasProperty(PROPERTY_IS_DRAGGABLE)) {
-      options.isDraggable = feature.getProperty(PROPERTY_IS_DRAGGABLE).getAsBoolean();
+        if (feature.hasProperty(PROPERTY_IS_DRAGGABLE)) {
+            options.isDraggable = feature.getProperty(PROPERTY_IS_DRAGGABLE).getAsBoolean();
+        }
+        return options;
     }
-    return options;
-  }
 }


### PR DESCRIPTION
Re. https://github.com/maplibre/maplibre-plugins-android/pull/31#issuecomment-1594461801, the code generation files currently contain a large diff to the actual files mostly due to indentation changes.

This PR sets generation files to 4-space indentation so we can better see the actual diff. Future work: align generation files and actual files further.