### PR TITLE
Fix Jitpack build and publish

### DIFF
--- a/gradle/artifact-settings.gradle
+++ b/gradle/artifact-settings.gradle
@@ -16,8 +16,7 @@ ext {
 def getVersionName() {
     def cmd = "git describe --tag --abbrev=0"
     def version = cmd.execute().text.trim()
-    return isSnapshot() ? getSnapshotVersion(version) : getReleaseVersion(version)
-}
+    return (version == null || version.isBlank()) ? "0.0.1" : isSnapshot() ? getSnapshotVersion(version) : getReleaseVersion(version)}
 
 def isSnapshot() {
     return project.hasProperty("snapshot")

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -13,12 +13,12 @@ task androidJavadocs(type: Javadoc) {
 }
 
 task androidJavadocsJar(type: Jar, dependsOn: androidJavadocs) {
-    classifier = 'dokka'
+    archiveClassifier = 'dokka'
     from androidJavadocs.destinationDir
 }
 
 task androidSourcesJar(type: Jar) {
-    classifier = 'sources'
+    archiveClassifier = 'sources'
     from android.sourceSets.main.java.sourceFiles
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.2-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,1 @@
+jdk: openjdk11


### PR DESCRIPTION
This almost works 
- force jdk 11 during build, otherwise gradle plugin fails
- update deprecated field name which causes error instead of warning
- bump gradle to benefit from recommended patch release

Currently the build fails because it's trying to find `/home/jitpack/build/signing-key.gpg`, maybe somebody can help with this? 
If I comment out the signing it's fine