### PR TITLE
Align code generation and actual code

### DIFF
--- a/plugin-annotation/scripts/annotation.java.ejs
+++ b/plugin-annotation/scripts/annotation.java.ejs
@@ -10,8 +10,10 @@ package com.mapbox.mapboxsdk.plugins.annotation;
 import androidx.annotation.ColorInt;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import android.graphics.PointF;
 import androidx.annotation.UiThread;
+
+import android.graphics.PointF;
+
 import com.google.gson.JsonArray;
 import com.google.gson.JsonNull;
 import com.google.gson.JsonObject;
@@ -90,7 +92,7 @@ public class <%- camelize(type) %> extends Annotation<<%- geometryType(type) %>>
      * @param latLngs a list of the locations of the line in a longitude and latitude pairs
      */
     public void setLatLngs(List<LatLng> latLngs) {
-        List<Point>points = new ArrayList<>();
+        List<Point> points = new ArrayList<>();
         for (LatLng latLng : latLngs) {
             points.add(Point.fromLngLat(latLng.getLongitude(), latLng.getLatitude()));
         }
@@ -106,7 +108,7 @@ public class <%- camelize(type) %> extends Annotation<<%- geometryType(type) %>>
     public List<LatLng> getLatLngs() {
         LineString lineString = (LineString) geometry;
         List<LatLng> latLngs = new ArrayList<>();
-        for (Point point: lineString.coordinates()) {
+        for (Point point : lineString.coordinates()) {
             latLngs.add(new LatLng(point.latitude(), point.longitude()));
         }
         return latLngs;
@@ -124,7 +126,7 @@ public class <%- camelize(type) %> extends Annotation<<%- geometryType(type) %>>
     public void setLatLngs(List<List<LatLng>> latLngs) {
         List<List<Point>> points = new ArrayList<>();
         for (List<LatLng> innerLatLngs : latLngs) {
-            List<Point>innerList = new ArrayList<>();
+            List<Point> innerList = new ArrayList<>();
             for (LatLng latLng : innerLatLngs) {
                 innerList.add(Point.fromLngLat(latLng.getLongitude(), latLng.getLatitude()));
             }
@@ -340,7 +342,7 @@ public class <%- camelize(type) %> extends Annotation<<%- geometryType(type) %>>
     @Override
     @Nullable
     Geometry getOffsetGeometry(@NonNull Projection projection, @NonNull MoveDistancesObject moveDistancesObject,
-                                                         float touchAreaShiftX, float touchAreaShiftY) {
+                               float touchAreaShiftX, float touchAreaShiftY) {
         List<Point> originalPoints = geometry.coordinates();
         List<Point> resultingPoints = new ArrayList<>(originalPoints.size());
         for (Point jsonPoint : originalPoints) {
@@ -362,7 +364,7 @@ public class <%- camelize(type) %> extends Annotation<<%- geometryType(type) %>>
     @Override
     @Nullable
     Geometry getOffsetGeometry(@NonNull Projection projection, @NonNull MoveDistancesObject moveDistancesObject,
-                                                         float touchAreaShiftX, float touchAreaShiftY) {
+                               float touchAreaShiftX, float touchAreaShiftY) {
         List<List<Point>> originalPoints = geometry.coordinates();
         if (originalPoints != null) {
             List<List<Point>> resultingPoints = new ArrayList<>(originalPoints.size());
@@ -398,7 +400,7 @@ public class <%- camelize(type) %> extends Annotation<<%- geometryType(type) %>>
 <% } else if (type === "fill")    { -%>
         return "Fill";
 <% } else if (type === "line")    { -%>
-         return "Line";
+        return "Line";
 <% } else { -%>
         return "Annotation";
 <% } -%>

--- a/plugin-annotation/scripts/annotation_click_listener.java.ejs
+++ b/plugin-annotation/scripts/annotation_click_listener.java.ejs
@@ -10,6 +10,6 @@ package com.mapbox.mapboxsdk.plugins.annotation;
 /**
  * Interface definition for a callback to be invoked when a <%- type %> has been clicked.
  */
-public interface On<%- camelize(type) %>ClickListener extends OnAnnotationClickListener<<%- camelize(type) %>>{
+public interface On<%- camelize(type) %>ClickListener extends OnAnnotationClickListener<<%- camelize(type) %>> {
 
 }

--- a/plugin-annotation/scripts/annotation_drag_listener.java.ejs
+++ b/plugin-annotation/scripts/annotation_drag_listener.java.ejs
@@ -10,6 +10,6 @@ package com.mapbox.mapboxsdk.plugins.annotation;
 /**
  * Interface definition for a callback to be invoked when a <%- type %> is dragged.
  */
-public interface On<%- camelize(type) %>DragListener extends OnAnnotationDragListener<<%- camelize(type) %>>{
+public interface On<%- camelize(type) %>DragListener extends OnAnnotationDragListener<<%- camelize(type) %>> {
 
 }

--- a/plugin-annotation/scripts/annotation_element_provider.java.ejs
+++ b/plugin-annotation/scripts/annotation_element_provider.java.ejs
@@ -8,6 +8,7 @@
 package com.mapbox.mapboxsdk.plugins.annotation;
 
 import androidx.annotation.Nullable;
+
 import com.mapbox.mapboxsdk.style.layers.<%- camelize(type) %>Layer;
 import com.mapbox.mapboxsdk.style.sources.GeoJsonOptions;
 import com.mapbox.mapboxsdk.style.sources.GeoJsonSource;
@@ -17,7 +18,7 @@ import java.util.concurrent.atomic.AtomicLong;
 /**
  * Concrete instance of a core element provider for <%- camelize(type) %>.
  */
-class <%- camelize(type) %>ElementProvider implements CoreElementProvider<<%- camelize(type) %>Layer>{
+class <%- camelize(type) %>ElementProvider implements CoreElementProvider<<%- camelize(type) %>Layer> {
 
     private static final AtomicLong ID_GENERATOR = new AtomicLong(0);
     private static final String ID_GEOJSON_LAYER = "mapbox-android-<%- type %>-layer-%s";

--- a/plugin-annotation/scripts/annotation_instrumentation_test.junit.ejs
+++ b/plugin-annotation/scripts/annotation_instrumentation_test.junit.ejs
@@ -7,12 +7,14 @@
 package com.mapbox.mapboxsdk.plugins.annotation;
 
 import android.graphics.PointF;
+
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.plugins.BaseActivityTest;
 import com.mapbox.mapboxsdk.plugins.testapp.activity.TestActivity;
 import com.mapbox.mapboxsdk.utils.ColorUtils;
+
 import timber.log.Timber;
 
 import org.junit.Test;
@@ -47,16 +49,16 @@ public class <%- camelize(type) %>Test extends BaseActivityTest {
 <% if (type === "circle" || type === "symbol") { -%>
             <%- type %> = <%- type %>Manager.create(new <%- camelize(type) %>Options().withLatLng(new LatLng()));
 <% } else if (type === "line") { -%>
-            List<LatLng>latLngs = new ArrayList<>();
+            List<LatLng> latLngs = new ArrayList<>();
             latLngs.add(new LatLng());
-            latLngs.add(new LatLng(1,1));
+            latLngs.add(new LatLng(1, 1));
             <%- type %> = <%- type %>Manager.create(new <%- camelize(type) %>Options().withLatLngs(latLngs));
 <% } else { -%>
-            List<LatLng>innerLatLngs = new ArrayList<>();
+            List<LatLng> innerLatLngs = new ArrayList<>();
             innerLatLngs.add(new LatLng());
-            innerLatLngs.add(new LatLng(1,1));
-            innerLatLngs.add(new LatLng(-1,-1));
-            List<List<LatLng>>latLngs = new ArrayList<>();
+            innerLatLngs.add(new LatLng(1, 1));
+            innerLatLngs.add(new LatLng(-1, -1));
+            List<List<LatLng>> latLngs = new ArrayList<>();
             latLngs.add(innerLatLngs);
             <%- type %> = <%- type %>Manager.create(new <%- camelize(type) %>Options().withLatLngs(latLngs));
 <% } -%>

--- a/plugin-annotation/scripts/annotation_manager.java.ejs
+++ b/plugin-annotation/scripts/annotation_manager.java.ejs
@@ -45,7 +45,7 @@ public class <%- camelize(type) %>Manager extends AnnotationManager<<%- camelize
      * Create a <%- type %> manager, used to manage <%- type %>s.
      *
      * @param mapboxMap the map object to add <%- type %>s to
-     * @param style a valid a fully loaded style object
+     * @param style     a valid a fully loaded style object
      */
     @UiThread
     public <%- camelize(type) %>Manager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style) {
@@ -55,8 +55,8 @@ public class <%- camelize(type) %>Manager extends AnnotationManager<<%- camelize
     /**
      * Create a <%- type %> manager, used to manage <%- type %>s.
      *
-     * @param mapboxMap the map object to add <%- type %>s to
-     * @param style a valid a fully loaded style object
+     * @param mapboxMap    the map object to add <%- type %>s to
+     * @param style        a valid a fully loaded style object
      * @param belowLayerId the id of the layer above the circle layer
      */
     @UiThread
@@ -67,9 +67,9 @@ public class <%- camelize(type) %>Manager extends AnnotationManager<<%- camelize
     /**
      * Create a <%- type %> manager, used to manage <%- type %>s.
      *
-     * @param mapboxMap the map object to add <%- type %>s to
-     * @param style a valid a fully loaded style object
-     * @param belowLayerId the id of the layer above the circle layer
+     * @param mapboxMap      the map object to add <%- type %>s to
+     * @param style          a valid a fully loaded style object
+     * @param belowLayerId   the id of the layer above the circle layer
      * @param geoJsonOptions options for the internal source
      */
     @UiThread
@@ -81,9 +81,9 @@ public class <%- camelize(type) %>Manager extends AnnotationManager<<%- camelize
     /**
      * Create a <%- type %> manager, used to manage <%- type %>s.
      *
-     * @param mapboxMap the map object to add <%- type %>s to
-     * @param style a valid a fully loaded style object
-     * @param belowLayerId the id of the layer above the circle layer
+     * @param mapboxMap      the map object to add <%- type %>s to
+     * @param style          a valid a fully loaded style object
+     * @param belowLayerId   the id of the layer above the circle layer
      * @param clusterOptions options for the clustering configuration
      */
     @UiThread
@@ -189,6 +189,7 @@ public class <%- camelize(type) %>Manager extends AnnotationManager<<%- camelize
     }
 
     // Property accessors
+
 <% for (const property of properties) { -%>
 <% if (!supportsPropertyFunction(property) && property.name !== "line-gradient" && property.name !== "symbol-z-order") { -%>
     /**
@@ -211,7 +212,7 @@ public class <%- camelize(type) %>Manager extends AnnotationManager<<%- camelize
      *
      * @param value property wrapper value around <%- propertyType(property) %>
      */
-    public void set<%- camelize(property.name) %>(<%- propertyTypeAnnotation(property) %><%- iff(() => propertyTypeAnnotation(property), "") %> <%- propertyType(property) %> value) {
+    public void set<%- camelize(property.name) %>(<%- propertyTypeAnnotation(property) %><%- iff(() => propertyTypeAnnotation(property), " ") %><%- propertyType(property) %> value) {
         PropertyValue propertyValue = <%- camelizeWithLeadingLowercase(property.name) %>(value);
         constantPropertyUsageMap.put(PROPERTY_<%- snakeCaseUpper(property.name) %>, propertyValue);
         layer.setProperties(propertyValue);
@@ -224,7 +225,7 @@ public class <%- camelize(type) %>Manager extends AnnotationManager<<%- camelize
      *
      * @param expression expression
      */
-     @Override
+    @Override
     public void setFilter(@NonNull Expression expression) {
         layerFilter = expression;
         layer.setFilter(layerFilter);

--- a/plugin-annotation/scripts/annotation_manager_instrumentation_test.junit.ejs
+++ b/plugin-annotation/scripts/annotation_manager_instrumentation_test.junit.ejs
@@ -11,6 +11,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.plugins.testapp.activity.TestActivity;
 import com.mapbox.mapboxsdk.plugins.BaseActivityTest;
+
 import timber.log.Timber;
 
 import org.junit.Test;

--- a/plugin-annotation/scripts/annotation_manager_unit_test.junit.ejs
+++ b/plugin-annotation/scripts/annotation_manager_unit_test.junit.ejs
@@ -7,6 +7,8 @@
 
 package com.mapbox.mapboxsdk.plugins.annotation;
 
+import android.graphics.PointF;
+
 import com.google.gson.JsonPrimitive;
 import com.mapbox.geojson.*;
 import com.mapbox.mapboxsdk.geometry.LatLng;
@@ -18,6 +20,7 @@ import com.mapbox.mapboxsdk.style.layers.*;
 import com.mapbox.mapboxsdk.style.sources.GeoJsonOptions;
 import com.mapbox.mapboxsdk.style.sources.GeoJsonSource;
 import com.mapbox.mapboxsdk.utils.ColorUtils;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -25,7 +28,6 @@ import org.mockito.ArgumentCaptor;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Arrays;
-import android.graphics.PointF;
 
 import static com.mapbox.mapboxsdk.plugins.annotation.ConvertUtils.convertArray;
 import static com.mapbox.mapboxsdk.style.expressions.Expression.get;
@@ -167,17 +169,17 @@ public class <%- camelize(type) %>ManagerTest {
 <% if (type === "circle" || type === "symbol") { -%>
         <%- camelize(type) %> <%- type %> = <%- type %>Manager.create(new <%- camelize(type) %>Options().withLatLng(new LatLng()));
 <% } else if (type === "line") { -%>
-        List<LatLng>latLngs = new ArrayList<>();
+        List<LatLng> latLngs = new ArrayList<>();
         latLngs.add(new LatLng());
-        latLngs.add(new LatLng(1,1));
+        latLngs.add(new LatLng(1, 1));
         <%- camelize(type) %> <%- type %> = <%- type %>Manager.create(new <%- camelize(type) %>Options().withLatLngs(latLngs));
 <% } else { -%>
-        List<LatLng>innerLatLngs = new ArrayList<>();
+        List<LatLng> innerLatLngs = new ArrayList<>();
         innerLatLngs.add(new LatLng());
-        innerLatLngs.add(new LatLng(1,1));
-        innerLatLngs.add(new LatLng(-1,-1));
+        innerLatLngs.add(new LatLng(1, 1));
+        innerLatLngs.add(new LatLng(-1, -1));
         innerLatLngs.add(new LatLng());
-        List<List<LatLng>>latLngs = new ArrayList<>();
+        List<List<LatLng>> latLngs = new ArrayList<>();
         latLngs.add(innerLatLngs);
         <%- camelize(type) %> <%- type %> = <%- type %>Manager.create(new <%- camelize(type) %>Options().withLatLngs(latLngs));
 <% } -%>
@@ -250,9 +252,9 @@ public class <%- camelize(type) %>ManagerTest {
         List<LatLng> latLngList = new ArrayList<>();
         latLngList.add(new LatLng());
         latLngList.add(new LatLng(1, 1));
-        List< <%- camelize(type) %>Options> options = new ArrayList<>();
+        List<<%- camelize(type) %>Options> options = new ArrayList<>();
         for (LatLng latLng : latLngList) {
-            options.add(new  <%- camelize(type) %>Options().withLatLng(latLng));
+            options.add(new <%- camelize(type) %>Options().withLatLng(latLng));
         }
 <% } else if (type === "line") { -%>
         List<List<LatLng>> latLngList = new ArrayList<>();
@@ -289,7 +291,7 @@ public class <%- camelize(type) %>ManagerTest {
             add(new LatLng(3, 9));
         }});
 
-        List<List<List<LatLng>>> latLngList = new ArrayList<List<List<LatLng>>>(){{
+        List<List<List<LatLng>>> latLngList = new ArrayList<List<List<LatLng>>>() {{
             add(latLngListOne);
             add(latLngListTwo);
         }};
@@ -309,16 +311,16 @@ public class <%- camelize(type) %>ManagerTest {
 <% if (type === "circle" || type === "symbol") { -%>
         <%- camelize(type) %> <%- type %> = <%- type %>Manager.create(new <%- camelize(type) %>Options().withLatLng(new LatLng()));
 <% } else if (type === "line") { -%>
-        List<LatLng>latLngs = new ArrayList<>();
+        List<LatLng> latLngs = new ArrayList<>();
         latLngs.add(new LatLng());
-        latLngs.add(new LatLng(1,1));
+        latLngs.add(new LatLng(1, 1));
         <%- camelize(type) %> <%- type %> = <%- type %>Manager.create(new <%- camelize(type) %>Options().withLatLngs(latLngs));
 <% } else { -%>
-        List<LatLng>innerLatLngs = new ArrayList<>();
+        List<LatLng> innerLatLngs = new ArrayList<>();
         innerLatLngs.add(new LatLng());
-        innerLatLngs.add(new LatLng(1,1));
-        innerLatLngs.add(new LatLng(-1,-1));
-        List<List<LatLng>>latLngs = new ArrayList<>();
+        innerLatLngs.add(new LatLng(1, 1));
+        innerLatLngs.add(new LatLng(-1, -1));
+        List<List<LatLng>> latLngs = new ArrayList<>();
         latLngs.add(innerLatLngs);
         <%- camelize(type) %> <%- type %> = <%- type %>Manager.create(new <%- camelize(type) %>Options().withLatLngs(latLngs));
 <% } -%>
@@ -338,27 +340,27 @@ public class <%- camelize(type) %>ManagerTest {
         assertEquals(options.getGeometry(), Point.fromLngLat(34, 12));
         assertEquals(<%- type  %>.getGeometry(), Point.fromLngLat(34, 12));
 <% } else if (type === "line") { -%>
-        List<LatLng>latLngs = new ArrayList<>();
+        List<LatLng> latLngs = new ArrayList<>();
         latLngs.add(new LatLng());
-        latLngs.add(new LatLng(1,1));
+        latLngs.add(new LatLng(1, 1));
         <%- camelize(type) %>Options options = new <%- camelize(type) %>Options().withLatLngs(latLngs);
         <%- camelize(type) %> <%- type %> = <%- type %>Manager.create(options);
         assertEquals(options.getLatLngs(), latLngs);
         assertEquals(line.getLatLngs(), latLngs);
         assertEquals(options.getGeometry(), LineString.fromLngLats(new ArrayList<Point>() {{
-                    add(Point.fromLngLat(0, 0));
-                    add(Point.fromLngLat(1, 1));
+            add(Point.fromLngLat(0, 0));
+            add(Point.fromLngLat(1, 1));
         }}));
         assertEquals(line.getGeometry(), LineString.fromLngLats(new ArrayList<Point>() {{
             add(Point.fromLngLat(0, 0));
             add(Point.fromLngLat(1, 1));
         }}));
 <% } else { -%>
-        List<LatLng>innerLatLngs = new ArrayList<>();
+        List<LatLng> innerLatLngs = new ArrayList<>();
         innerLatLngs.add(new LatLng());
-        innerLatLngs.add(new LatLng(1,1));
-        innerLatLngs.add(new LatLng(-1,-1));
-        List<List<LatLng>>latLngs = new ArrayList<>();
+        innerLatLngs.add(new LatLng(1, 1));
+        innerLatLngs.add(new LatLng(-1, -1));
+        List<List<LatLng>> latLngs = new ArrayList<>();
         latLngs.add(innerLatLngs);
         <%- camelize(type) %>Options options = new <%- camelize(type) %>Options().withLatLngs(latLngs);
         Fill fill = fillManager.create(options);
@@ -388,17 +390,17 @@ public class <%- camelize(type) %>ManagerTest {
         <%- camelize(type) %> <%- type %>Zero = <%- type %>Manager.create(new <%- camelize(type) %>Options().withLatLng(new LatLng()));
         <%- camelize(type) %> <%- type %>One = <%- type %>Manager.create(new <%- camelize(type) %>Options().withLatLng(new LatLng()));
 <% } else if (type === "line") { -%>
-        List<LatLng>latLngs = new ArrayList<>();
+        List<LatLng> latLngs = new ArrayList<>();
         latLngs.add(new LatLng());
-        latLngs.add(new LatLng(1,1));
+        latLngs.add(new LatLng(1, 1));
         <%- camelize(type) %> <%- type %>Zero = <%- type %>Manager.create(new <%- camelize(type) %>Options().withLatLngs(latLngs));
         <%- camelize(type) %> <%- type %>One = <%- type %>Manager.create(new <%- camelize(type) %>Options().withLatLngs(latLngs));
 <% } else { -%>
-        List<LatLng>innerLatLngs = new ArrayList<>();
+        List<LatLng> innerLatLngs = new ArrayList<>();
         innerLatLngs.add(new LatLng());
-        innerLatLngs.add(new LatLng(1,1));
-        innerLatLngs.add(new LatLng(-1,-1));
-        List<List<LatLng>>latLngs = new ArrayList<>();
+        innerLatLngs.add(new LatLng(1, 1));
+        innerLatLngs.add(new LatLng(-1, -1));
+        List<List<LatLng>> latLngs = new ArrayList<>();
         latLngs.add(innerLatLngs);
         <%- camelize(type) %> <%- type %>Zero = <%- type %>Manager.create(new <%- camelize(type) %>Options().withLatLngs(latLngs));
         <%- camelize(type) %> <%- type %>One = <%- type %>Manager.create(new <%- camelize(type) %>Options().withLatLngs(latLngs));
@@ -413,16 +415,16 @@ public class <%- camelize(type) %>ManagerTest {
 <% if (type === "circle" || type === "symbol") { -%>
         <%- camelize(type) %> <%- type %>Zero = <%- type %>Manager.create(new <%- camelize(type) %>Options().withLatLng(new LatLng()));
 <% } else if (type === "line") { -%>
-        List<LatLng>latLngs = new ArrayList<>();
+        List<LatLng> latLngs = new ArrayList<>();
         latLngs.add(new LatLng());
-        latLngs.add(new LatLng(1,1));
+        latLngs.add(new LatLng(1, 1));
         <%- camelize(type) %> <%- type %>Zero = <%- type %>Manager.create(new <%- camelize(type) %>Options().withLatLngs(latLngs));
 <% } else { -%>
-        List<LatLng>innerLatLngs = new ArrayList<>();
+        List<LatLng> innerLatLngs = new ArrayList<>();
         innerLatLngs.add(new LatLng());
-        innerLatLngs.add(new LatLng(1,1));
-        innerLatLngs.add(new LatLng(-1,-1));
-        List<List<LatLng>>latLngs = new ArrayList<>();
+        innerLatLngs.add(new LatLng(1, 1));
+        innerLatLngs.add(new LatLng(-1, -1));
+        List<List<LatLng>> latLngs = new ArrayList<>();
         latLngs.add(innerLatLngs);
         <%- camelize(type) %> <%- type %>Zero = <%- type %>Manager.create(new <%- camelize(type) %>Options().withLatLngs(latLngs));
 <% } -%>
@@ -445,16 +447,16 @@ public class <%- camelize(type) %>ManagerTest {
 <% if (type === "circle" || type === "symbol") { -%>
         <%- camelize(type) %>Options options = new <%- camelize(type) %>Options().withLatLng(new LatLng()).with<%- camelize(property.name) %>(<%- defaultValueJava(property) %>);
 <% } else if (type === "line") { -%>
-        List<LatLng>latLngs = new ArrayList<>();
+        List<LatLng> latLngs = new ArrayList<>();
         latLngs.add(new LatLng());
-        latLngs.add(new LatLng(1,1));
+        latLngs.add(new LatLng(1, 1));
         <%- camelize(type) %>Options options = new <%- camelize(type) %>Options().withLatLngs(latLngs).with<%- camelize(property.name) %>(<%- defaultValueJava(property) %>);
 <% } else { -%>
-        List<LatLng>innerLatLngs = new ArrayList<>();
+        List<LatLng> innerLatLngs = new ArrayList<>();
         innerLatLngs.add(new LatLng());
-        innerLatLngs.add(new LatLng(1,1));
-        innerLatLngs.add(new LatLng(-1,-1));
-        List<List<LatLng>>latLngs = new ArrayList<>();
+        innerLatLngs.add(new LatLng(1, 1));
+        innerLatLngs.add(new LatLng(-1, -1));
+        List<List<LatLng>> latLngs = new ArrayList<>();
         latLngs.add(innerLatLngs);
         <%- camelize(type) %>Options options = new <%- camelize(type) %>Options().withLatLngs(latLngs).with<%- camelize(property.name) %>(<%- defaultValueJava(property) %>);
 <% } -%>
@@ -484,12 +486,12 @@ public class <%- camelize(type) %>ManagerTest {
     @Test
     public void testClickListener() {
         On<%- camelize(type) %>ClickListener listener = mock(On<%- camelize(type) %>ClickListener.class);
-        <%- type  %>Manager = new  <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
+        <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, draggableAnnotationController);
         assertTrue(<%- type  %>Manager.getClickListeners().isEmpty());
         <%- type  %>Manager.addClickListener(listener);
         assertTrue(<%- type  %>Manager.getClickListeners().contains(listener));
         <%- type  %>Manager.removeClickListener(listener);
-        assertTrue( <%- type  %>Manager.getClickListeners().isEmpty());
+        assertTrue(<%- type  %>Manager.getClickListeners().isEmpty());
     }
 
     @Test
@@ -520,16 +522,16 @@ public class <%- camelize(type) %>ManagerTest {
 <% if (type === "circle" || type === "symbol") { -%>
         <%- camelize(type) %>Options options = new <%- camelize(type) %>Options().withLatLng(new LatLng());
 <% } else if (type === "line") { -%>
-        List<LatLng>latLngs = new ArrayList<>();
+        List<LatLng> latLngs = new ArrayList<>();
         latLngs.add(new LatLng());
-        latLngs.add(new LatLng(1,1));
+        latLngs.add(new LatLng(1, 1));
         <%- camelize(type) %>Options options = new <%- camelize(type) %>Options().withLatLngs(latLngs);
 <% } else { -%>
-        List<LatLng>innerLatLngs = new ArrayList<>();
+        List<LatLng> innerLatLngs = new ArrayList<>();
         innerLatLngs.add(new LatLng());
-        innerLatLngs.add(new LatLng(1,1));
-        innerLatLngs.add(new LatLng(-1,-1));
-        List<List<LatLng>>latLngs = new ArrayList<>();
+        innerLatLngs.add(new LatLng(1, 1));
+        innerLatLngs.add(new LatLng(-1, -1));
+        List<List<LatLng>> latLngs = new ArrayList<>();
         latLngs.add(innerLatLngs);
         <%- camelize(type) %>Options options = new <%- camelize(type) %>Options().withLatLngs(latLngs);
 <% } -%>
@@ -544,16 +546,16 @@ public class <%- camelize(type) %>ManagerTest {
 <% if (type === "circle" || type === "symbol") { -%>
         <%- camelize(type) %>Options options = new <%- camelize(type) %>Options().withLatLng(new LatLng());
 <% } else if (type === "line") { -%>
-        List<LatLng>latLngs = new ArrayList<>();
+        List<LatLng> latLngs = new ArrayList<>();
         latLngs.add(new LatLng());
-        latLngs.add(new LatLng(1,1));
+        latLngs.add(new LatLng(1, 1));
         <%- camelize(type) %>Options options = new <%- camelize(type) %>Options().withLatLngs(latLngs);
 <% } else { -%>
-        List<LatLng>innerLatLngs = new ArrayList<>();
+        List<LatLng> innerLatLngs = new ArrayList<>();
         innerLatLngs.add(new LatLng());
-        innerLatLngs.add(new LatLng(1,1));
-        innerLatLngs.add(new LatLng(-1,-1));
-        List<List<LatLng>>latLngs = new ArrayList<>();
+        innerLatLngs.add(new LatLng(1, 1));
+        innerLatLngs.add(new LatLng(-1, -1));
+        List<List<LatLng>> latLngs = new ArrayList<>();
         latLngs.add(innerLatLngs);
         <%- camelize(type) %>Options options = new <%- camelize(type) %>Options().withLatLngs(latLngs);
 <% } -%>
@@ -569,20 +571,20 @@ public class <%- camelize(type) %>ManagerTest {
 <% if (type === "circle" || type === "symbol") { -%>
         <%- camelize(type) %>Options options = new <%- camelize(type) %>Options().withLatLng(new LatLng());
 <% } else if (type === "line") { -%>
-        List<LatLng>latLngs = new ArrayList<>();
+        List<LatLng> latLngs = new ArrayList<>();
         latLngs.add(new LatLng());
-        latLngs.add(new LatLng(1,1));
+        latLngs.add(new LatLng(1, 1));
         <%- camelize(type) %>Options options = new <%- camelize(type) %>Options().withLatLngs(latLngs);
 <% } else { -%>
-        List<LatLng>innerLatLngs = new ArrayList<>();
+        List<LatLng> innerLatLngs = new ArrayList<>();
         innerLatLngs.add(new LatLng());
-        innerLatLngs.add(new LatLng(1,1));
-        innerLatLngs.add(new LatLng(-1,-1));
-        List<List<LatLng>>latLngs = new ArrayList<>();
+        innerLatLngs.add(new LatLng(1, 1));
+        innerLatLngs.add(new LatLng(-1, -1));
+        List<List<LatLng>> latLngs = new ArrayList<>();
         latLngs.add(innerLatLngs);
         <%- camelize(type) %>Options options = new <%- camelize(type) %>Options().withLatLngs(latLngs);
 <% } -%>
-         <%- camelize(type) %>  <%- type %> = <%- type  %>Manager.create(options);
+        <%- camelize(type) %> <%- type %> = <%- type  %>Manager.create(options);
         assertEquals(1, <%- type  %>Manager.annotations.size());
 
         <%- type  %>Manager.getAnnotations().clear();

--- a/plugin-annotation/scripts/annotation_options.java.ejs
+++ b/plugin-annotation/scripts/annotation_options.java.ejs
@@ -53,11 +53,12 @@ public class <%- camelize(type) %>Options extends Options<<%- camelize(type) %>>
      * <p>
      * <%- propertyFactoryMethodDoc(property) %>
      * </p>
+     *
      * @param <%- camelizeWithLeadingLowercase(property.name) %> the <%- property.name %> value
      * @return this
      */
     public <%- camelize(type) %>Options with<%- camelize(property.name) %>(<%- propertyTypeAnnotation(property) %><%- iff(() => propertyTypeAnnotation(property), " ") %><%- propertyType(property) %> <%- camelizeWithLeadingLowercase(property.name) %>) {
-        this.<%- camelizeWithLeadingLowercase(property.name) %> =  <%- camelizeWithLeadingLowercase(property.name) %>;
+        this.<%- camelizeWithLeadingLowercase(property.name) %> = <%- camelizeWithLeadingLowercase(property.name) %>;
         return this;
     }
 
@@ -66,6 +67,7 @@ public class <%- camelize(type) %>Options extends Options<<%- camelize(type) %>>
      * <p>
      * <%- propertyFactoryMethodDoc(property) %>
      * </p>
+     *
      * @return <%- camelizeWithLeadingLowercase(property.name) %> value
      */
     public <%- propertyType(property) %> get<%- camelize(property.name) %>() {
@@ -126,7 +128,7 @@ public class <%- camelize(type) %>Options extends Options<<%- camelize(type) %>>
      * @return this
      */
     public <%- camelize(type) %>Options withLatLngs(List<LatLng> latLngs) {
-        List<Point>points = new ArrayList<>();
+        List<Point> points = new ArrayList<>();
         for (LatLng latLng : latLngs) {
             points.add(Point.fromLngLat(latLng.getLongitude(), latLng.getLatitude()));
         }
@@ -140,8 +142,8 @@ public class <%- camelize(type) %>Options extends Options<<%- camelize(type) %>>
      * @return a list of the locations of the line in a longitude and latitude pairs
      */
     public List<LatLng> getLatLngs() {
-        List<LatLng>latLngs = new ArrayList<>();
-        if (geometry!=null) {
+        List<LatLng> latLngs = new ArrayList<>();
+        if (geometry != null) {
             for (Point coordinate : geometry.coordinates()) {
                 latLngs.add(new LatLng(coordinate.latitude(), coordinate.longitude()));
             }
@@ -179,7 +181,7 @@ public class <%- camelize(type) %>Options extends Options<<%- camelize(type) %>>
     public <%- camelize(type) %>Options withLatLngs(List<List<LatLng>> latLngs) {
         List<List<Point>> points = new ArrayList<>();
         for (List<LatLng> innerLatLngs : latLngs) {
-            List<Point>innerList = new ArrayList<>();
+            List<Point> innerList = new ArrayList<>();
             for (LatLng latLng : innerLatLngs) {
                 innerList.add(Point.fromLngLat(latLng.getLongitude(), latLng.getLatitude()));
             }
@@ -305,7 +307,8 @@ public class <%- camelize(type) %>Options extends Options<<%- camelize(type) %>>
 <% } else if (type === "line") { -%>
         if (!(feature.geometry() instanceof LineString)) {
 <% } else { -%>
-        if (!(feature.geometry() instanceof Polygon)) {<% } -%>
+        if (!(feature.geometry() instanceof Polygon)) {
+<% } -%>
             return null;
         }
 

--- a/plugin-annotation/scripts/code-gen.js
+++ b/plugin-annotation/scripts/code-gen.js
@@ -249,7 +249,7 @@ global.defaultValueJava = function(property) {
               case 'string':
                 return '[' + property['default'] + "]";
               case 'number':
-                var result ='new Float[] {';
+                var result ='new Float[]{';
                 for (var i = 0; i < property.length; i++) {
                     result += "0f";
                     if (i +1 != property.length) {

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/Circle.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/Circle.java
@@ -5,10 +5,9 @@ package com.mapbox.mapboxsdk.plugins.annotation;
 import androidx.annotation.ColorInt;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.UiThread;
 
 import android.graphics.PointF;
-
-import androidx.annotation.UiThread;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonNull;

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/Fill.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/Fill.java
@@ -5,10 +5,9 @@ package com.mapbox.mapboxsdk.plugins.annotation;
 import androidx.annotation.ColorInt;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.UiThread;
 
 import android.graphics.PointF;
-
-import androidx.annotation.UiThread;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonNull;

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/Line.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/Line.java
@@ -5,10 +5,9 @@ package com.mapbox.mapboxsdk.plugins.annotation;
 import androidx.annotation.ColorInt;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.UiThread;
 
 import android.graphics.PointF;
-
-import androidx.annotation.UiThread;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonNull;

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/Symbol.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/Symbol.java
@@ -5,10 +5,9 @@ package com.mapbox.mapboxsdk.plugins.annotation;
 import androidx.annotation.ColorInt;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.UiThread;
 
 import android.graphics.PointF;
-
-import androidx.annotation.UiThread;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonNull;

--- a/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/CircleManagerTest.java
+++ b/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/CircleManagerTest.java
@@ -2,6 +2,8 @@
 
 package com.mapbox.mapboxsdk.plugins.annotation;
 
+import android.graphics.PointF;
+
 import com.google.gson.JsonPrimitive;
 import com.mapbox.geojson.*;
 import com.mapbox.mapboxsdk.geometry.LatLng;
@@ -21,8 +23,6 @@ import org.mockito.ArgumentCaptor;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Arrays;
-
-import android.graphics.PointF;
 
 import static com.mapbox.mapboxsdk.plugins.annotation.ConvertUtils.convertArray;
 import static com.mapbox.mapboxsdk.style.expressions.Expression.get;

--- a/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/FillManagerTest.java
+++ b/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/FillManagerTest.java
@@ -2,6 +2,8 @@
 
 package com.mapbox.mapboxsdk.plugins.annotation;
 
+import android.graphics.PointF;
+
 import com.google.gson.JsonPrimitive;
 import com.mapbox.geojson.*;
 import com.mapbox.mapboxsdk.geometry.LatLng;
@@ -21,8 +23,6 @@ import org.mockito.ArgumentCaptor;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Arrays;
-
-import android.graphics.PointF;
 
 import static com.mapbox.mapboxsdk.plugins.annotation.ConvertUtils.convertArray;
 import static com.mapbox.mapboxsdk.style.expressions.Expression.get;

--- a/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/LineManagerTest.java
+++ b/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/LineManagerTest.java
@@ -2,6 +2,8 @@
 
 package com.mapbox.mapboxsdk.plugins.annotation;
 
+import android.graphics.PointF;
+
 import com.google.gson.JsonPrimitive;
 import com.mapbox.geojson.*;
 import com.mapbox.mapboxsdk.geometry.LatLng;
@@ -21,8 +23,6 @@ import org.mockito.ArgumentCaptor;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Arrays;
-
-import android.graphics.PointF;
 
 import static com.mapbox.mapboxsdk.plugins.annotation.ConvertUtils.convertArray;
 import static com.mapbox.mapboxsdk.style.expressions.Expression.get;

--- a/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/SymbolManagerTest.java
+++ b/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/SymbolManagerTest.java
@@ -2,6 +2,8 @@
 
 package com.mapbox.mapboxsdk.plugins.annotation;
 
+import android.graphics.PointF;
+
 import com.google.gson.JsonPrimitive;
 import com.mapbox.geojson.*;
 import com.mapbox.mapboxsdk.geometry.LatLng;
@@ -21,8 +23,6 @@ import org.mockito.ArgumentCaptor;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Arrays;
-
-import android.graphics.PointF;
 
 import static com.mapbox.mapboxsdk.plugins.annotation.ConvertUtils.convertArray;
 import static com.mapbox.mapboxsdk.style.expressions.Expression.get;


### PR DESCRIPTION
Follow-up to #32 and re. https://github.com/maplibre/maplibre-plugins-android/pull/31#issuecomment-1594461801, the generated code now matches the code that is actually in the repo. There were only further indentation changes.