### PR TITLE
Re-implement delayed source update

### DIFF
--- a/plugin-annotation/scripts/annotation_manager_unit_test.junit.ejs
+++ b/plugin-annotation/scripts/annotation_manager_unit_test.junit.ejs
@@ -441,6 +441,7 @@ public class <%- camelize(type) %>ManagerTest {
         <%- camelize(type) %>Options options = new <%- camelize(type) %>Options().withLatLngs(latLngs).with<%- camelize(property.name) %>(<%- defaultValueJava(property) %>);
 <% } -%>
         <%- type  %>Manager.create(options);
+        <%- type  %>Manager.updateSourceNow();
         verify(<%- type  %>Layer, times(1)).setProperties(argThat(new PropertyValueMatcher(<%- camelizeWithLeadingLowercase(property.name) %>(get("<%- property.name %>")))));
 
         <%- type  %>Manager.create(options);

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/DraggableAnnotationController.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/DraggableAnnotationController.java
@@ -144,7 +144,7 @@ final class DraggableAnnotationController {
                 draggedAnnotation.setGeometry(
                     shiftedGeometry
                 );
-                draggedAnnotationManager.postUpdateSource();
+                draggedAnnotationManager.updateSource();
                 for (OnAnnotationDragListener d : (List<OnAnnotationDragListener>) draggedAnnotationManager.getDragListeners()) {
                     d.onAnnotationDrag(draggedAnnotation);
                 }

--- a/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/CircleManagerTest.java
+++ b/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/CircleManagerTest.java
@@ -238,6 +238,7 @@ public class CircleManagerTest {
 
         CircleOptions options = new CircleOptions().withLatLng(new LatLng()).withCircleRadius(2.0f);
         circleManager.create(options);
+        circleManager.updateSourceNow();
         verify(circleLayer, times(1)).setProperties(argThat(new PropertyValueMatcher(circleRadius(get("circle-radius")))));
 
         circleManager.create(options);
@@ -251,6 +252,7 @@ public class CircleManagerTest {
 
         CircleOptions options = new CircleOptions().withLatLng(new LatLng()).withCircleColor("rgba(0, 0, 0, 1)");
         circleManager.create(options);
+        circleManager.updateSourceNow();
         verify(circleLayer, times(1)).setProperties(argThat(new PropertyValueMatcher(circleColor(get("circle-color")))));
 
         circleManager.create(options);
@@ -264,6 +266,7 @@ public class CircleManagerTest {
 
         CircleOptions options = new CircleOptions().withLatLng(new LatLng()).withCircleBlur(2.0f);
         circleManager.create(options);
+        circleManager.updateSourceNow();
         verify(circleLayer, times(1)).setProperties(argThat(new PropertyValueMatcher(circleBlur(get("circle-blur")))));
 
         circleManager.create(options);
@@ -277,6 +280,7 @@ public class CircleManagerTest {
 
         CircleOptions options = new CircleOptions().withLatLng(new LatLng()).withCircleOpacity(2.0f);
         circleManager.create(options);
+        circleManager.updateSourceNow();
         verify(circleLayer, times(1)).setProperties(argThat(new PropertyValueMatcher(circleOpacity(get("circle-opacity")))));
 
         circleManager.create(options);
@@ -290,6 +294,7 @@ public class CircleManagerTest {
 
         CircleOptions options = new CircleOptions().withLatLng(new LatLng()).withCircleStrokeWidth(2.0f);
         circleManager.create(options);
+        circleManager.updateSourceNow();
         verify(circleLayer, times(1)).setProperties(argThat(new PropertyValueMatcher(circleStrokeWidth(get("circle-stroke-width")))));
 
         circleManager.create(options);
@@ -303,6 +308,7 @@ public class CircleManagerTest {
 
         CircleOptions options = new CircleOptions().withLatLng(new LatLng()).withCircleStrokeColor("rgba(0, 0, 0, 1)");
         circleManager.create(options);
+        circleManager.updateSourceNow();
         verify(circleLayer, times(1)).setProperties(argThat(new PropertyValueMatcher(circleStrokeColor(get("circle-stroke-color")))));
 
         circleManager.create(options);
@@ -316,6 +322,7 @@ public class CircleManagerTest {
 
         CircleOptions options = new CircleOptions().withLatLng(new LatLng()).withCircleStrokeOpacity(2.0f);
         circleManager.create(options);
+        circleManager.updateSourceNow();
         verify(circleLayer, times(1)).setProperties(argThat(new PropertyValueMatcher(circleStrokeOpacity(get("circle-stroke-opacity")))));
 
         circleManager.create(options);

--- a/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/DraggableAnnotationControllerTest.java
+++ b/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/DraggableAnnotationControllerTest.java
@@ -265,7 +265,7 @@ public class DraggableAnnotationControllerTest {
 
         assertTrue(moved);
         verify(annotation).setGeometry(geometry);
-        verify(annotationManager).postUpdateSource();
+        verify(annotationManager).updateSource();
         verify(dragListener, times(1)).onAnnotationDrag(annotation);
     }
 

--- a/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/FillManagerTest.java
+++ b/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/FillManagerTest.java
@@ -308,6 +308,7 @@ public class FillManagerTest {
         latLngs.add(innerLatLngs);
         FillOptions options = new FillOptions().withLatLngs(latLngs).withFillOpacity(2.0f);
         fillManager.create(options);
+        fillManager.updateSourceNow();
         verify(fillLayer, times(1)).setProperties(argThat(new PropertyValueMatcher(fillOpacity(get("fill-opacity")))));
 
         fillManager.create(options);
@@ -327,6 +328,7 @@ public class FillManagerTest {
         latLngs.add(innerLatLngs);
         FillOptions options = new FillOptions().withLatLngs(latLngs).withFillColor("rgba(0, 0, 0, 1)");
         fillManager.create(options);
+        fillManager.updateSourceNow();
         verify(fillLayer, times(1)).setProperties(argThat(new PropertyValueMatcher(fillColor(get("fill-color")))));
 
         fillManager.create(options);
@@ -346,6 +348,7 @@ public class FillManagerTest {
         latLngs.add(innerLatLngs);
         FillOptions options = new FillOptions().withLatLngs(latLngs).withFillOutlineColor("rgba(0, 0, 0, 1)");
         fillManager.create(options);
+        fillManager.updateSourceNow();
         verify(fillLayer, times(1)).setProperties(argThat(new PropertyValueMatcher(fillOutlineColor(get("fill-outline-color")))));
 
         fillManager.create(options);
@@ -365,6 +368,7 @@ public class FillManagerTest {
         latLngs.add(innerLatLngs);
         FillOptions options = new FillOptions().withLatLngs(latLngs).withFillPattern("pedestrian-polygon");
         fillManager.create(options);
+        fillManager.updateSourceNow();
         verify(fillLayer, times(1)).setProperties(argThat(new PropertyValueMatcher(fillPattern(get("fill-pattern")))));
 
         fillManager.create(options);

--- a/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/LineManagerTest.java
+++ b/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/LineManagerTest.java
@@ -272,6 +272,7 @@ public class LineManagerTest {
         latLngs.add(new LatLng(1, 1));
         LineOptions options = new LineOptions().withLatLngs(latLngs).withLineJoin(LINE_JOIN_BEVEL);
         lineManager.create(options);
+        lineManager.updateSourceNow();
         verify(lineLayer, times(1)).setProperties(argThat(new PropertyValueMatcher(lineJoin(get("line-join")))));
 
         lineManager.create(options);
@@ -288,6 +289,7 @@ public class LineManagerTest {
         latLngs.add(new LatLng(1, 1));
         LineOptions options = new LineOptions().withLatLngs(latLngs).withLineOpacity(2.0f);
         lineManager.create(options);
+        lineManager.updateSourceNow();
         verify(lineLayer, times(1)).setProperties(argThat(new PropertyValueMatcher(lineOpacity(get("line-opacity")))));
 
         lineManager.create(options);
@@ -304,6 +306,7 @@ public class LineManagerTest {
         latLngs.add(new LatLng(1, 1));
         LineOptions options = new LineOptions().withLatLngs(latLngs).withLineColor("rgba(0, 0, 0, 1)");
         lineManager.create(options);
+        lineManager.updateSourceNow();
         verify(lineLayer, times(1)).setProperties(argThat(new PropertyValueMatcher(lineColor(get("line-color")))));
 
         lineManager.create(options);
@@ -320,6 +323,7 @@ public class LineManagerTest {
         latLngs.add(new LatLng(1, 1));
         LineOptions options = new LineOptions().withLatLngs(latLngs).withLineWidth(2.0f);
         lineManager.create(options);
+        lineManager.updateSourceNow();
         verify(lineLayer, times(1)).setProperties(argThat(new PropertyValueMatcher(lineWidth(get("line-width")))));
 
         lineManager.create(options);
@@ -336,6 +340,7 @@ public class LineManagerTest {
         latLngs.add(new LatLng(1, 1));
         LineOptions options = new LineOptions().withLatLngs(latLngs).withLineGapWidth(2.0f);
         lineManager.create(options);
+        lineManager.updateSourceNow();
         verify(lineLayer, times(1)).setProperties(argThat(new PropertyValueMatcher(lineGapWidth(get("line-gap-width")))));
 
         lineManager.create(options);
@@ -352,6 +357,7 @@ public class LineManagerTest {
         latLngs.add(new LatLng(1, 1));
         LineOptions options = new LineOptions().withLatLngs(latLngs).withLineOffset(2.0f);
         lineManager.create(options);
+        lineManager.updateSourceNow();
         verify(lineLayer, times(1)).setProperties(argThat(new PropertyValueMatcher(lineOffset(get("line-offset")))));
 
         lineManager.create(options);
@@ -368,6 +374,7 @@ public class LineManagerTest {
         latLngs.add(new LatLng(1, 1));
         LineOptions options = new LineOptions().withLatLngs(latLngs).withLineBlur(2.0f);
         lineManager.create(options);
+        lineManager.updateSourceNow();
         verify(lineLayer, times(1)).setProperties(argThat(new PropertyValueMatcher(lineBlur(get("line-blur")))));
 
         lineManager.create(options);
@@ -384,6 +391,7 @@ public class LineManagerTest {
         latLngs.add(new LatLng(1, 1));
         LineOptions options = new LineOptions().withLatLngs(latLngs).withLinePattern("pedestrian-polygon");
         lineManager.create(options);
+        lineManager.updateSourceNow();
         verify(lineLayer, times(1)).setProperties(argThat(new PropertyValueMatcher(linePattern(get("line-pattern")))));
 
         lineManager.create(options);

--- a/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/SymbolManagerTest.java
+++ b/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/SymbolManagerTest.java
@@ -282,6 +282,7 @@ public class SymbolManagerTest {
 
         SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withSymbolSortKey(2.0f);
         symbolManager.create(options);
+        symbolManager.updateSourceNow();
         verify(symbolLayer, times(1)).setProperties(argThat(new PropertyValueMatcher(symbolSortKey(get("symbol-sort-key")))));
 
         symbolManager.create(options);
@@ -295,6 +296,7 @@ public class SymbolManagerTest {
 
         SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withIconSize(2.0f);
         symbolManager.create(options);
+        symbolManager.updateSourceNow();
         verify(symbolLayer, times(1)).setProperties(argThat(new PropertyValueMatcher(iconSize(get("icon-size")))));
 
         symbolManager.create(options);
@@ -308,6 +310,7 @@ public class SymbolManagerTest {
 
         SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withIconImage("undefined");
         symbolManager.create(options);
+        symbolManager.updateSourceNow();
         verify(symbolLayer, times(1)).setProperties(argThat(new PropertyValueMatcher(iconImage(get("icon-image")))));
 
         symbolManager.create(options);
@@ -321,6 +324,7 @@ public class SymbolManagerTest {
 
         SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withIconRotate(2.0f);
         symbolManager.create(options);
+        symbolManager.updateSourceNow();
         verify(symbolLayer, times(1)).setProperties(argThat(new PropertyValueMatcher(iconRotate(get("icon-rotate")))));
 
         symbolManager.create(options);
@@ -334,6 +338,7 @@ public class SymbolManagerTest {
 
         SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withIconOffset(new Float[]{0f, 0f});
         symbolManager.create(options);
+        symbolManager.updateSourceNow();
         verify(symbolLayer, times(1)).setProperties(argThat(new PropertyValueMatcher(iconOffset(get("icon-offset")))));
 
         symbolManager.create(options);
@@ -347,6 +352,7 @@ public class SymbolManagerTest {
 
         SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withIconAnchor(ICON_ANCHOR_CENTER);
         symbolManager.create(options);
+        symbolManager.updateSourceNow();
         verify(symbolLayer, times(1)).setProperties(argThat(new PropertyValueMatcher(iconAnchor(get("icon-anchor")))));
 
         symbolManager.create(options);
@@ -360,6 +366,7 @@ public class SymbolManagerTest {
 
         SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withTextField("");
         symbolManager.create(options);
+        symbolManager.updateSourceNow();
         verify(symbolLayer, times(1)).setProperties(argThat(new PropertyValueMatcher(textField(get("text-field")))));
 
         symbolManager.create(options);
@@ -373,6 +380,7 @@ public class SymbolManagerTest {
 
         SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withTextFont(new String[]{"Open Sans Regular", "Arial Unicode MS Regular"});
         symbolManager.create(options);
+        symbolManager.updateSourceNow();
         verify(symbolLayer, times(1)).setProperties(argThat(new PropertyValueMatcher(textFont(get("text-font")))));
 
         symbolManager.create(options);
@@ -386,6 +394,7 @@ public class SymbolManagerTest {
 
         SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withTextSize(2.0f);
         symbolManager.create(options);
+        symbolManager.updateSourceNow();
         verify(symbolLayer, times(1)).setProperties(argThat(new PropertyValueMatcher(textSize(get("text-size")))));
 
         symbolManager.create(options);
@@ -399,6 +408,7 @@ public class SymbolManagerTest {
 
         SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withTextMaxWidth(2.0f);
         symbolManager.create(options);
+        symbolManager.updateSourceNow();
         verify(symbolLayer, times(1)).setProperties(argThat(new PropertyValueMatcher(textMaxWidth(get("text-max-width")))));
 
         symbolManager.create(options);
@@ -412,6 +422,7 @@ public class SymbolManagerTest {
 
         SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withTextLetterSpacing(2.0f);
         symbolManager.create(options);
+        symbolManager.updateSourceNow();
         verify(symbolLayer, times(1)).setProperties(argThat(new PropertyValueMatcher(textLetterSpacing(get("text-letter-spacing")))));
 
         symbolManager.create(options);
@@ -425,6 +436,7 @@ public class SymbolManagerTest {
 
         SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withTextJustify(TEXT_JUSTIFY_AUTO);
         symbolManager.create(options);
+        symbolManager.updateSourceNow();
         verify(symbolLayer, times(1)).setProperties(argThat(new PropertyValueMatcher(textJustify(get("text-justify")))));
 
         symbolManager.create(options);
@@ -438,6 +450,7 @@ public class SymbolManagerTest {
 
         SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withTextRadialOffset(2.0f);
         symbolManager.create(options);
+        symbolManager.updateSourceNow();
         verify(symbolLayer, times(1)).setProperties(argThat(new PropertyValueMatcher(textRadialOffset(get("text-radial-offset")))));
 
         symbolManager.create(options);
@@ -451,6 +464,7 @@ public class SymbolManagerTest {
 
         SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withTextAnchor(TEXT_ANCHOR_CENTER);
         symbolManager.create(options);
+        symbolManager.updateSourceNow();
         verify(symbolLayer, times(1)).setProperties(argThat(new PropertyValueMatcher(textAnchor(get("text-anchor")))));
 
         symbolManager.create(options);
@@ -464,6 +478,7 @@ public class SymbolManagerTest {
 
         SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withTextRotate(2.0f);
         symbolManager.create(options);
+        symbolManager.updateSourceNow();
         verify(symbolLayer, times(1)).setProperties(argThat(new PropertyValueMatcher(textRotate(get("text-rotate")))));
 
         symbolManager.create(options);
@@ -477,6 +492,7 @@ public class SymbolManagerTest {
 
         SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withTextTransform(TEXT_TRANSFORM_NONE);
         symbolManager.create(options);
+        symbolManager.updateSourceNow();
         verify(symbolLayer, times(1)).setProperties(argThat(new PropertyValueMatcher(textTransform(get("text-transform")))));
 
         symbolManager.create(options);
@@ -490,6 +506,7 @@ public class SymbolManagerTest {
 
         SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withTextOffset(new Float[]{0f, 0f});
         symbolManager.create(options);
+        symbolManager.updateSourceNow();
         verify(symbolLayer, times(1)).setProperties(argThat(new PropertyValueMatcher(textOffset(get("text-offset")))));
 
         symbolManager.create(options);
@@ -503,6 +520,7 @@ public class SymbolManagerTest {
 
         SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withIconOpacity(2.0f);
         symbolManager.create(options);
+        symbolManager.updateSourceNow();
         verify(symbolLayer, times(1)).setProperties(argThat(new PropertyValueMatcher(iconOpacity(get("icon-opacity")))));
 
         symbolManager.create(options);
@@ -516,6 +534,7 @@ public class SymbolManagerTest {
 
         SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withIconColor("rgba(0, 0, 0, 1)");
         symbolManager.create(options);
+        symbolManager.updateSourceNow();
         verify(symbolLayer, times(1)).setProperties(argThat(new PropertyValueMatcher(iconColor(get("icon-color")))));
 
         symbolManager.create(options);
@@ -529,6 +548,7 @@ public class SymbolManagerTest {
 
         SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withIconHaloColor("rgba(0, 0, 0, 1)");
         symbolManager.create(options);
+        symbolManager.updateSourceNow();
         verify(symbolLayer, times(1)).setProperties(argThat(new PropertyValueMatcher(iconHaloColor(get("icon-halo-color")))));
 
         symbolManager.create(options);
@@ -542,6 +562,7 @@ public class SymbolManagerTest {
 
         SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withIconHaloWidth(2.0f);
         symbolManager.create(options);
+        symbolManager.updateSourceNow();
         verify(symbolLayer, times(1)).setProperties(argThat(new PropertyValueMatcher(iconHaloWidth(get("icon-halo-width")))));
 
         symbolManager.create(options);
@@ -555,6 +576,7 @@ public class SymbolManagerTest {
 
         SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withIconHaloBlur(2.0f);
         symbolManager.create(options);
+        symbolManager.updateSourceNow();
         verify(symbolLayer, times(1)).setProperties(argThat(new PropertyValueMatcher(iconHaloBlur(get("icon-halo-blur")))));
 
         symbolManager.create(options);
@@ -568,6 +590,7 @@ public class SymbolManagerTest {
 
         SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withTextOpacity(2.0f);
         symbolManager.create(options);
+        symbolManager.updateSourceNow();
         verify(symbolLayer, times(1)).setProperties(argThat(new PropertyValueMatcher(textOpacity(get("text-opacity")))));
 
         symbolManager.create(options);
@@ -581,6 +604,7 @@ public class SymbolManagerTest {
 
         SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withTextColor("rgba(0, 0, 0, 1)");
         symbolManager.create(options);
+        symbolManager.updateSourceNow();
         verify(symbolLayer, times(1)).setProperties(argThat(new PropertyValueMatcher(textColor(get("text-color")))));
 
         symbolManager.create(options);
@@ -594,6 +618,7 @@ public class SymbolManagerTest {
 
         SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withTextHaloColor("rgba(0, 0, 0, 1)");
         symbolManager.create(options);
+        symbolManager.updateSourceNow();
         verify(symbolLayer, times(1)).setProperties(argThat(new PropertyValueMatcher(textHaloColor(get("text-halo-color")))));
 
         symbolManager.create(options);
@@ -607,6 +632,7 @@ public class SymbolManagerTest {
 
         SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withTextHaloWidth(2.0f);
         symbolManager.create(options);
+        symbolManager.updateSourceNow();
         verify(symbolLayer, times(1)).setProperties(argThat(new PropertyValueMatcher(textHaloWidth(get("text-halo-width")))));
 
         symbolManager.create(options);
@@ -620,6 +646,7 @@ public class SymbolManagerTest {
 
         SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withTextHaloBlur(2.0f);
         symbolManager.create(options);
+        symbolManager.updateSourceNow();
         verify(symbolLayer, times(1)).setProperties(argThat(new PropertyValueMatcher(textHaloBlur(get("text-halo-blur")))));
 
         symbolManager.create(options);


### PR DESCRIPTION
The performance improvements from https://github.com/maplibre/maplibre-plugins-android/pull/12 were undone in https://github.com/maplibre/maplibre-plugins-android/pull/25#pullrequestreview-1557170506, thus have no effect. Hence, this PR re-adds them.

The effect of https://github.com/maplibre/maplibre-plugins-android/pull/30 is still in place, i.e. adding additional markers to the map while dragging another marker does not cancel the drag.

For the sake of clarity, the three methods `updateSource`, `postUpdateSource` and `internalUpdateSource` have been renamed to `updateSource` and `updateSourceNow`, the latter of which is documented not to be called except from `updateSource`. It is required for testing, as our tests now need to force the source to update immediately instead of delayed. `postUpdateSource` has been removed as it was an unnecessary indirection.

Tests should still pass as previously (one instrumentation test was and still is failing).

cc @RomanBapst @JonasVautherin