### PR TITLE
Offline: fix crash on Android S+ caused by pending intent.

### DIFF
--- a/plugin-offline/src/main/java/com/mapbox/mapboxsdk/plugins/offline/offline/OfflineDownloadStateReceiver.java
+++ b/plugin-offline/src/main/java/com/mapbox/mapboxsdk/plugins/offline/offline/OfflineDownloadStateReceiver.java
@@ -97,7 +97,7 @@ public class OfflineDownloadStateReceiver extends BroadcastReceiver {
             context,
             0,
             notificationIntent,
-            PendingIntent.FLAG_UPDATE_CURRENT
+            PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE
         );
     }
 }

--- a/plugin-offline/src/main/java/com/mapbox/mapboxsdk/plugins/offline/utils/NotificationUtils.java
+++ b/plugin-offline/src/main/java/com/mapbox/mapboxsdk/plugins/offline/utils/NotificationUtils.java
@@ -52,6 +52,6 @@ public class NotificationUtils {
             .addAction(Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP ? 0 : R.drawable.ic_cancel,
                 options.cancelText(),
                 PendingIntent.getService(context, offlineDownload.uuid().intValue(), cancelIntent,
-                    PendingIntent.FLAG_CANCEL_CURRENT));
+                    PendingIntent.FLAG_CANCEL_CURRENT | PendingIntent.FLAG_IMMUTABLE));
     }
 }


### PR DESCRIPTION
Adds `PendingIntent.FLAG_IMMUTABLE` to the two PendingIntents within the offline maps plugin. Google have made this mutability flag a requirement on API S and beyond. The old behavior was to imply `FLAG_MUTABLE`, but it doesn't look like this plugin is actually modifying the intent, so `FLAG_IMMUTABLE` should work. This change removes the crash.