### PR TITLE
Fix dragging ordering

### DIFF
--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/AnnotationManager.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/AnnotationManager.java
@@ -88,9 +88,9 @@ public abstract class AnnotationManager<
 
         mapboxMap.addOnMapClickListener(mapClickResolver = new MapClickResolver());
         mapboxMap.addOnMapLongClickListener(mapClickResolver);
-        draggableAnnotationController.addAnnotationManager(this);
 
         initializeSourcesAndLayers(geoJsonOptions);
+        draggableAnnotationController.addAnnotationManager(this);
 
         mapView.addOnDidFinishLoadingStyleListener(new MapView.OnDidFinishLoadingStyleListener() {
             @Override
@@ -116,6 +116,14 @@ public abstract class AnnotationManager<
      */
     public String getLayerId() {
         return layer.getId();
+    }
+
+    public String getBelowLayerId() {
+        return belowLayerId;
+    }
+
+    public String getAboveLayerId() {
+        return aboveLayerId;
     }
 
     /**


### PR DESCRIPTION
Resolves https://github.com/maplibre/maplibre-plugins-android/issues/44.

This now orders the `annotationManagers` according to their vertical order (using the `belowLayer` and `aboveLayer`).

Tested by @RomanBapst and I (on two different apps, both with [ramani-maps](https://github.com/ramani-maps/ramani-maps/) and a pure Maplibre-Android app).

See the sample code of #44 with the fix here:

https://github.com/maplibre/maplibre-plugins-android/assets/2606672/e5c9ce45-090b-4c4b-92b4-0190e88e6eb5

