### PR TITLE
Update Plugins for MapLibre Native Android v11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       BUILDTYPE: Release
       IS_LOCAL_DEVELOPMENT: false
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
           fetch-depth: 0

--- a/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/BaseActivityTest.java
+++ b/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/BaseActivityTest.java
@@ -5,7 +5,6 @@ import android.content.Context;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 
-import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.plugins.annotation.MapboxMapAction;
 import com.mapbox.mapboxsdk.plugins.annotation.WaitAction;
 import com.mapbox.mapboxsdk.plugins.utils.OnMapReadyIdlingResource;
@@ -16,6 +15,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.rules.TestName;
+import org.maplibre.android.maps.MapLibreMap;
 
 import androidx.test.espresso.Espresso;
 import androidx.test.espresso.IdlingRegistry;
@@ -38,7 +38,7 @@ public abstract class BaseActivityTest {
     @Rule
     public TestName testName = new TestName();
 
-    protected MapboxMap mapboxMap;
+    protected MapLibreMap mapboxMap;
     protected OnMapReadyIdlingResource idlingResource;
 
     @Before
@@ -63,7 +63,7 @@ public abstract class BaseActivityTest {
         Assert.assertNotNull(mapboxMap);
     }
 
-    protected MapboxMap getMapboxMap() {
+    protected MapLibreMap getMapboxMap() {
         return mapboxMap;
     }
 

--- a/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/BaseActivityTest.java
+++ b/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/BaseActivityTest.java
@@ -47,7 +47,7 @@ public abstract class BaseActivityTest {
             Timber.e("@Before %s: register idle resource", testName.getMethodName());
             IdlingRegistry.getInstance().register(idlingResource = new OnMapReadyIdlingResource(rule.getActivity()));
             Espresso.onIdle();
-            mapboxMap = idlingResource.getMapboxMap();
+            mapboxMap = idlingResource.getMapLibreMap();
         } catch (IdlingResourceTimeoutException idlingResourceTimeoutException) {
             throw new RuntimeException(String.format("Could not start %s test for %s.\n  Either the ViewHierarchy doesn't "
                     + "contain a view with resource id = R.id.mapView or \n the hosting Activity wasn't in an idle state.",

--- a/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/BaseActivityTest.java
+++ b/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/BaseActivityTest.java
@@ -38,7 +38,7 @@ public abstract class BaseActivityTest {
     @Rule
     public TestName testName = new TestName();
 
-    protected MapLibreMap mapboxMap;
+    protected MapLibreMap maplibreMap;
     protected OnMapReadyIdlingResource idlingResource;
 
     @Before
@@ -47,7 +47,7 @@ public abstract class BaseActivityTest {
             Timber.e("@Before %s: register idle resource", testName.getMethodName());
             IdlingRegistry.getInstance().register(idlingResource = new OnMapReadyIdlingResource(rule.getActivity()));
             Espresso.onIdle();
-            mapboxMap = idlingResource.getMapLibreMap();
+            maplibreMap = idlingResource.getMapLibreMap();
         } catch (IdlingResourceTimeoutException idlingResourceTimeoutException) {
             throw new RuntimeException(String.format("Could not start %s test for %s.\n  Either the ViewHierarchy doesn't "
                     + "contain a view with resource id = R.id.mapView or \n the hosting Activity wasn't in an idle state.",
@@ -60,11 +60,11 @@ public abstract class BaseActivityTest {
     protected void validateTestSetup() {
         Assert.assertTrue("Device is not connected to the Internet.", isConnected(rule.getActivity()));
         checkViewIsDisplayed(android.R.id.content);
-        Assert.assertNotNull(mapboxMap);
+        Assert.assertNotNull(maplibreMap);
     }
 
     protected MapLibreMap getMapboxMap() {
-        return mapboxMap;
+        return maplibreMap;
     }
 
     protected abstract Class getActivityClass();
@@ -93,7 +93,7 @@ public abstract class BaseActivityTest {
     }
 
     protected MapboxMapAction getMapboxMapAction(MapboxMapAction.OnInvokeActionListener onInvokeActionListener) {
-        return new MapboxMapAction(onInvokeActionListener, mapboxMap);
+        return new MapboxMapAction(onInvokeActionListener, maplibreMap);
     }
 
     @After

--- a/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/annotation/CircleManagerTest.java
+++ b/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/annotation/CircleManagerTest.java
@@ -34,8 +34,8 @@ public class CircleManagerTest extends BaseActivityTest {
 
     private void setupCircleManager() {
         Timber.i("Retrieving layer");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
-            circleManager = new CircleManager(idlingResource.getMapView(), mapboxMap, Objects.requireNonNull(mapboxMap.getStyle()));
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
+            circleManager = new CircleManager(idlingResource.getMapView(), maplibreMap, Objects.requireNonNull(maplibreMap.getStyle()));
         });
     }
 
@@ -44,7 +44,7 @@ public class CircleManagerTest extends BaseActivityTest {
         validateTestSetup();
         setupCircleManager();
         Timber.i("circle-translate");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertNotNull(circleManager);
 
             circleManager.setCircleTranslate(new Float[]{0f, 0f});
@@ -57,7 +57,7 @@ public class CircleManagerTest extends BaseActivityTest {
         validateTestSetup();
         setupCircleManager();
         Timber.i("circle-translate-anchor");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertNotNull(circleManager);
 
             circleManager.setCircleTranslateAnchor(CIRCLE_TRANSLATE_ANCHOR_MAP);
@@ -70,7 +70,7 @@ public class CircleManagerTest extends BaseActivityTest {
         validateTestSetup();
         setupCircleManager();
         Timber.i("circle-pitch-scale");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertNotNull(circleManager);
 
             circleManager.setCirclePitchScale(CIRCLE_PITCH_SCALE_MAP);
@@ -83,7 +83,7 @@ public class CircleManagerTest extends BaseActivityTest {
         validateTestSetup();
         setupCircleManager();
         Timber.i("circle-pitch-alignment");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertNotNull(circleManager);
 
             circleManager.setCirclePitchAlignment(CIRCLE_PITCH_ALIGNMENT_MAP);

--- a/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/annotation/CircleManagerTest.java
+++ b/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/annotation/CircleManagerTest.java
@@ -4,7 +4,7 @@ package com.mapbox.mapboxsdk.plugins.annotation;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
-import com.mapbox.mapboxsdk.geometry.LatLng;
+import org.maplibre.android.geometry.LatLng;
 import com.mapbox.mapboxsdk.plugins.testapp.activity.TestActivity;
 import com.mapbox.mapboxsdk.plugins.BaseActivityTest;
 
@@ -17,7 +17,7 @@ import java.util.Objects;
 
 import static com.mapbox.mapboxsdk.plugins.annotation.MapboxMapAction.invoke;
 import static org.junit.Assert.*;
-import static com.mapbox.mapboxsdk.style.layers.Property.*;
+import static org.maplibre.android.style.layers.Property.*;
 
 /**
  * Basic smoke tests for CircleManager

--- a/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/annotation/CircleTest.java
+++ b/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/annotation/CircleTest.java
@@ -10,7 +10,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 import org.maplibre.android.geometry.LatLng;
 import com.mapbox.mapboxsdk.plugins.BaseActivityTest;
 import com.mapbox.mapboxsdk.plugins.testapp.activity.TestActivity;
-import com.mapbox.mapboxsdk.utils.ColorUtils;
+import org.maplibre.android.utils.ColorUtils;
 
 import timber.log.Timber;
 

--- a/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/annotation/CircleTest.java
+++ b/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/annotation/CircleTest.java
@@ -1,3 +1,4 @@
+
 // This file is generated.
 
 package com.mapbox.mapboxsdk.plugins.annotation;
@@ -6,7 +7,7 @@ import android.graphics.PointF;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
-import com.mapbox.mapboxsdk.geometry.LatLng;
+import org.maplibre.android.geometry.LatLng;
 import com.mapbox.mapboxsdk.plugins.BaseActivityTest;
 import com.mapbox.mapboxsdk.plugins.testapp.activity.TestActivity;
 import com.mapbox.mapboxsdk.utils.ColorUtils;
@@ -20,7 +21,7 @@ import java.util.Objects;
 
 import static com.mapbox.mapboxsdk.plugins.annotation.MapboxMapAction.invoke;
 import static org.junit.Assert.*;
-import static com.mapbox.mapboxsdk.style.layers.Property.*;
+import static org.maplibre.android.style.layers.Property.*;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/annotation/CircleTest.java
+++ b/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/annotation/CircleTest.java
@@ -41,8 +41,8 @@ public class CircleTest extends BaseActivityTest {
 
     private void setupAnnotation() {
         Timber.i("Retrieving layer");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
-            CircleManager circleManager = new CircleManager(idlingResource.getMapView(), mapboxMap, Objects.requireNonNull(mapboxMap.getStyle()));
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
+            CircleManager circleManager = new CircleManager(idlingResource.getMapView(), maplibreMap, Objects.requireNonNull(maplibreMap.getStyle()));
             circle = circleManager.create(new CircleOptions().withLatLng(new LatLng()));
         });
     }
@@ -52,7 +52,7 @@ public class CircleTest extends BaseActivityTest {
         validateTestSetup();
         setupAnnotation();
         Timber.i("circle-radius");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertNotNull(circle);
 
             circle.setCircleRadius(2.0f);
@@ -65,7 +65,7 @@ public class CircleTest extends BaseActivityTest {
         validateTestSetup();
         setupAnnotation();
         Timber.i("circle-color");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertNotNull(circle);
 
             circle.setCircleColor("rgba(0, 0, 0, 1)");
@@ -78,7 +78,7 @@ public class CircleTest extends BaseActivityTest {
         validateTestSetup();
         setupAnnotation();
         Timber.i("circle-color");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertNotNull(circle);
             circle.setCircleColor(ColorUtils.rgbaToColor("rgba(0, 0, 0, 1)"));
             assertEquals(circle.getCircleColorAsInt(), ColorUtils.rgbaToColor("rgba(0, 0, 0, 1)"));
@@ -91,7 +91,7 @@ public class CircleTest extends BaseActivityTest {
         validateTestSetup();
         setupAnnotation();
         Timber.i("circle-blur");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertNotNull(circle);
 
             circle.setCircleBlur(2.0f);
@@ -104,7 +104,7 @@ public class CircleTest extends BaseActivityTest {
         validateTestSetup();
         setupAnnotation();
         Timber.i("circle-opacity");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertNotNull(circle);
 
             circle.setCircleOpacity(2.0f);
@@ -117,7 +117,7 @@ public class CircleTest extends BaseActivityTest {
         validateTestSetup();
         setupAnnotation();
         Timber.i("circle-stroke-width");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertNotNull(circle);
 
             circle.setCircleStrokeWidth(2.0f);
@@ -130,7 +130,7 @@ public class CircleTest extends BaseActivityTest {
         validateTestSetup();
         setupAnnotation();
         Timber.i("circle-stroke-color");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertNotNull(circle);
 
             circle.setCircleStrokeColor("rgba(0, 0, 0, 1)");
@@ -143,7 +143,7 @@ public class CircleTest extends BaseActivityTest {
         validateTestSetup();
         setupAnnotation();
         Timber.i("circle-stroke-color");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertNotNull(circle);
             circle.setCircleStrokeColor(ColorUtils.rgbaToColor("rgba(0, 0, 0, 1)"));
             assertEquals(circle.getCircleStrokeColorAsInt(), ColorUtils.rgbaToColor("rgba(0, 0, 0, 1)"));
@@ -156,7 +156,7 @@ public class CircleTest extends BaseActivityTest {
         validateTestSetup();
         setupAnnotation();
         Timber.i("circle-stroke-opacity");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertNotNull(circle);
 
             circle.setCircleStrokeOpacity(2.0f);

--- a/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/annotation/FillManagerTest.java
+++ b/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/annotation/FillManagerTest.java
@@ -34,8 +34,8 @@ public class FillManagerTest extends BaseActivityTest {
 
     private void setupFillManager() {
         Timber.i("Retrieving layer");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
-            fillManager = new FillManager(idlingResource.getMapView(), mapboxMap, Objects.requireNonNull(mapboxMap.getStyle()));
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
+            fillManager = new FillManager(idlingResource.getMapView(), maplibreMap, Objects.requireNonNull(maplibreMap.getStyle()));
         });
     }
 
@@ -44,7 +44,7 @@ public class FillManagerTest extends BaseActivityTest {
         validateTestSetup();
         setupFillManager();
         Timber.i("fill-antialias");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertNotNull(fillManager);
 
             fillManager.setFillAntialias(true);
@@ -57,7 +57,7 @@ public class FillManagerTest extends BaseActivityTest {
         validateTestSetup();
         setupFillManager();
         Timber.i("fill-translate");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertNotNull(fillManager);
 
             fillManager.setFillTranslate(new Float[]{0f, 0f});
@@ -70,7 +70,7 @@ public class FillManagerTest extends BaseActivityTest {
         validateTestSetup();
         setupFillManager();
         Timber.i("fill-translate-anchor");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertNotNull(fillManager);
 
             fillManager.setFillTranslateAnchor(FILL_TRANSLATE_ANCHOR_MAP);

--- a/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/annotation/FillManagerTest.java
+++ b/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/annotation/FillManagerTest.java
@@ -4,7 +4,7 @@ package com.mapbox.mapboxsdk.plugins.annotation;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
-import com.mapbox.mapboxsdk.geometry.LatLng;
+import org.maplibre.android.geometry.LatLng;
 import com.mapbox.mapboxsdk.plugins.testapp.activity.TestActivity;
 import com.mapbox.mapboxsdk.plugins.BaseActivityTest;
 
@@ -17,7 +17,7 @@ import java.util.Objects;
 
 import static com.mapbox.mapboxsdk.plugins.annotation.MapboxMapAction.invoke;
 import static org.junit.Assert.*;
-import static com.mapbox.mapboxsdk.style.layers.Property.*;
+import static org.maplibre.android.style.layers.Property.*;
 
 /**
  * Basic smoke tests for FillManager

--- a/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/annotation/FillTest.java
+++ b/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/annotation/FillTest.java
@@ -41,8 +41,8 @@ public class FillTest extends BaseActivityTest {
 
     private void setupAnnotation() {
         Timber.i("Retrieving layer");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
-            FillManager fillManager = new FillManager(idlingResource.getMapView(), mapboxMap, Objects.requireNonNull(mapboxMap.getStyle()));
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
+            FillManager fillManager = new FillManager(idlingResource.getMapView(), maplibreMap, Objects.requireNonNull(maplibreMap.getStyle()));
             List<LatLng> innerLatLngs = new ArrayList<>();
             innerLatLngs.add(new LatLng());
             innerLatLngs.add(new LatLng(1, 1));
@@ -58,7 +58,7 @@ public class FillTest extends BaseActivityTest {
         validateTestSetup();
         setupAnnotation();
         Timber.i("fill-opacity");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertNotNull(fill);
 
             fill.setFillOpacity(2.0f);
@@ -71,7 +71,7 @@ public class FillTest extends BaseActivityTest {
         validateTestSetup();
         setupAnnotation();
         Timber.i("fill-color");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertNotNull(fill);
 
             fill.setFillColor("rgba(0, 0, 0, 1)");
@@ -84,7 +84,7 @@ public class FillTest extends BaseActivityTest {
         validateTestSetup();
         setupAnnotation();
         Timber.i("fill-color");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertNotNull(fill);
             fill.setFillColor(ColorUtils.rgbaToColor("rgba(0, 0, 0, 1)"));
             assertEquals(fill.getFillColorAsInt(), ColorUtils.rgbaToColor("rgba(0, 0, 0, 1)"));
@@ -97,7 +97,7 @@ public class FillTest extends BaseActivityTest {
         validateTestSetup();
         setupAnnotation();
         Timber.i("fill-outline-color");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertNotNull(fill);
 
             fill.setFillOutlineColor("rgba(0, 0, 0, 1)");
@@ -110,7 +110,7 @@ public class FillTest extends BaseActivityTest {
         validateTestSetup();
         setupAnnotation();
         Timber.i("fill-outline-color");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertNotNull(fill);
             fill.setFillOutlineColor(ColorUtils.rgbaToColor("rgba(0, 0, 0, 1)"));
             assertEquals(fill.getFillOutlineColorAsInt(), ColorUtils.rgbaToColor("rgba(0, 0, 0, 1)"));
@@ -123,7 +123,7 @@ public class FillTest extends BaseActivityTest {
         validateTestSetup();
         setupAnnotation();
         Timber.i("fill-pattern");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertNotNull(fill);
 
             fill.setFillPattern("pedestrian-polygon");

--- a/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/annotation/FillTest.java
+++ b/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/annotation/FillTest.java
@@ -10,7 +10,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 import org.maplibre.android.geometry.LatLng;
 import com.mapbox.mapboxsdk.plugins.BaseActivityTest;
 import com.mapbox.mapboxsdk.plugins.testapp.activity.TestActivity;
-import com.mapbox.mapboxsdk.utils.ColorUtils;
+import org.maplibre.android.utils.ColorUtils;
 
 import timber.log.Timber;
 

--- a/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/annotation/FillTest.java
+++ b/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/annotation/FillTest.java
@@ -1,3 +1,4 @@
+
 // This file is generated.
 
 package com.mapbox.mapboxsdk.plugins.annotation;
@@ -6,7 +7,7 @@ import android.graphics.PointF;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
-import com.mapbox.mapboxsdk.geometry.LatLng;
+import org.maplibre.android.geometry.LatLng;
 import com.mapbox.mapboxsdk.plugins.BaseActivityTest;
 import com.mapbox.mapboxsdk.plugins.testapp.activity.TestActivity;
 import com.mapbox.mapboxsdk.utils.ColorUtils;
@@ -20,7 +21,7 @@ import java.util.Objects;
 
 import static com.mapbox.mapboxsdk.plugins.annotation.MapboxMapAction.invoke;
 import static org.junit.Assert.*;
-import static com.mapbox.mapboxsdk.style.layers.Property.*;
+import static org.maplibre.android.style.layers.Property.*;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/annotation/LineManagerTest.java
+++ b/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/annotation/LineManagerTest.java
@@ -4,7 +4,7 @@ package com.mapbox.mapboxsdk.plugins.annotation;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
-import com.mapbox.mapboxsdk.geometry.LatLng;
+import org.maplibre.android.geometry.LatLng;
 import com.mapbox.mapboxsdk.plugins.testapp.activity.TestActivity;
 import com.mapbox.mapboxsdk.plugins.BaseActivityTest;
 
@@ -17,7 +17,7 @@ import java.util.Objects;
 
 import static com.mapbox.mapboxsdk.plugins.annotation.MapboxMapAction.invoke;
 import static org.junit.Assert.*;
-import static com.mapbox.mapboxsdk.style.layers.Property.*;
+import static org.maplibre.android.style.layers.Property.*;
 
 /**
  * Basic smoke tests for LineManager

--- a/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/annotation/LineManagerTest.java
+++ b/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/annotation/LineManagerTest.java
@@ -34,8 +34,8 @@ public class LineManagerTest extends BaseActivityTest {
 
     private void setupLineManager() {
         Timber.i("Retrieving layer");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
-            lineManager = new LineManager(idlingResource.getMapView(), mapboxMap, Objects.requireNonNull(mapboxMap.getStyle()));
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
+            lineManager = new LineManager(idlingResource.getMapView(), maplibreMap, Objects.requireNonNull(maplibreMap.getStyle()));
         });
     }
 
@@ -44,7 +44,7 @@ public class LineManagerTest extends BaseActivityTest {
         validateTestSetup();
         setupLineManager();
         Timber.i("line-cap");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertNotNull(lineManager);
 
             lineManager.setLineCap(LINE_CAP_BUTT);
@@ -57,7 +57,7 @@ public class LineManagerTest extends BaseActivityTest {
         validateTestSetup();
         setupLineManager();
         Timber.i("line-miter-limit");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertNotNull(lineManager);
 
             lineManager.setLineMiterLimit(2.0f);
@@ -70,7 +70,7 @@ public class LineManagerTest extends BaseActivityTest {
         validateTestSetup();
         setupLineManager();
         Timber.i("line-round-limit");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertNotNull(lineManager);
 
             lineManager.setLineRoundLimit(2.0f);
@@ -83,7 +83,7 @@ public class LineManagerTest extends BaseActivityTest {
         validateTestSetup();
         setupLineManager();
         Timber.i("line-translate");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertNotNull(lineManager);
 
             lineManager.setLineTranslate(new Float[]{0f, 0f});
@@ -96,7 +96,7 @@ public class LineManagerTest extends BaseActivityTest {
         validateTestSetup();
         setupLineManager();
         Timber.i("line-translate-anchor");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertNotNull(lineManager);
 
             lineManager.setLineTranslateAnchor(LINE_TRANSLATE_ANCHOR_MAP);
@@ -109,7 +109,7 @@ public class LineManagerTest extends BaseActivityTest {
         validateTestSetup();
         setupLineManager();
         Timber.i("line-dasharray");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertNotNull(lineManager);
 
             lineManager.setLineDasharray(new Float[]{});

--- a/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/annotation/LineTest.java
+++ b/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/annotation/LineTest.java
@@ -41,8 +41,8 @@ public class LineTest extends BaseActivityTest {
 
     private void setupAnnotation() {
         Timber.i("Retrieving layer");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
-            LineManager lineManager = new LineManager(idlingResource.getMapView(), mapboxMap, Objects.requireNonNull(mapboxMap.getStyle()));
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
+            LineManager lineManager = new LineManager(idlingResource.getMapView(), maplibreMap, Objects.requireNonNull(maplibreMap.getStyle()));
             List<LatLng> latLngs = new ArrayList<>();
             latLngs.add(new LatLng());
             latLngs.add(new LatLng(1, 1));
@@ -55,7 +55,7 @@ public class LineTest extends BaseActivityTest {
         validateTestSetup();
         setupAnnotation();
         Timber.i("line-join");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertNotNull(line);
 
             line.setLineJoin(LINE_JOIN_BEVEL);
@@ -68,7 +68,7 @@ public class LineTest extends BaseActivityTest {
         validateTestSetup();
         setupAnnotation();
         Timber.i("line-opacity");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertNotNull(line);
 
             line.setLineOpacity(2.0f);
@@ -81,7 +81,7 @@ public class LineTest extends BaseActivityTest {
         validateTestSetup();
         setupAnnotation();
         Timber.i("line-color");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertNotNull(line);
 
             line.setLineColor("rgba(0, 0, 0, 1)");
@@ -94,7 +94,7 @@ public class LineTest extends BaseActivityTest {
         validateTestSetup();
         setupAnnotation();
         Timber.i("line-color");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertNotNull(line);
             line.setLineColor(ColorUtils.rgbaToColor("rgba(0, 0, 0, 1)"));
             assertEquals(line.getLineColorAsInt(), ColorUtils.rgbaToColor("rgba(0, 0, 0, 1)"));
@@ -107,7 +107,7 @@ public class LineTest extends BaseActivityTest {
         validateTestSetup();
         setupAnnotation();
         Timber.i("line-width");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertNotNull(line);
 
             line.setLineWidth(2.0f);
@@ -120,7 +120,7 @@ public class LineTest extends BaseActivityTest {
         validateTestSetup();
         setupAnnotation();
         Timber.i("line-gap-width");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertNotNull(line);
 
             line.setLineGapWidth(2.0f);
@@ -133,7 +133,7 @@ public class LineTest extends BaseActivityTest {
         validateTestSetup();
         setupAnnotation();
         Timber.i("line-offset");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertNotNull(line);
 
             line.setLineOffset(2.0f);
@@ -146,7 +146,7 @@ public class LineTest extends BaseActivityTest {
         validateTestSetup();
         setupAnnotation();
         Timber.i("line-blur");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertNotNull(line);
 
             line.setLineBlur(2.0f);
@@ -159,7 +159,7 @@ public class LineTest extends BaseActivityTest {
         validateTestSetup();
         setupAnnotation();
         Timber.i("line-pattern");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertNotNull(line);
 
             line.setLinePattern("pedestrian-polygon");

--- a/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/annotation/LineTest.java
+++ b/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/annotation/LineTest.java
@@ -10,7 +10,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 import org.maplibre.android.geometry.LatLng;
 import com.mapbox.mapboxsdk.plugins.BaseActivityTest;
 import com.mapbox.mapboxsdk.plugins.testapp.activity.TestActivity;
-import com.mapbox.mapboxsdk.utils.ColorUtils;
+import org.maplibre.android.utils.ColorUtils;
 
 import timber.log.Timber;
 

--- a/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/annotation/LineTest.java
+++ b/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/annotation/LineTest.java
@@ -1,3 +1,4 @@
+
 // This file is generated.
 
 package com.mapbox.mapboxsdk.plugins.annotation;
@@ -6,7 +7,7 @@ import android.graphics.PointF;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
-import com.mapbox.mapboxsdk.geometry.LatLng;
+import org.maplibre.android.geometry.LatLng;
 import com.mapbox.mapboxsdk.plugins.BaseActivityTest;
 import com.mapbox.mapboxsdk.plugins.testapp.activity.TestActivity;
 import com.mapbox.mapboxsdk.utils.ColorUtils;
@@ -20,7 +21,7 @@ import java.util.Objects;
 
 import static com.mapbox.mapboxsdk.plugins.annotation.MapboxMapAction.invoke;
 import static org.junit.Assert.*;
-import static com.mapbox.mapboxsdk.style.layers.Property.*;
+import static org.maplibre.android.style.layers.Property.*;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/annotation/MapboxMapAction.java
+++ b/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/annotation/MapboxMapAction.java
@@ -17,11 +17,11 @@ import static androidx.test.espresso.matcher.ViewMatchers.withId;
 public class MapboxMapAction implements ViewAction {
 
     private OnInvokeActionListener invokeViewAction;
-    private MapLibreMap mapboxMap;
+    private MapLibreMap maplibreMap;
 
-    public MapboxMapAction(OnInvokeActionListener invokeViewAction, MapLibreMap mapboxMap) {
+    public MapboxMapAction(OnInvokeActionListener invokeViewAction, MapLibreMap maplibreMap) {
         this.invokeViewAction = invokeViewAction;
-        this.mapboxMap = mapboxMap;
+        this.maplibreMap = maplibreMap;
     }
 
     @Override
@@ -36,15 +36,15 @@ public class MapboxMapAction implements ViewAction {
 
     @Override
     public void perform(UiController uiController, View view) {
-        invokeViewAction.onInvokeAction(uiController, mapboxMap);
+        invokeViewAction.onInvokeAction(uiController, maplibreMap);
     }
 
-    public static void invoke(MapLibreMap mapboxMap, OnInvokeActionListener invokeViewAction) {
-        onView(withId(android.R.id.content)).perform(new MapboxMapAction(invokeViewAction, mapboxMap));
+    public static void invoke(MapLibreMap maplibreMap, OnInvokeActionListener invokeViewAction) {
+        onView(withId(android.R.id.content)).perform(new MapboxMapAction(invokeViewAction, maplibreMap));
     }
 
     public interface OnInvokeActionListener {
-        void onInvokeAction(UiController uiController, MapLibreMap mapboxMap);
+        void onInvokeAction(UiController uiController, MapLibreMap maplibreMap);
     }
 }
 

--- a/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/annotation/MapboxMapAction.java
+++ b/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/annotation/MapboxMapAction.java
@@ -2,12 +2,13 @@ package com.mapbox.mapboxsdk.plugins.annotation;
 
 import android.view.View;
 
-import com.mapbox.mapboxsdk.maps.MapboxMap;
+import org.maplibre.android.maps.MapLibreMap;
 
 import org.hamcrest.Matcher;
 
 import androidx.test.espresso.UiController;
 import androidx.test.espresso.ViewAction;
+import org.maplibre.android.maps.MapLibreMap;
 
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
@@ -16,9 +17,9 @@ import static androidx.test.espresso.matcher.ViewMatchers.withId;
 public class MapboxMapAction implements ViewAction {
 
     private OnInvokeActionListener invokeViewAction;
-    private MapboxMap mapboxMap;
+    private MapLibreMap mapboxMap;
 
-    public MapboxMapAction(OnInvokeActionListener invokeViewAction, MapboxMap mapboxMap) {
+    public MapboxMapAction(OnInvokeActionListener invokeViewAction, MapLibreMap mapboxMap) {
         this.invokeViewAction = invokeViewAction;
         this.mapboxMap = mapboxMap;
     }
@@ -38,12 +39,12 @@ public class MapboxMapAction implements ViewAction {
         invokeViewAction.onInvokeAction(uiController, mapboxMap);
     }
 
-    public static void invoke(MapboxMap mapboxMap, OnInvokeActionListener invokeViewAction) {
+    public static void invoke(MapLibreMap mapboxMap, OnInvokeActionListener invokeViewAction) {
         onView(withId(android.R.id.content)).perform(new MapboxMapAction(invokeViewAction, mapboxMap));
     }
 
     public interface OnInvokeActionListener {
-        void onInvokeAction(UiController uiController, MapboxMap mapboxMap);
+        void onInvokeAction(UiController uiController, MapLibreMap mapboxMap);
     }
 }
 

--- a/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/annotation/SymbolManagerTest.java
+++ b/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/annotation/SymbolManagerTest.java
@@ -4,7 +4,7 @@ package com.mapbox.mapboxsdk.plugins.annotation;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
-import com.mapbox.mapboxsdk.geometry.LatLng;
+import org.maplibre.android.geometry.LatLng;
 import com.mapbox.mapboxsdk.plugins.testapp.activity.TestActivity;
 import com.mapbox.mapboxsdk.plugins.BaseActivityTest;
 
@@ -17,7 +17,7 @@ import java.util.Objects;
 
 import static com.mapbox.mapboxsdk.plugins.annotation.MapboxMapAction.invoke;
 import static org.junit.Assert.*;
-import static com.mapbox.mapboxsdk.style.layers.Property.*;
+import static org.maplibre.android.style.layers.Property.*;
 
 /**
  * Basic smoke tests for SymbolManager

--- a/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/annotation/SymbolManagerTest.java
+++ b/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/annotation/SymbolManagerTest.java
@@ -34,8 +34,8 @@ public class SymbolManagerTest extends BaseActivityTest {
 
     private void setupSymbolManager() {
         Timber.i("Retrieving layer");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
-            symbolManager = new SymbolManager(idlingResource.getMapView(), mapboxMap, Objects.requireNonNull(mapboxMap.getStyle()));
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
+            symbolManager = new SymbolManager(idlingResource.getMapView(), maplibreMap, Objects.requireNonNull(maplibreMap.getStyle()));
         });
     }
 
@@ -44,7 +44,7 @@ public class SymbolManagerTest extends BaseActivityTest {
         validateTestSetup();
         setupSymbolManager();
         Timber.i("symbol-placement");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertNotNull(symbolManager);
 
             symbolManager.setSymbolPlacement(SYMBOL_PLACEMENT_POINT);
@@ -57,7 +57,7 @@ public class SymbolManagerTest extends BaseActivityTest {
         validateTestSetup();
         setupSymbolManager();
         Timber.i("symbol-spacing");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertNotNull(symbolManager);
 
             symbolManager.setSymbolSpacing(2.0f);
@@ -70,7 +70,7 @@ public class SymbolManagerTest extends BaseActivityTest {
         validateTestSetup();
         setupSymbolManager();
         Timber.i("symbol-avoid-edges");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertNotNull(symbolManager);
 
             symbolManager.setSymbolAvoidEdges(true);
@@ -83,7 +83,7 @@ public class SymbolManagerTest extends BaseActivityTest {
         validateTestSetup();
         setupSymbolManager();
         Timber.i("icon-allow-overlap");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertNotNull(symbolManager);
 
             symbolManager.setIconAllowOverlap(true);
@@ -96,7 +96,7 @@ public class SymbolManagerTest extends BaseActivityTest {
         validateTestSetup();
         setupSymbolManager();
         Timber.i("icon-ignore-placement");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertNotNull(symbolManager);
 
             symbolManager.setIconIgnorePlacement(true);
@@ -109,7 +109,7 @@ public class SymbolManagerTest extends BaseActivityTest {
         validateTestSetup();
         setupSymbolManager();
         Timber.i("icon-optional");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertNotNull(symbolManager);
 
             symbolManager.setIconOptional(true);
@@ -122,7 +122,7 @@ public class SymbolManagerTest extends BaseActivityTest {
         validateTestSetup();
         setupSymbolManager();
         Timber.i("icon-rotation-alignment");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertNotNull(symbolManager);
 
             symbolManager.setIconRotationAlignment(ICON_ROTATION_ALIGNMENT_MAP);
@@ -135,7 +135,7 @@ public class SymbolManagerTest extends BaseActivityTest {
         validateTestSetup();
         setupSymbolManager();
         Timber.i("icon-text-fit");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertNotNull(symbolManager);
 
             symbolManager.setIconTextFit(ICON_TEXT_FIT_NONE);
@@ -148,7 +148,7 @@ public class SymbolManagerTest extends BaseActivityTest {
         validateTestSetup();
         setupSymbolManager();
         Timber.i("icon-text-fit-padding");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertNotNull(symbolManager);
 
             symbolManager.setIconTextFitPadding(new Float[]{0f, 0f, 0f, 0f});
@@ -161,7 +161,7 @@ public class SymbolManagerTest extends BaseActivityTest {
         validateTestSetup();
         setupSymbolManager();
         Timber.i("icon-padding");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertNotNull(symbolManager);
 
             symbolManager.setIconPadding(2.0f);
@@ -174,7 +174,7 @@ public class SymbolManagerTest extends BaseActivityTest {
         validateTestSetup();
         setupSymbolManager();
         Timber.i("icon-keep-upright");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertNotNull(symbolManager);
 
             symbolManager.setIconKeepUpright(true);
@@ -187,7 +187,7 @@ public class SymbolManagerTest extends BaseActivityTest {
         validateTestSetup();
         setupSymbolManager();
         Timber.i("icon-pitch-alignment");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertNotNull(symbolManager);
 
             symbolManager.setIconPitchAlignment(ICON_PITCH_ALIGNMENT_MAP);
@@ -200,7 +200,7 @@ public class SymbolManagerTest extends BaseActivityTest {
         validateTestSetup();
         setupSymbolManager();
         Timber.i("text-pitch-alignment");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertNotNull(symbolManager);
 
             symbolManager.setTextPitchAlignment(TEXT_PITCH_ALIGNMENT_MAP);
@@ -213,7 +213,7 @@ public class SymbolManagerTest extends BaseActivityTest {
         validateTestSetup();
         setupSymbolManager();
         Timber.i("text-rotation-alignment");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertNotNull(symbolManager);
 
             symbolManager.setTextRotationAlignment(TEXT_ROTATION_ALIGNMENT_MAP);
@@ -226,7 +226,7 @@ public class SymbolManagerTest extends BaseActivityTest {
         validateTestSetup();
         setupSymbolManager();
         Timber.i("text-line-height");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertNotNull(symbolManager);
 
             symbolManager.setTextLineHeight(2.0f);
@@ -239,7 +239,7 @@ public class SymbolManagerTest extends BaseActivityTest {
         validateTestSetup();
         setupSymbolManager();
         Timber.i("text-variable-anchor");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertNotNull(symbolManager);
 
             symbolManager.setTextVariableAnchor(new String[]{TEXT_ANCHOR_RIGHT, TEXT_ANCHOR_TOP});
@@ -252,7 +252,7 @@ public class SymbolManagerTest extends BaseActivityTest {
         validateTestSetup();
         setupSymbolManager();
         Timber.i("text-max-angle");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertNotNull(symbolManager);
 
             symbolManager.setTextMaxAngle(2.0f);
@@ -265,7 +265,7 @@ public class SymbolManagerTest extends BaseActivityTest {
         validateTestSetup();
         setupSymbolManager();
         Timber.i("text-padding");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertNotNull(symbolManager);
 
             symbolManager.setTextPadding(2.0f);
@@ -278,7 +278,7 @@ public class SymbolManagerTest extends BaseActivityTest {
         validateTestSetup();
         setupSymbolManager();
         Timber.i("text-keep-upright");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertNotNull(symbolManager);
 
             symbolManager.setTextKeepUpright(true);
@@ -291,7 +291,7 @@ public class SymbolManagerTest extends BaseActivityTest {
         validateTestSetup();
         setupSymbolManager();
         Timber.i("text-allow-overlap");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertNotNull(symbolManager);
 
             symbolManager.setTextAllowOverlap(true);
@@ -304,7 +304,7 @@ public class SymbolManagerTest extends BaseActivityTest {
         validateTestSetup();
         setupSymbolManager();
         Timber.i("text-ignore-placement");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertNotNull(symbolManager);
 
             symbolManager.setTextIgnorePlacement(true);
@@ -317,7 +317,7 @@ public class SymbolManagerTest extends BaseActivityTest {
         validateTestSetup();
         setupSymbolManager();
         Timber.i("text-optional");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertNotNull(symbolManager);
 
             symbolManager.setTextOptional(true);
@@ -330,7 +330,7 @@ public class SymbolManagerTest extends BaseActivityTest {
         validateTestSetup();
         setupSymbolManager();
         Timber.i("icon-translate");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertNotNull(symbolManager);
 
             symbolManager.setIconTranslate(new Float[]{0f, 0f});
@@ -343,7 +343,7 @@ public class SymbolManagerTest extends BaseActivityTest {
         validateTestSetup();
         setupSymbolManager();
         Timber.i("icon-translate-anchor");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertNotNull(symbolManager);
 
             symbolManager.setIconTranslateAnchor(ICON_TRANSLATE_ANCHOR_MAP);
@@ -356,7 +356,7 @@ public class SymbolManagerTest extends BaseActivityTest {
         validateTestSetup();
         setupSymbolManager();
         Timber.i("text-translate");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertNotNull(symbolManager);
 
             symbolManager.setTextTranslate(new Float[]{0f, 0f});
@@ -369,7 +369,7 @@ public class SymbolManagerTest extends BaseActivityTest {
         validateTestSetup();
         setupSymbolManager();
         Timber.i("text-translate-anchor");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertNotNull(symbolManager);
 
             symbolManager.setTextTranslateAnchor(TEXT_TRANSLATE_ANCHOR_MAP);

--- a/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/annotation/SymbolTest.java
+++ b/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/annotation/SymbolTest.java
@@ -10,7 +10,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 import org.maplibre.android.geometry.LatLng;
 import com.mapbox.mapboxsdk.plugins.BaseActivityTest;
 import com.mapbox.mapboxsdk.plugins.testapp.activity.TestActivity;
-import com.mapbox.mapboxsdk.utils.ColorUtils;
+import org.maplibre.android.utils.ColorUtils;
 
 import timber.log.Timber;
 

--- a/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/annotation/SymbolTest.java
+++ b/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/annotation/SymbolTest.java
@@ -1,3 +1,4 @@
+
 // This file is generated.
 
 package com.mapbox.mapboxsdk.plugins.annotation;
@@ -6,7 +7,7 @@ import android.graphics.PointF;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
-import com.mapbox.mapboxsdk.geometry.LatLng;
+import org.maplibre.android.geometry.LatLng;
 import com.mapbox.mapboxsdk.plugins.BaseActivityTest;
 import com.mapbox.mapboxsdk.plugins.testapp.activity.TestActivity;
 import com.mapbox.mapboxsdk.utils.ColorUtils;
@@ -20,7 +21,7 @@ import java.util.Objects;
 
 import static com.mapbox.mapboxsdk.plugins.annotation.MapboxMapAction.invoke;
 import static org.junit.Assert.*;
-import static com.mapbox.mapboxsdk.style.layers.Property.*;
+import static org.maplibre.android.style.layers.Property.*;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/annotation/SymbolTest.java
+++ b/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/annotation/SymbolTest.java
@@ -41,8 +41,8 @@ public class SymbolTest extends BaseActivityTest {
 
     private void setupAnnotation() {
         Timber.i("Retrieving layer");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
-            SymbolManager symbolManager = new SymbolManager(idlingResource.getMapView(), mapboxMap, Objects.requireNonNull(mapboxMap.getStyle()));
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
+            SymbolManager symbolManager = new SymbolManager(idlingResource.getMapView(), maplibreMap, Objects.requireNonNull(maplibreMap.getStyle()));
             symbol = symbolManager.create(new SymbolOptions().withLatLng(new LatLng()));
         });
     }
@@ -52,7 +52,7 @@ public class SymbolTest extends BaseActivityTest {
         validateTestSetup();
         setupAnnotation();
         Timber.i("symbol-sort-key");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertNotNull(symbol);
 
             symbol.setSymbolSortKey(2.0f);
@@ -65,7 +65,7 @@ public class SymbolTest extends BaseActivityTest {
         validateTestSetup();
         setupAnnotation();
         Timber.i("icon-size");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertNotNull(symbol);
 
             symbol.setIconSize(2.0f);
@@ -78,7 +78,7 @@ public class SymbolTest extends BaseActivityTest {
         validateTestSetup();
         setupAnnotation();
         Timber.i("icon-image");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertNotNull(symbol);
 
             symbol.setIconImage("undefined");
@@ -91,7 +91,7 @@ public class SymbolTest extends BaseActivityTest {
         validateTestSetup();
         setupAnnotation();
         Timber.i("icon-rotate");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertNotNull(symbol);
 
             symbol.setIconRotate(2.0f);
@@ -104,7 +104,7 @@ public class SymbolTest extends BaseActivityTest {
         validateTestSetup();
         setupAnnotation();
         Timber.i("icon-offset");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertNotNull(symbol);
 
             symbol.setIconOffset(new PointF(1.0f, 1.0f));
@@ -117,7 +117,7 @@ public class SymbolTest extends BaseActivityTest {
         validateTestSetup();
         setupAnnotation();
         Timber.i("icon-anchor");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertNotNull(symbol);
 
             symbol.setIconAnchor(ICON_ANCHOR_CENTER);
@@ -130,7 +130,7 @@ public class SymbolTest extends BaseActivityTest {
         validateTestSetup();
         setupAnnotation();
         Timber.i("text-field");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertNotNull(symbol);
 
             symbol.setTextField("");
@@ -143,7 +143,7 @@ public class SymbolTest extends BaseActivityTest {
         validateTestSetup();
         setupAnnotation();
         Timber.i("text-font");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertNotNull(symbol);
 
             symbol.setTextFont(new String[]{"Open Sans Regular", "Arial Unicode MS Regular"});
@@ -156,7 +156,7 @@ public class SymbolTest extends BaseActivityTest {
         validateTestSetup();
         setupAnnotation();
         Timber.i("text-size");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertNotNull(symbol);
 
             symbol.setTextSize(2.0f);
@@ -169,7 +169,7 @@ public class SymbolTest extends BaseActivityTest {
         validateTestSetup();
         setupAnnotation();
         Timber.i("text-max-width");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertNotNull(symbol);
 
             symbol.setTextMaxWidth(2.0f);
@@ -182,7 +182,7 @@ public class SymbolTest extends BaseActivityTest {
         validateTestSetup();
         setupAnnotation();
         Timber.i("text-letter-spacing");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertNotNull(symbol);
 
             symbol.setTextLetterSpacing(2.0f);
@@ -195,7 +195,7 @@ public class SymbolTest extends BaseActivityTest {
         validateTestSetup();
         setupAnnotation();
         Timber.i("text-justify");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertNotNull(symbol);
 
             symbol.setTextJustify(TEXT_JUSTIFY_AUTO);
@@ -208,7 +208,7 @@ public class SymbolTest extends BaseActivityTest {
         validateTestSetup();
         setupAnnotation();
         Timber.i("text-radial-offset");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertNotNull(symbol);
 
             symbol.setTextRadialOffset(2.0f);
@@ -221,7 +221,7 @@ public class SymbolTest extends BaseActivityTest {
         validateTestSetup();
         setupAnnotation();
         Timber.i("text-anchor");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertNotNull(symbol);
 
             symbol.setTextAnchor(TEXT_ANCHOR_CENTER);
@@ -234,7 +234,7 @@ public class SymbolTest extends BaseActivityTest {
         validateTestSetup();
         setupAnnotation();
         Timber.i("text-rotate");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertNotNull(symbol);
 
             symbol.setTextRotate(2.0f);
@@ -247,7 +247,7 @@ public class SymbolTest extends BaseActivityTest {
         validateTestSetup();
         setupAnnotation();
         Timber.i("text-transform");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertNotNull(symbol);
 
             symbol.setTextTransform(TEXT_TRANSFORM_NONE);
@@ -260,7 +260,7 @@ public class SymbolTest extends BaseActivityTest {
         validateTestSetup();
         setupAnnotation();
         Timber.i("text-offset");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertNotNull(symbol);
 
             symbol.setTextOffset(new PointF(1.0f, 1.0f));
@@ -273,7 +273,7 @@ public class SymbolTest extends BaseActivityTest {
         validateTestSetup();
         setupAnnotation();
         Timber.i("icon-opacity");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertNotNull(symbol);
 
             symbol.setIconOpacity(2.0f);
@@ -286,7 +286,7 @@ public class SymbolTest extends BaseActivityTest {
         validateTestSetup();
         setupAnnotation();
         Timber.i("icon-color");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertNotNull(symbol);
 
             symbol.setIconColor("rgba(0, 0, 0, 1)");
@@ -299,7 +299,7 @@ public class SymbolTest extends BaseActivityTest {
         validateTestSetup();
         setupAnnotation();
         Timber.i("icon-color");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertNotNull(symbol);
             symbol.setIconColor(ColorUtils.rgbaToColor("rgba(0, 0, 0, 1)"));
             assertEquals(symbol.getIconColorAsInt(), ColorUtils.rgbaToColor("rgba(0, 0, 0, 1)"));
@@ -312,7 +312,7 @@ public class SymbolTest extends BaseActivityTest {
         validateTestSetup();
         setupAnnotation();
         Timber.i("icon-halo-color");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertNotNull(symbol);
 
             symbol.setIconHaloColor("rgba(0, 0, 0, 1)");
@@ -325,7 +325,7 @@ public class SymbolTest extends BaseActivityTest {
         validateTestSetup();
         setupAnnotation();
         Timber.i("icon-halo-color");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertNotNull(symbol);
             symbol.setIconHaloColor(ColorUtils.rgbaToColor("rgba(0, 0, 0, 1)"));
             assertEquals(symbol.getIconHaloColorAsInt(), ColorUtils.rgbaToColor("rgba(0, 0, 0, 1)"));
@@ -338,7 +338,7 @@ public class SymbolTest extends BaseActivityTest {
         validateTestSetup();
         setupAnnotation();
         Timber.i("icon-halo-width");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertNotNull(symbol);
 
             symbol.setIconHaloWidth(2.0f);
@@ -351,7 +351,7 @@ public class SymbolTest extends BaseActivityTest {
         validateTestSetup();
         setupAnnotation();
         Timber.i("icon-halo-blur");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertNotNull(symbol);
 
             symbol.setIconHaloBlur(2.0f);
@@ -364,7 +364,7 @@ public class SymbolTest extends BaseActivityTest {
         validateTestSetup();
         setupAnnotation();
         Timber.i("text-opacity");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertNotNull(symbol);
 
             symbol.setTextOpacity(2.0f);
@@ -377,7 +377,7 @@ public class SymbolTest extends BaseActivityTest {
         validateTestSetup();
         setupAnnotation();
         Timber.i("text-color");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertNotNull(symbol);
 
             symbol.setTextColor("rgba(0, 0, 0, 1)");
@@ -390,7 +390,7 @@ public class SymbolTest extends BaseActivityTest {
         validateTestSetup();
         setupAnnotation();
         Timber.i("text-color");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertNotNull(symbol);
             symbol.setTextColor(ColorUtils.rgbaToColor("rgba(0, 0, 0, 1)"));
             assertEquals(symbol.getTextColorAsInt(), ColorUtils.rgbaToColor("rgba(0, 0, 0, 1)"));
@@ -403,7 +403,7 @@ public class SymbolTest extends BaseActivityTest {
         validateTestSetup();
         setupAnnotation();
         Timber.i("text-halo-color");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertNotNull(symbol);
 
             symbol.setTextHaloColor("rgba(0, 0, 0, 1)");
@@ -416,7 +416,7 @@ public class SymbolTest extends BaseActivityTest {
         validateTestSetup();
         setupAnnotation();
         Timber.i("text-halo-color");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertNotNull(symbol);
             symbol.setTextHaloColor(ColorUtils.rgbaToColor("rgba(0, 0, 0, 1)"));
             assertEquals(symbol.getTextHaloColorAsInt(), ColorUtils.rgbaToColor("rgba(0, 0, 0, 1)"));
@@ -429,7 +429,7 @@ public class SymbolTest extends BaseActivityTest {
         validateTestSetup();
         setupAnnotation();
         Timber.i("text-halo-width");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertNotNull(symbol);
 
             symbol.setTextHaloWidth(2.0f);
@@ -442,7 +442,7 @@ public class SymbolTest extends BaseActivityTest {
         validateTestSetup();
         setupAnnotation();
         Timber.i("text-halo-blur");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertNotNull(symbol);
 
             symbol.setTextHaloBlur(2.0f);

--- a/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/scalebar/ScaleBarTest.java
+++ b/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/scalebar/ScaleBarTest.java
@@ -42,8 +42,8 @@ public class ScaleBarTest extends BaseActivityTest {
 
     private void setupScaleBar() {
         Timber.i("Retrieving layer");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
-            scaleBarPlugin = new ScaleBarPlugin(idlingResource.getMapView(), mapboxMap);
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
+            scaleBarPlugin = new ScaleBarPlugin(idlingResource.getMapView(), maplibreMap);
             activity = rule.getActivity();
             scaleBarWidget = scaleBarPlugin.create(new ScaleBarOptions(activity));
             assertNotNull(scaleBarPlugin);
@@ -55,7 +55,7 @@ public class ScaleBarTest extends BaseActivityTest {
     public void testScaleBarEnable() {
         validateTestSetup();
         setupScaleBar();
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertEquals(View.VISIBLE, scaleBarWidget.getVisibility());
             assertTrue(scaleBarPlugin.isEnabled());
             scaleBarPlugin.setEnabled(false);
@@ -68,7 +68,7 @@ public class ScaleBarTest extends BaseActivityTest {
     public void testScaleBarColor() {
         validateTestSetup();
         setupScaleBar();
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertEquals(ContextCompat.getColor(activity, android.R.color.black), scaleBarWidget.getTextColor());
             assertEquals(ContextCompat.getColor(activity, android.R.color.black), scaleBarWidget.getPrimaryColor());
             assertEquals(ContextCompat.getColor(activity, android.R.color.white), scaleBarWidget.getSecondaryColor());
@@ -94,7 +94,7 @@ public class ScaleBarTest extends BaseActivityTest {
     public void testTextBorder() {
         validateTestSetup();
         setupScaleBar();
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertEquals(activity.getResources().getDimension(R.dimen.mapbox_scale_bar_text_border_width),
                 scaleBarWidget.getTextBorderWidth(), 0);
             assertTrue(scaleBarWidget.isShowTextBorder());
@@ -125,7 +125,7 @@ public class ScaleBarTest extends BaseActivityTest {
     public void testScaleBarWidth() {
         validateTestSetup();
         setupScaleBar();
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertEquals(MapView.class, scaleBarWidget.getParent().getClass());
             MapView parent = (MapView) scaleBarWidget.getParent();
             assertEquals(parent.getWidth(), scaleBarWidget.getMapViewWidth());
@@ -136,7 +136,7 @@ public class ScaleBarTest extends BaseActivityTest {
     public void testMargin() {
         validateTestSetup();
         setupScaleBar();
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertEquals(activity.getResources().getDimension(R.dimen.mapbox_scale_bar_margin_left),
                 scaleBarWidget.getMarginLeft(), 0);
             assertEquals(activity.getResources().getDimension(R.dimen.mapbox_scale_bar_margin_top),
@@ -174,7 +174,7 @@ public class ScaleBarTest extends BaseActivityTest {
     public void testBarHeight() {
         validateTestSetup();
         setupScaleBar();
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertEquals(activity.getResources().getDimension(R.dimen.mapbox_scale_bar_height),
                 scaleBarWidget.getBarHeight(), 0);
 
@@ -198,7 +198,7 @@ public class ScaleBarTest extends BaseActivityTest {
     public void testTextSize() {
         validateTestSetup();
         setupScaleBar();
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertEquals(activity.getResources().getDimension(R.dimen.mapbox_scale_bar_text_size),
                 scaleBarWidget.getTextSize(), 0);
 
@@ -222,7 +222,7 @@ public class ScaleBarTest extends BaseActivityTest {
     public void testBorderWidth() {
         validateTestSetup();
         setupScaleBar();
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertEquals(activity.getResources().getDimension(R.dimen.mapbox_scale_bar_border_width),
                 scaleBarWidget.getBorderWidth(), 0);
 
@@ -247,7 +247,7 @@ public class ScaleBarTest extends BaseActivityTest {
     public void testRefreshInterval() {
         validateTestSetup();
         setupScaleBar();
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertEquals(ScaleBarOptions.REFRESH_INTERVAL_DEFAULT, scaleBarWidget.getRefreshInterval(), 0);
 
             ScaleBarOptions option = new ScaleBarOptions(activity);
@@ -263,7 +263,7 @@ public class ScaleBarTest extends BaseActivityTest {
     public void testMetrics() {
         validateTestSetup();
         setupScaleBar();
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertEquals(ScaleBarOptions.LocaleUnitResolver.isMetricSystem(), scaleBarWidget.isMetricUnit());
 
             ScaleBarOptions option = new ScaleBarOptions(activity);
@@ -285,14 +285,14 @@ public class ScaleBarTest extends BaseActivityTest {
         validateTestSetup();
         setupScaleBar();
         assertEquals(0.5f, scaleBarWidget.getRatio(), 0f);
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             ScaleBarOptions option = new ScaleBarOptions(activity);
             option.setMaxWidthRatio(0.1f);
             scaleBarWidget = scaleBarPlugin.create(option);
             assertNotNull(scaleBarWidget);
             assertEquals(0.1f, scaleBarWidget.getRatio(), 0f);
         });
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             ScaleBarOptions option = new ScaleBarOptions(activity);
             option.setMaxWidthRatio(1.0f);
             scaleBarWidget = scaleBarPlugin.create(option);

--- a/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/scalebar/ScaleBarTest.java
+++ b/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/scalebar/ScaleBarTest.java
@@ -4,7 +4,6 @@ package com.mapbox.mapboxsdk.plugins.scalebar;
 import android.app.Activity;
 import android.view.View;
 
-import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.plugins.BaseActivityTest;
 import com.mapbox.mapboxsdk.plugins.testapp.R;
 import com.mapbox.mapboxsdk.plugins.testapp.activity.TestActivity;
@@ -14,6 +13,7 @@ import com.mapbox.pluginscalebar.ScaleBarWidget;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.maplibre.android.maps.MapView;
 
 import androidx.core.content.ContextCompat;
 import androidx.test.ext.junit.runners.AndroidJUnit4;

--- a/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/utils/OnMapReadyIdlingResource.java
+++ b/app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/utils/OnMapReadyIdlingResource.java
@@ -4,18 +4,19 @@ import android.app.Activity;
 import android.os.Handler;
 import android.os.Looper;
 
-import com.mapbox.mapboxsdk.maps.MapView;
-import com.mapbox.mapboxsdk.maps.MapboxMap;
-import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
-import com.mapbox.mapboxsdk.maps.Style;
 import com.mapbox.mapboxsdk.plugins.testapp.R;
 
 import androidx.annotation.NonNull;
 import androidx.test.espresso.IdlingResource;
 
+import org.maplibre.android.maps.MapLibreMap;
+import org.maplibre.android.maps.MapView;
+import org.maplibre.android.maps.OnMapReadyCallback;
+import org.maplibre.android.maps.Style;
+
 public class OnMapReadyIdlingResource implements IdlingResource, OnMapReadyCallback {
 
-    private MapboxMap mapboxMap;
+    private MapLibreMap mapLibreMap;
     private MapView mapView;
     private IdlingResource.ResourceCallback resourceCallback;
 
@@ -35,7 +36,7 @@ public class OnMapReadyIdlingResource implements IdlingResource, OnMapReadyCallb
 
     @Override
     public boolean isIdleNow() {
-        return mapboxMap != null && mapboxMap.getStyle() != null && mapboxMap.getStyle().isFullyLoaded();
+        return mapLibreMap != null && mapLibreMap.getStyle() != null && mapLibreMap.getStyle().isFullyLoaded();
     }
 
     @Override
@@ -47,14 +48,14 @@ public class OnMapReadyIdlingResource implements IdlingResource, OnMapReadyCallb
         return mapView;
     }
 
-    public MapboxMap getMapboxMap() {
-        return mapboxMap;
+    public MapLibreMap getMapLibreMap() {
+        return mapLibreMap;
     }
 
     @Override
-    public void onMapReady(@NonNull MapboxMap mapboxMap) {
-        this.mapboxMap = mapboxMap;
-        mapboxMap.setStyle(Style.getPredefinedStyle("Streets"), style -> {
+    public void onMapReady(@NonNull MapLibreMap mapLibreMap) {
+        this.mapLibreMap = mapLibreMap;
+        mapLibreMap.setStyle(Style.getPredefinedStyle("Streets"), style -> {
             if (resourceCallback != null) {
                 resourceCallback.onTransitionToIdle();
             }

--- a/app/src/debug/java/com/mapbox/mapboxsdk/plugins/testapp/activity/TestActivity.kt
+++ b/app/src/debug/java/com/mapbox/mapboxsdk/plugins/testapp/activity/TestActivity.kt
@@ -2,8 +2,8 @@ package com.mapbox.mapboxsdk.plugins.testapp.activity
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
-import com.mapbox.mapboxsdk.maps.MapView
 import com.mapbox.mapboxsdk.plugins.testapp.R
+import org.maplibre.android.maps.MapView
 
 class TestActivity : AppCompatActivity() {
 

--- a/app/src/debug/res/layout/activity_test.xml
+++ b/app/src/debug/res/layout/activity_test.xml
@@ -5,7 +5,7 @@
     android:layout_height="match_parent"
     tools:context=".activity.TestActivity">
 
-    <com.mapbox.mapboxsdk.maps.MapView
+    <org.maplibre.android.maps.MapView
         android:id="@+id/mapView"
         android:layout_width="match_parent"
         android:layout_height="match_parent" />

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/PluginApplication.kt
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/PluginApplication.kt
@@ -1,8 +1,8 @@
 package com.mapbox.mapboxsdk.plugins.testapp
 
 import android.app.Application
-import com.mapbox.mapboxsdk.Mapbox
 import com.squareup.leakcanary.LeakCanary
+import org.maplibre.android.MapLibre
 import timber.log.Timber
 
 class PluginApplication : Application() {
@@ -15,7 +15,7 @@ class PluginApplication : Application() {
 
         LeakCanary.install(this)
         initializeLogger()
-        Mapbox.getInstance(this)
+        MapLibre.getInstance(this)
     }
 
     private fun initializeLogger() {

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/Utils.kt
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/Utils.kt
@@ -3,7 +3,7 @@ package com.mapbox.mapboxsdk.plugins.testapp
 import android.content.Context
 import android.location.Location
 import com.mapbox.core.utils.TextUtils
-import com.mapbox.mapboxsdk.maps.Style
+import org.maplibre.android.maps.Style
 import timber.log.Timber
 import java.io.BufferedReader
 import java.io.IOException

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/BulkSymbolActivity.java
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/BulkSymbolActivity.java
@@ -15,22 +15,23 @@ import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
 import android.widget.Spinner;
 
-import com.mapbox.geojson.Feature;
-import com.mapbox.geojson.FeatureCollection;
-import com.mapbox.geojson.Point;
-import com.mapbox.mapboxsdk.Mapbox;
-import com.mapbox.mapboxsdk.WellKnownTileServer;
-import com.mapbox.mapboxsdk.camera.CameraUpdateFactory;
-import com.mapbox.mapboxsdk.geometry.LatLng;
-import com.mapbox.mapboxsdk.maps.MapView;
-import com.mapbox.mapboxsdk.maps.MapboxMap;
-import com.mapbox.mapboxsdk.maps.Style;
 import com.mapbox.mapboxsdk.plugins.annotation.Symbol;
 import com.mapbox.mapboxsdk.plugins.annotation.SymbolManager;
 import com.mapbox.mapboxsdk.plugins.annotation.SymbolOptions;
 import com.mapbox.mapboxsdk.plugins.testapp.BuildConfig;
 import com.mapbox.mapboxsdk.plugins.testapp.R;
 import com.mapbox.mapboxsdk.plugins.testapp.Utils;
+
+import org.maplibre.android.MapLibre;
+import org.maplibre.android.WellKnownTileServer;
+import org.maplibre.android.camera.CameraUpdateFactory;
+import org.maplibre.android.geometry.LatLng;
+import org.maplibre.android.maps.MapLibreMap;
+import org.maplibre.android.maps.MapView;
+import org.maplibre.android.maps.Style;
+import org.maplibre.geojson.Feature;
+import org.maplibre.geojson.FeatureCollection;
+import org.maplibre.geojson.Point;
 
 import timber.log.Timber;
 
@@ -51,7 +52,7 @@ public class BulkSymbolActivity extends AppCompatActivity implements AdapterView
     private SymbolManager symbolManager;
     private List<Symbol> symbols = new ArrayList<>();
 
-    private MapboxMap mapboxMap;
+    private MapLibreMap mapLibreMap;
     private MapView mapView;
     private FeatureCollection locations;
     private ProgressDialog progressDialog;
@@ -60,26 +61,26 @@ public class BulkSymbolActivity extends AppCompatActivity implements AdapterView
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_annotation);
-        Mapbox.getInstance(this, BuildConfig.MAPTILER_API_KEY, WellKnownTileServer.MapTiler);
+        MapLibre.getInstance(this, BuildConfig.MAPTILER_API_KEY, WellKnownTileServer.MapTiler);
         mapView = findViewById(R.id.mapView);
         mapView.onCreate(savedInstanceState);
         mapView.getMapAsync(this::initMap);
     }
 
-    private void initMap(MapboxMap mapboxMap) {
-        this.mapboxMap = mapboxMap;
-        mapboxMap.moveCamera(
+    private void initMap(MapLibreMap mapLibreMap) {
+        this.mapLibreMap = mapLibreMap;
+        mapLibreMap.moveCamera(
             CameraUpdateFactory.newLatLngZoom(
                 new LatLng(38.87031, -77.00897), 10
             )
         );
 
-        mapboxMap.setStyle(new Style.Builder()
+        mapLibreMap.setStyle(new Style.Builder()
                 .fromUri(Style.getPredefinedStyle("Streets"))
                 .withImage(IMAGE_ID_FIRE_HYDRANT, getDrawable(R.drawable.ic_fire_hydrant)),
             style -> {
-                findViewById(R.id.fabStyles).setOnClickListener(v -> mapboxMap.setStyle(Utils.INSTANCE.getNextStyle()));
-                symbolManager = new SymbolManager(mapView, mapboxMap, style);
+                findViewById(R.id.fabStyles).setOnClickListener(v -> mapLibreMap.setStyle(Utils.INSTANCE.getNextStyle()));
+                symbolManager = new SymbolManager(mapView, mapLibreMap, style);
                 symbolManager.setIconAllowOverlap(true);
                 loadData(0);
             });
@@ -101,7 +102,7 @@ public class BulkSymbolActivity extends AppCompatActivity implements AdapterView
 
     @Override
     public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
-        if (mapboxMap.getStyle() == null || !mapboxMap.getStyle().isFullyLoaded()) {
+        if (mapLibreMap.getStyle() == null || !mapLibreMap.getStyle().isFullyLoaded()) {
             return;
         }
 
@@ -131,7 +132,7 @@ public class BulkSymbolActivity extends AppCompatActivity implements AdapterView
 
     private void showMarkers(int amount) {
         Timber.i("Showing markers");
-        if (mapboxMap == null || locations == null || locations.features() == null || mapView.isDestroyed()) {
+        if (mapLibreMap == null || locations == null || locations.features() == null || mapView.isDestroyed()) {
             Timber.i("Not showing markers");
             return;
         }

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/CircleActivity.java
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/CircleActivity.java
@@ -8,17 +8,12 @@ import android.view.View;
 import android.widget.TextView;
 import android.widget.Toast;
 
-import com.mapbox.mapboxsdk.camera.CameraUpdateFactory;
-import com.mapbox.mapboxsdk.geometry.LatLng;
-import com.mapbox.mapboxsdk.maps.MapView;
-import com.mapbox.mapboxsdk.maps.Style;
 import com.mapbox.mapboxsdk.plugins.annotation.Circle;
 import com.mapbox.mapboxsdk.plugins.annotation.CircleManager;
 import com.mapbox.mapboxsdk.plugins.annotation.CircleOptions;
 import com.mapbox.mapboxsdk.plugins.annotation.OnCircleDragListener;
 import com.mapbox.mapboxsdk.plugins.testapp.R;
 import com.mapbox.mapboxsdk.plugins.testapp.Utils;
-import com.mapbox.mapboxsdk.utils.ColorUtils;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -27,6 +22,12 @@ import java.util.Locale;
 import java.util.Random;
 
 import androidx.appcompat.app.AppCompatActivity;
+
+import org.maplibre.android.camera.CameraUpdateFactory;
+import org.maplibre.android.geometry.LatLng;
+import org.maplibre.android.maps.MapView;
+import org.maplibre.android.maps.Style;
+import org.maplibre.android.utils.ColorUtils;
 
 /**
  * Activity showcasing adding circles using the annotation plugin

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/CircleActivity.java
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/CircleActivity.java
@@ -48,13 +48,13 @@ public class CircleActivity extends AppCompatActivity {
 
         mapView = findViewById(R.id.mapView);
         mapView.onCreate(savedInstanceState);
-        mapView.getMapAsync(mapboxMap -> mapboxMap.setStyle(Style.getPredefinedStyle("Streets"), style -> {
-            findViewById(R.id.fabStyles).setOnClickListener(v -> mapboxMap.setStyle(Utils.INSTANCE.getNextStyle()));
+        mapView.getMapAsync(maplibreMap -> maplibreMap.setStyle(Style.getPredefinedStyle("Streets"), style -> {
+            findViewById(R.id.fabStyles).setOnClickListener(v -> maplibreMap.setStyle(Utils.INSTANCE.getNextStyle()));
 
-            mapboxMap.moveCamera(CameraUpdateFactory.zoomTo(2));
+            maplibreMap.moveCamera(CameraUpdateFactory.zoomTo(2));
 
             // create circle manager
-            circleManager = new CircleManager(mapView, mapboxMap, style);
+            circleManager = new CircleManager(mapView, maplibreMap, style);
             circleManager.addClickListener(circle -> {
                 Toast.makeText(CircleActivity.this,
                     String.format("Circle clicked %s", circle.getId()),

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/ClusterSymbolActivity.java
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/ClusterSymbolActivity.java
@@ -8,19 +8,20 @@ import android.os.Bundle;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.util.Pair;
 
-import com.mapbox.geojson.Feature;
-import com.mapbox.geojson.FeatureCollection;
-import com.mapbox.geojson.Point;
-import com.mapbox.mapboxsdk.camera.CameraUpdateFactory;
-import com.mapbox.mapboxsdk.geometry.LatLng;
-import com.mapbox.mapboxsdk.maps.MapView;
-import com.mapbox.mapboxsdk.maps.MapboxMap;
-import com.mapbox.mapboxsdk.maps.Style;
 import com.mapbox.mapboxsdk.plugins.annotation.ClusterOptions;
 import com.mapbox.mapboxsdk.plugins.annotation.Symbol;
 import com.mapbox.mapboxsdk.plugins.annotation.SymbolManager;
 import com.mapbox.mapboxsdk.plugins.annotation.SymbolOptions;
 import com.mapbox.mapboxsdk.plugins.testapp.R;
+
+import org.maplibre.android.camera.CameraUpdateFactory;
+import org.maplibre.android.geometry.LatLng;
+import org.maplibre.android.maps.MapLibreMap;
+import org.maplibre.android.maps.MapView;
+import org.maplibre.android.maps.Style;
+import org.maplibre.geojson.Feature;
+import org.maplibre.geojson.FeatureCollection;
+import org.maplibre.geojson.Point;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -43,7 +44,7 @@ public class ClusterSymbolActivity extends AppCompatActivity {
     private SymbolManager symbolManager;
     private List<Symbol> symbols = new ArrayList<>();
 
-    private MapboxMap mapboxMap;
+    private MapLibreMap maplibreMap;
     private MapView mapView;
     private FeatureCollection locations;
 
@@ -57,8 +58,8 @@ public class ClusterSymbolActivity extends AppCompatActivity {
         mapView.getMapAsync(this::initMap);
     }
 
-    private void initMap(MapboxMap mapboxMap) {
-        this.mapboxMap = mapboxMap;
+    private void initMap(MapLibreMap mapboxMap) {
+        this.maplibreMap = mapboxMap;
         mapboxMap.moveCamera(
             CameraUpdateFactory.newLatLngZoom(
                 new LatLng(38.87031, -77.00897), 10
@@ -94,7 +95,7 @@ public class ClusterSymbolActivity extends AppCompatActivity {
     }
 
     private void showMarkers(int amount) {
-        if (mapboxMap == null || locations == null || locations.features() == null || mapView.isDestroyed()) {
+        if (maplibreMap == null || locations == null || locations.features() == null || mapView.isDestroyed()) {
             return;
         }
         // delete old symbols

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/ClusterSymbolActivity.java
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/ClusterSymbolActivity.java
@@ -58,9 +58,9 @@ public class ClusterSymbolActivity extends AppCompatActivity {
         mapView.getMapAsync(this::initMap);
     }
 
-    private void initMap(MapLibreMap mapboxMap) {
-        this.maplibreMap = mapboxMap;
-        mapboxMap.moveCamera(
+    private void initMap(MapLibreMap maplibreMap) {
+        this.maplibreMap = maplibreMap;
+        maplibreMap.moveCamera(
             CameraUpdateFactory.newLatLngZoom(
                 new LatLng(38.87031, -77.00897), 10
             )
@@ -73,8 +73,8 @@ public class ClusterSymbolActivity extends AppCompatActivity {
                 new Pair(0, Color.GREEN)
             });
 
-        mapboxMap.setStyle(new Style.Builder().fromUri(Style.getPredefinedStyle("Streets")), style -> {
-            symbolManager = new SymbolManager(mapView, mapboxMap, style, null, null, clusterOptions);
+        maplibreMap.setStyle(new Style.Builder().fromUri(Style.getPredefinedStyle("Streets")), style -> {
+            symbolManager = new SymbolManager(mapView, maplibreMap, style, null, null, clusterOptions);
             symbolManager.setIconAllowOverlap(true);
             loadData();
         });

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/DynamicSymbolChangeActivity.java
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/DynamicSymbolChangeActivity.java
@@ -7,12 +7,6 @@ import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
-import com.mapbox.mapboxsdk.camera.CameraPosition;
-import com.mapbox.mapboxsdk.camera.CameraUpdateFactory;
-import com.mapbox.mapboxsdk.geometry.LatLng;
-import com.mapbox.mapboxsdk.maps.MapView;
-import com.mapbox.mapboxsdk.maps.MapboxMap;
-import com.mapbox.mapboxsdk.maps.Style;
 import com.mapbox.mapboxsdk.plugins.annotation.Symbol;
 import com.mapbox.mapboxsdk.plugins.annotation.SymbolManager;
 import com.mapbox.mapboxsdk.plugins.annotation.SymbolOptions;
@@ -20,6 +14,13 @@ import com.mapbox.mapboxsdk.plugins.testapp.R;
 
 import androidx.annotation.DrawableRes;
 import androidx.appcompat.app.AppCompatActivity;
+
+import org.maplibre.android.camera.CameraPosition;
+import org.maplibre.android.camera.CameraUpdateFactory;
+import org.maplibre.android.geometry.LatLng;
+import org.maplibre.android.maps.MapLibreMap;
+import org.maplibre.android.maps.MapView;
+import org.maplibre.android.maps.Style;
 
 /**
  * Test activity showcasing updating a Marker position, title, icon and snippet.
@@ -34,7 +35,7 @@ public class DynamicSymbolChangeActivity extends AppCompatActivity {
 
     private SymbolManager symbolManager;
     private MapView mapView;
-    private MapboxMap mapboxMap;
+    private MapLibreMap maplibreMap;
     private Symbol symbol;
 
     @Override
@@ -46,7 +47,7 @@ public class DynamicSymbolChangeActivity extends AppCompatActivity {
         mapView.setTag(false);
         mapView.onCreate(savedInstanceState);
         mapView.getMapAsync(mapboxMap -> {
-            DynamicSymbolChangeActivity.this.mapboxMap = mapboxMap;
+            DynamicSymbolChangeActivity.this.maplibreMap = mapboxMap;
 
             LatLng target = new LatLng(51.506675, -0.128699);
 
@@ -82,7 +83,7 @@ public class DynamicSymbolChangeActivity extends AppCompatActivity {
         FloatingActionButton fab = findViewById(R.id.fabStyles);
         fab.setVisibility(MapView.VISIBLE);
         fab.setOnClickListener(view -> {
-            if (mapboxMap != null) {
+            if (maplibreMap != null) {
                 updateSymbol();
             }
         });

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/DynamicSymbolChangeActivity.java
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/DynamicSymbolChangeActivity.java
@@ -46,12 +46,12 @@ public class DynamicSymbolChangeActivity extends AppCompatActivity {
         mapView = findViewById(R.id.mapView);
         mapView.setTag(false);
         mapView.onCreate(savedInstanceState);
-        mapView.getMapAsync(mapboxMap -> {
-            DynamicSymbolChangeActivity.this.maplibreMap = mapboxMap;
+        mapView.getMapAsync(maplibreMap -> {
+            DynamicSymbolChangeActivity.this.maplibreMap = maplibreMap;
 
             LatLng target = new LatLng(51.506675, -0.128699);
 
-            mapboxMap.moveCamera(CameraUpdateFactory.newCameraPosition(
+            maplibreMap.moveCamera(CameraUpdateFactory.newCameraPosition(
                 new CameraPosition.Builder()
                     .bearing(90)
                     .tilt(40)
@@ -60,12 +60,12 @@ public class DynamicSymbolChangeActivity extends AppCompatActivity {
                     .build()
             ));
 
-            mapboxMap.setStyle(new Style.Builder()
+            maplibreMap.setStyle(new Style.Builder()
                     .fromUri(Style.getPredefinedStyle("Streets"))
                 //.withImage(ID_ICON_1, generateBitmap(R.drawable.mapbox_ic_place), true)
                 //.withImage(ID_ICON_2, generateBitmap(R.drawable.mapbox_ic_offline), true)
                 , style -> {
-                    symbolManager = new SymbolManager(mapView, mapboxMap, style);
+                    symbolManager = new SymbolManager(mapView, maplibreMap, style);
                     symbolManager.setIconAllowOverlap(true);
                     symbolManager.setTextAllowOverlap(true);
 

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/FillActivity.java
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/FillActivity.java
@@ -44,12 +44,12 @@ public class FillActivity extends AppCompatActivity {
         setContentView(R.layout.activity_annotation);
         mapView = findViewById(R.id.mapView);
         mapView.onCreate(savedInstanceState);
-        mapView.getMapAsync(mapboxMap -> mapboxMap.setStyle(Style.getPredefinedStyle("Streets"), style -> {
-            findViewById(R.id.fabStyles).setOnClickListener(v -> mapboxMap.setStyle(Utils.INSTANCE.getNextStyle()));
+        mapView.getMapAsync(maplibreMap -> maplibreMap.setStyle(Style.getPredefinedStyle("Streets"), style -> {
+            findViewById(R.id.fabStyles).setOnClickListener(v -> maplibreMap.setStyle(Utils.INSTANCE.getNextStyle()));
 
-            mapboxMap.moveCamera(CameraUpdateFactory.zoomTo(2));
+            maplibreMap.moveCamera(CameraUpdateFactory.zoomTo(2));
 
-            fillManager = new FillManager(mapView, mapboxMap, style);
+            fillManager = new FillManager(mapView, maplibreMap, style);
             fillManager.addClickListener(fill -> {
                 Toast.makeText(FillActivity.this,
                     String.format("Fill clicked %s with title: %s", fill.getId(), getTitleFromFill(fill)),

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/FillActivity.java
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/FillActivity.java
@@ -8,17 +8,11 @@ import android.widget.Toast;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonPrimitive;
-import com.mapbox.geojson.FeatureCollection;
-import com.mapbox.mapboxsdk.camera.CameraUpdateFactory;
-import com.mapbox.mapboxsdk.geometry.LatLng;
-import com.mapbox.mapboxsdk.maps.MapView;
-import com.mapbox.mapboxsdk.maps.Style;
 import com.mapbox.mapboxsdk.plugins.annotation.Fill;
 import com.mapbox.mapboxsdk.plugins.annotation.FillManager;
 import com.mapbox.mapboxsdk.plugins.annotation.FillOptions;
 import com.mapbox.mapboxsdk.plugins.testapp.R;
 import com.mapbox.mapboxsdk.plugins.testapp.Utils;
-import com.mapbox.mapboxsdk.utils.ColorUtils;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -26,6 +20,13 @@ import java.util.List;
 import java.util.Random;
 
 import androidx.appcompat.app.AppCompatActivity;
+
+import org.maplibre.android.camera.CameraUpdateFactory;
+import org.maplibre.android.geometry.LatLng;
+import org.maplibre.android.maps.MapView;
+import org.maplibre.android.maps.Style;
+import org.maplibre.android.utils.ColorUtils;
+import org.maplibre.geojson.FeatureCollection;
 
 /**
  * Activity showcasing adding fills using the annotation plugin

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/FillChangeActivity.java
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/FillChangeActivity.java
@@ -6,18 +6,10 @@ import android.view.Menu;
 import android.view.MenuItem;
 import android.widget.Toast;
 
-import com.mapbox.mapboxsdk.camera.CameraPosition;
-import com.mapbox.mapboxsdk.geometry.LatLng;
-import com.mapbox.mapboxsdk.maps.MapView;
-import com.mapbox.mapboxsdk.maps.MapboxMap;
-import com.mapbox.mapboxsdk.maps.MapboxMapOptions;
-import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
-import com.mapbox.mapboxsdk.maps.Style;
 import com.mapbox.mapboxsdk.plugins.annotation.Fill;
 import com.mapbox.mapboxsdk.plugins.annotation.FillManager;
 import com.mapbox.mapboxsdk.plugins.annotation.FillOptions;
 import com.mapbox.mapboxsdk.plugins.testapp.R;
-import com.mapbox.mapboxsdk.utils.ColorUtils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -33,6 +25,15 @@ import static com.mapbox.mapboxsdk.plugins.testapp.activity.annotation.FillChang
 import static com.mapbox.mapboxsdk.plugins.testapp.activity.annotation.FillChangeActivity.Config.RED_COLOR;
 import static com.mapbox.mapboxsdk.plugins.testapp.activity.annotation.FillChangeActivity.Config.STAR_SHAPE_HOLES;
 import static com.mapbox.mapboxsdk.plugins.testapp.activity.annotation.FillChangeActivity.Config.STAR_SHAPE_POINTS;
+
+import org.maplibre.android.camera.CameraPosition;
+import org.maplibre.android.geometry.LatLng;
+import org.maplibre.android.maps.MapLibreMap;
+import org.maplibre.android.maps.MapLibreMapOptions;
+import org.maplibre.android.maps.MapView;
+import org.maplibre.android.maps.OnMapReadyCallback;
+import org.maplibre.android.maps.Style;
+import org.maplibre.android.utils.ColorUtils;
 
 /**
  * Test activity to showcase the Polygon annotation API & programmatically creating a MapView.
@@ -58,7 +59,7 @@ public class FillChangeActivity extends AppCompatActivity implements OnMapReadyC
         super.onCreate(savedInstanceState);
 
         // configure initial map state
-        MapboxMapOptions options = new MapboxMapOptions()
+        MapLibreMapOptions options = new MapLibreMapOptions()
             .attributionTintColor(RED_COLOR)
             .compassFadesWhenFacingNorth(false)
             .camera(new CameraPosition.Builder()
@@ -77,7 +78,7 @@ public class FillChangeActivity extends AppCompatActivity implements OnMapReadyC
     }
 
     @Override
-    public void onMapReady(@NonNull MapboxMap map) {
+    public void onMapReady(@NonNull MapLibreMap map) {
         map.setStyle(new Style.Builder().fromUri(Style.getPredefinedStyle("Streets")), style -> {
             fillManager = new FillManager(mapView, map, style, "aerialway", null);
             fillManager.addClickListener(fill -> {

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/LineActivity.java
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/LineActivity.java
@@ -6,16 +6,11 @@ import android.view.Menu;
 import android.view.MenuItem;
 import android.widget.Toast;
 
-import com.mapbox.mapboxsdk.camera.CameraUpdateFactory;
-import com.mapbox.mapboxsdk.geometry.LatLng;
-import com.mapbox.mapboxsdk.maps.MapView;
-import com.mapbox.mapboxsdk.maps.Style;
 import com.mapbox.mapboxsdk.plugins.annotation.Line;
 import com.mapbox.mapboxsdk.plugins.annotation.LineManager;
 import com.mapbox.mapboxsdk.plugins.annotation.LineOptions;
 import com.mapbox.mapboxsdk.plugins.testapp.R;
 import com.mapbox.mapboxsdk.plugins.testapp.Utils;
-import com.mapbox.mapboxsdk.utils.ColorUtils;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -23,6 +18,12 @@ import java.util.List;
 import java.util.Random;
 
 import androidx.appcompat.app.AppCompatActivity;
+
+import org.maplibre.android.camera.CameraUpdateFactory;
+import org.maplibre.android.geometry.LatLng;
+import org.maplibre.android.maps.MapView;
+import org.maplibre.android.maps.Style;
+import org.maplibre.android.utils.ColorUtils;
 
 /**
  * Activity showcasing adding lines using the annotation plugin

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/LineActivity.java
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/LineActivity.java
@@ -41,12 +41,12 @@ public class LineActivity extends AppCompatActivity {
         setContentView(R.layout.activity_annotation);
         mapView = findViewById(R.id.mapView);
         mapView.onCreate(savedInstanceState);
-        mapView.getMapAsync(mapboxMap -> mapboxMap.setStyle(Style.getPredefinedStyle("Streets"), style -> {
-            findViewById(R.id.fabStyles).setOnClickListener(v -> mapboxMap.setStyle(Utils.INSTANCE.getNextStyle()));
+        mapView.getMapAsync(maplibreMap -> maplibreMap.setStyle(Style.getPredefinedStyle("Streets"), style -> {
+            findViewById(R.id.fabStyles).setOnClickListener(v -> maplibreMap.setStyle(Utils.INSTANCE.getNextStyle()));
 
-            mapboxMap.moveCamera(CameraUpdateFactory.zoomTo(2));
+            maplibreMap.moveCamera(CameraUpdateFactory.zoomTo(2));
 
-            lineManager = new LineManager(mapView, mapboxMap, style);
+            lineManager = new LineManager(mapView, maplibreMap, style);
             lineManager.addClickListener(line -> {
                 Toast.makeText(LineActivity.this,
                     String.format("Line clicked %s", line.getId()),

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/LineChangeActivity.java
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/LineChangeActivity.java
@@ -7,24 +7,25 @@ import android.view.MenuItem;
 import android.view.View;
 import android.widget.Toast;
 
-import com.mapbox.geojson.LineString;
-import com.mapbox.geojson.Point;
-import com.mapbox.mapboxsdk.camera.CameraUpdateFactory;
-import com.mapbox.mapboxsdk.geometry.LatLng;
-import com.mapbox.mapboxsdk.maps.MapView;
-import com.mapbox.mapboxsdk.maps.Style;
 import com.mapbox.mapboxsdk.plugins.annotation.Line;
 import com.mapbox.mapboxsdk.plugins.annotation.LineManager;
 import com.mapbox.mapboxsdk.plugins.annotation.LineOptions;
 import com.mapbox.mapboxsdk.plugins.testapp.R;
 import com.mapbox.mapboxsdk.plugins.testapp.Utils;
-import com.mapbox.mapboxsdk.utils.ColorUtils;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
 import androidx.appcompat.app.AppCompatActivity;
+
+import org.maplibre.android.camera.CameraUpdateFactory;
+import org.maplibre.android.geometry.LatLng;
+import org.maplibre.android.maps.MapView;
+import org.maplibre.android.maps.Style;
+import org.maplibre.android.utils.ColorUtils;
+import org.maplibre.geojson.LineString;
+import org.maplibre.geojson.Point;
 
 /**
  * Test activity showcasing the Polyline annotations API.

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/LineChangeActivity.java
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/LineChangeActivity.java
@@ -63,17 +63,17 @@ public class LineChangeActivity extends AppCompatActivity {
 
         mapView = findViewById(R.id.mapView);
         mapView.onCreate(savedInstanceState);
-        mapView.getMapAsync(mapboxMap -> {
-            mapboxMap.moveCamera(
+        mapView.getMapAsync(maplibreMap -> {
+            maplibreMap.moveCamera(
                 CameraUpdateFactory.newLatLngZoom(
                     new LatLng(47.798202, 7.573781),
                     4)
             );
 
-            mapboxMap.setStyle(new Style.Builder().fromUri(Style.getPredefinedStyle("Streets")), style -> {
-                findViewById(R.id.fabStyles).setOnClickListener(v -> mapboxMap.setStyle(Utils.INSTANCE.getNextStyle()));
+            maplibreMap.setStyle(new Style.Builder().fromUri(Style.getPredefinedStyle("Streets")), style -> {
+                findViewById(R.id.fabStyles).setOnClickListener(v -> maplibreMap.setStyle(Utils.INSTANCE.getNextStyle()));
 
-                lineManager = new LineManager(mapView, mapboxMap, style);
+                lineManager = new LineManager(mapView, maplibreMap, style);
                 lines = lineManager.create(getAllPolylines());
                 lineManager.addClickListener(line -> {
                     Toast.makeText(
@@ -83,7 +83,7 @@ public class LineChangeActivity extends AppCompatActivity {
                     return false;
                 });
 
-                LineManager dottedLineManger = new LineManager(mapView, mapboxMap, style);
+                LineManager dottedLineManger = new LineManager(mapView, maplibreMap, style);
                 dottedLineManger.create(new LineOptions()
                     .withLinePattern("airfield-11")
                     .withLineWidth(5.0f)

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/PressForSymbolActivity.java
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/PressForSymbolActivity.java
@@ -1,21 +1,17 @@
 package com.mapbox.mapboxsdk.plugins.testapp.activity.annotation;
 
+import static org.maplibre.android.style.layers.Property.ICON_ANCHOR_BOTTOM;
+
 import android.graphics.Bitmap;
 import android.graphics.Canvas;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 
-import com.mapbox.mapboxsdk.camera.CameraPosition;
-import com.mapbox.mapboxsdk.geometry.LatLng;
-import com.mapbox.mapboxsdk.maps.MapView;
-import com.mapbox.mapboxsdk.maps.MapboxMap;
-import com.mapbox.mapboxsdk.maps.Style;
 import com.mapbox.mapboxsdk.plugins.annotation.SymbolManager;
 import com.mapbox.mapboxsdk.plugins.annotation.SymbolOptions;
 import com.mapbox.mapboxsdk.plugins.testapp.R;
 import com.mapbox.mapboxsdk.plugins.testapp.Utils;
-import com.mapbox.mapboxsdk.style.layers.Property;
 
 import androidx.annotation.DrawableRes;
 import androidx.annotation.NonNull;
@@ -23,7 +19,11 @@ import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.app.AppCompatDelegate;
 
-import static com.mapbox.mapboxsdk.style.layers.Property.ICON_ANCHOR_BOTTOM;
+import org.maplibre.android.camera.CameraPosition;
+import org.maplibre.android.geometry.LatLng;
+import org.maplibre.android.maps.MapLibreMap;
+import org.maplibre.android.maps.MapView;
+import org.maplibre.android.maps.Style;
 
 /**
  * Test activity showcasing to add a Symbol on click.
@@ -36,7 +36,7 @@ public class PressForSymbolActivity extends AppCompatActivity {
     public static final String ID_ICON = "id-icon";
     private SymbolManager symbolManager;
     private MapView mapView;
-    private MapboxMap mapboxMap;
+    private MapLibreMap maplibreMap;
 
     @Override
     protected void onCreate(@Nullable final Bundle savedInstanceState) {
@@ -46,21 +46,21 @@ public class PressForSymbolActivity extends AppCompatActivity {
         mapView = findViewById(R.id.mapView);
         mapView.onCreate(savedInstanceState);
         mapView.getMapAsync(map -> {
-            mapboxMap = map;
-            mapboxMap.setCameraPosition(new CameraPosition.Builder()
+            maplibreMap = map;
+            maplibreMap.setCameraPosition(new CameraPosition.Builder()
                 .target(new LatLng(60.169091, 24.939876))
                 .zoom(12)
                 .tilt(20)
                 .bearing(90)
                 .build()
             );
-            mapboxMap.addOnMapLongClickListener(this::addSymbol);
-            mapboxMap.addOnMapClickListener(this::addSymbol);
-            mapboxMap.setStyle(getStyleBuilder(Style.getPredefinedStyle("Streets")), style -> {
+            maplibreMap.addOnMapLongClickListener(this::addSymbol);
+            maplibreMap.addOnMapClickListener(this::addSymbol);
+            maplibreMap.setStyle(getStyleBuilder(Style.getPredefinedStyle("Streets")), style -> {
                 findViewById(R.id.fabStyles).setOnClickListener(v ->
-                    mapboxMap.setStyle(getStyleBuilder(Utils.INSTANCE.getNextStyle())));
+                    maplibreMap.setStyle(getStyleBuilder(Utils.INSTANCE.getNextStyle())));
 
-                symbolManager = new SymbolManager(mapView, mapboxMap, style);
+                symbolManager = new SymbolManager(mapView, maplibreMap, style);
                 symbolManager.setIconAllowOverlap(true);
                 symbolManager.setTextAllowOverlap(true);
             });
@@ -118,8 +118,8 @@ public class PressForSymbolActivity extends AppCompatActivity {
     @Override
     protected void onDestroy() {
         super.onDestroy();
-        mapboxMap.removeOnMapClickListener(this::addSymbol);
-        mapboxMap.removeOnMapLongClickListener(this::addSymbol);
+        maplibreMap.removeOnMapClickListener(this::addSymbol);
+        maplibreMap.removeOnMapLongClickListener(this::addSymbol);
 
         if (symbolManager != null) {
             symbolManager.onDestroy();

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/SymbolActivity.java
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/SymbolActivity.java
@@ -71,19 +71,19 @@ public class SymbolActivity extends AppCompatActivity {
 
         mapView = findViewById(R.id.mapView);
         mapView.onCreate(savedInstanceState);
-        mapView.getMapAsync(mapboxMap -> mapboxMap.setStyle(Style.getPredefinedStyle("Streets"), style -> {
+        mapView.getMapAsync(maplibreMap -> maplibreMap.setStyle(Style.getPredefinedStyle("Streets"), style -> {
             findViewById(R.id.fabStyles).setOnClickListener(v -> {
-                mapboxMap.setStyle(Utils.INSTANCE.getNextStyle());
-                mapboxMap.getStyle(this::addAirplaneImageToStyle);
+                maplibreMap.setStyle(Utils.INSTANCE.getNextStyle());
+                maplibreMap.getStyle(this::addAirplaneImageToStyle);
             });
 
-            mapboxMap.moveCamera(CameraUpdateFactory.zoomTo(2));
+            maplibreMap.moveCamera(CameraUpdateFactory.zoomTo(2));
 
             addAirplaneImageToStyle(style);
 
             // create symbol manager
             GeoJsonOptions geoJsonOptions = new GeoJsonOptions().withTolerance(0.4f);
-            symbolManager = new SymbolManager(mapView, mapboxMap, style, null, null, geoJsonOptions);
+            symbolManager = new SymbolManager(mapView, maplibreMap, style, null, null, geoJsonOptions);
             symbolManager.addClickListener(symbol -> {
                 Toast.makeText(SymbolActivity.this,
                     String.format("Symbol clicked %s", symbol.getId()),

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/SymbolActivity.java
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation/SymbolActivity.java
@@ -1,5 +1,10 @@
 package com.mapbox.mapboxsdk.plugins.testapp.activity.annotation;
 
+import static org.maplibre.android.style.expressions.Expression.eq;
+import static org.maplibre.android.style.expressions.Expression.get;
+import static org.maplibre.android.style.expressions.Expression.not;
+import static org.maplibre.android.style.expressions.Expression.toNumber;
+
 import android.animation.ValueAnimator;
 import android.graphics.Color;
 import android.graphics.PointF;
@@ -11,23 +16,12 @@ import android.view.animation.LinearInterpolator;
 import android.widget.TextView;
 import android.widget.Toast;
 
-import com.mapbox.geojson.FeatureCollection;
-import com.mapbox.geojson.Point;
-import com.mapbox.mapboxsdk.camera.CameraUpdateFactory;
-import com.mapbox.mapboxsdk.geometry.LatLng;
-import com.mapbox.mapboxsdk.maps.MapView;
-import com.mapbox.mapboxsdk.maps.Style;
 import com.mapbox.mapboxsdk.plugins.annotation.OnSymbolDragListener;
 import com.mapbox.mapboxsdk.plugins.annotation.Symbol;
 import com.mapbox.mapboxsdk.plugins.annotation.SymbolManager;
 import com.mapbox.mapboxsdk.plugins.annotation.SymbolOptions;
 import com.mapbox.mapboxsdk.plugins.testapp.R;
 import com.mapbox.mapboxsdk.plugins.testapp.Utils;
-import com.mapbox.mapboxsdk.style.expressions.Expression;
-import com.mapbox.mapboxsdk.style.layers.Property;
-import com.mapbox.mapboxsdk.style.sources.GeoJsonOptions;
-import com.mapbox.mapboxsdk.utils.BitmapUtils;
-import com.mapbox.mapboxsdk.utils.ColorUtils;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -37,12 +31,19 @@ import java.util.Random;
 
 import androidx.appcompat.app.AppCompatActivity;
 
-import timber.log.Timber;
+import org.maplibre.android.camera.CameraUpdateFactory;
+import org.maplibre.android.geometry.LatLng;
+import org.maplibre.android.maps.MapView;
+import org.maplibre.android.maps.Style;
+import org.maplibre.android.style.expressions.Expression;
+import org.maplibre.android.style.layers.Property;
+import org.maplibre.android.style.sources.GeoJsonOptions;
+import org.maplibre.android.utils.BitmapUtils;
+import org.maplibre.android.utils.ColorUtils;
+import org.maplibre.geojson.FeatureCollection;
+import org.maplibre.geojson.Point;
 
-import static com.mapbox.mapboxsdk.style.expressions.Expression.eq;
-import static com.mapbox.mapboxsdk.style.expressions.Expression.get;
-import static com.mapbox.mapboxsdk.style.expressions.Expression.not;
-import static com.mapbox.mapboxsdk.style.expressions.Expression.toNumber;
+import timber.log.Timber;
 
 /**
  * Activity showcasing adding symbols using the annotation plugin

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/ktx/maps/MapboxKtxActivity.kt
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/ktx/maps/MapboxKtxActivity.kt
@@ -3,17 +3,17 @@ package com.mapbox.mapboxsdk.plugins.testapp.activity.ktx.maps
 import android.os.Bundle
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
-import com.mapbox.mapboxsdk.geometry.LatLng
-import com.mapbox.mapboxsdk.maps.MapView
-import com.mapbox.mapboxsdk.maps.MapboxMap
-import com.mapbox.mapboxsdk.maps.OnMapReadyCallback
-import com.mapbox.mapboxsdk.maps.Style
 import com.mapbox.mapboxsdk.plugins.maps.queryRenderedFeatures
 import com.mapbox.mapboxsdk.plugins.testapp.databinding.ActivityMapsKtxBinding
+import org.maplibre.android.geometry.LatLng
+import org.maplibre.android.maps.MapLibreMap
+import org.maplibre.android.maps.MapView
+import org.maplibre.android.maps.OnMapReadyCallback
+import org.maplibre.android.maps.Style
 
-class MapboxKtxActivity : AppCompatActivity(), OnMapReadyCallback, MapboxMap.OnMapClickListener {
+class MapboxKtxActivity : AppCompatActivity(), OnMapReadyCallback, MapLibreMap.OnMapClickListener {
 
-    private var mapboxMap: MapboxMap? = null
+    private var maplibreMap: MapLibreMap? = null
 
     private lateinit var binding: ActivityMapsKtxBinding
     private lateinit var mapView: MapView
@@ -28,8 +28,8 @@ class MapboxKtxActivity : AppCompatActivity(), OnMapReadyCallback, MapboxMap.OnM
         mapView.getMapAsync(this)
     }
 
-    override fun onMapReady(mapboxMap: MapboxMap) {
-        this.mapboxMap = mapboxMap
+    override fun onMapReady(mapboxMap: MapLibreMap) {
+        this.maplibreMap = mapboxMap
         mapboxMap.setStyle(Style.getPredefinedStyle("Streets")) {
             mapboxMap.addOnMapClickListener(this)
             Toast.makeText(this, "Click on the map", Toast.LENGTH_SHORT).show()
@@ -37,7 +37,7 @@ class MapboxKtxActivity : AppCompatActivity(), OnMapReadyCallback, MapboxMap.OnM
     }
 
     override fun onMapClick(point: LatLng): Boolean {
-        val features = mapboxMap?.queryRenderedFeatures(point)
+        val features = maplibreMap?.queryRenderedFeatures(point)
         features?.first().let {
             Toast.makeText(this, it.toString(), Toast.LENGTH_SHORT).show()
         }
@@ -71,7 +71,7 @@ class MapboxKtxActivity : AppCompatActivity(), OnMapReadyCallback, MapboxMap.OnM
 
     override fun onDestroy() {
         super.onDestroy()
-        mapboxMap?.removeOnMapClickListener(this)
+        maplibreMap?.removeOnMapClickListener(this)
         mapView.onDestroy()
     }
 

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/ktx/maps/MapboxKtxActivity.kt
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/ktx/maps/MapboxKtxActivity.kt
@@ -28,10 +28,10 @@ class MapboxKtxActivity : AppCompatActivity(), OnMapReadyCallback, MapLibreMap.O
         mapView.getMapAsync(this)
     }
 
-    override fun onMapReady(mapboxMap: MapLibreMap) {
-        this.maplibreMap = mapboxMap
-        mapboxMap.setStyle(Style.getPredefinedStyle("Streets")) {
-            mapboxMap.addOnMapClickListener(this)
+    override fun onMapReady(maplibreMap: MapLibreMap) {
+        this.maplibreMap = maplibreMap
+        maplibreMap.setStyle(Style.getPredefinedStyle("Streets")) {
+            maplibreMap.addOnMapClickListener(this)
             Toast.makeText(this, "Click on the map", Toast.LENGTH_SHORT).show()
         }
     }

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/localization/LocalizationActivity.kt
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/localization/LocalizationActivity.kt
@@ -6,20 +6,20 @@ import android.view.MenuItem
 import android.view.View
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
-import com.mapbox.mapboxsdk.maps.MapView
-import com.mapbox.mapboxsdk.maps.MapboxMap
-import com.mapbox.mapboxsdk.maps.OnMapReadyCallback
-import com.mapbox.mapboxsdk.maps.Style
 import com.mapbox.mapboxsdk.plugins.localization.LocalizationPlugin
 import com.mapbox.mapboxsdk.plugins.localization.MapLocale
 import com.mapbox.mapboxsdk.plugins.testapp.R
 import com.mapbox.mapboxsdk.plugins.testapp.Utils
 import com.mapbox.mapboxsdk.plugins.testapp.databinding.ActivityLocalizationBinding
+import org.maplibre.android.maps.MapLibreMap
+import org.maplibre.android.maps.MapView
+import org.maplibre.android.maps.OnMapReadyCallback
+import org.maplibre.android.maps.Style
 
 class LocalizationActivity : AppCompatActivity(), OnMapReadyCallback {
 
     private var localizationPlugin: LocalizationPlugin? = null
-    private var mapboxMap: MapboxMap? = null
+    private var maplibreMap: MapLibreMap? = null
     private var mapIsLocalized: Boolean = false
     private lateinit var mapView: MapView
     private lateinit var binding: ActivityLocalizationBinding
@@ -34,11 +34,11 @@ class LocalizationActivity : AppCompatActivity(), OnMapReadyCallback {
         mapView.onCreate(savedInstanceState)
     }
 
-    override fun onMapReady(mapboxMap: MapboxMap) {
-        mapboxMap.setStyle(Style.getPredefinedStyle("Streets")) { style ->
-            this.mapboxMap = mapboxMap
+    override fun onMapReady(maplibreMap: MapLibreMap) {
+        maplibreMap?.setStyle(Style.getPredefinedStyle("Streets")) { style ->
+            this.maplibreMap = maplibreMap
             localizationPlugin =
-                LocalizationPlugin(mapView, mapboxMap, style).also { localizationPlugin ->
+                LocalizationPlugin(mapView, maplibreMap, style).also { localizationPlugin ->
                     localizationPlugin.matchMapLanguageWithDeviceDefault()
                 }
 
@@ -63,7 +63,7 @@ class LocalizationActivity : AppCompatActivity(), OnMapReadyCallback {
             }
 
             binding.fabStyles.setOnClickListener {
-                mapboxMap.setStyle(Style.Builder().fromUri(Utils.nextStyle))
+                maplibreMap.setStyle(Style.Builder().fromUri(Utils.nextStyle))
             }
         }
     }

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/markerview/MarkerViewActivity.kt
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/markerview/MarkerViewActivity.kt
@@ -9,21 +9,21 @@ import android.view.animation.AccelerateDecelerateInterpolator
 import android.widget.FrameLayout
 import android.widget.ImageView
 import androidx.appcompat.app.AppCompatActivity
-import com.mapbox.mapboxsdk.camera.CameraUpdateFactory
-import com.mapbox.mapboxsdk.geometry.LatLng
-import com.mapbox.mapboxsdk.maps.MapView
-import com.mapbox.mapboxsdk.maps.MapboxMap
-import com.mapbox.mapboxsdk.maps.Style
 import com.mapbox.mapboxsdk.plugins.markerview.MarkerView
 import com.mapbox.mapboxsdk.plugins.markerview.MarkerViewManager
 import com.mapbox.mapboxsdk.plugins.testapp.R
 import com.mapbox.mapboxsdk.plugins.testapp.Utils
+import org.maplibre.android.camera.CameraUpdateFactory
+import org.maplibre.android.geometry.LatLng
+import org.maplibre.android.maps.MapLibreMap
+import org.maplibre.android.maps.MapView
+import org.maplibre.android.maps.Style
 import java.util.Random
 
 class MarkerViewActivity :
     AppCompatActivity(),
-    MapboxMap.OnMapLongClickListener,
-    MapboxMap.OnMapClickListener {
+    MapLibreMap.OnMapLongClickListener,
+    MapLibreMap.OnMapClickListener {
 
     private val random = Random()
     private var markerViewManager: MarkerViewManager? = null

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/markerview/MarkerViewActivity.kt
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/markerview/MarkerViewActivity.kt
@@ -36,18 +36,18 @@ class MarkerViewActivity :
         mapView = findViewById<View>(R.id.mapView) as MapView
 
         mapView.onCreate(savedInstanceState)
-        mapView.getMapAsync { mapboxMap ->
-            mapboxMap.setStyle(Style.getPredefinedStyle("Streets")) { _ ->
-                findViewById<View>(R.id.fabStyles).setOnClickListener { mapboxMap.setStyle(Utils.nextStyle) }
+        mapView.getMapAsync { maplibreMap ->
+            maplibreMap.setStyle(Style.getPredefinedStyle("Streets")) { _ ->
+                findViewById<View>(R.id.fabStyles).setOnClickListener { maplibreMap.setStyle(Utils.nextStyle) }
 
-                mapboxMap.moveCamera(CameraUpdateFactory.zoomTo(2.0))
+                maplibreMap.moveCamera(CameraUpdateFactory.zoomTo(2.0))
 
-                markerViewManager = MarkerViewManager(mapView, mapboxMap)
+                markerViewManager = MarkerViewManager(mapView, maplibreMap)
                 createCustomMarker()
                 createRandomMarkers()
 
-                mapboxMap.addOnMapLongClickListener(this@MarkerViewActivity)
-                mapboxMap.addOnMapClickListener(this@MarkerViewActivity)
+                maplibreMap.addOnMapLongClickListener(this@MarkerViewActivity)
+                maplibreMap.addOnMapClickListener(this@MarkerViewActivity)
             }
         }
     }

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/offline/OfflineDownloadActivity.kt
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/offline/OfflineDownloadActivity.kt
@@ -5,17 +5,17 @@ import android.widget.ArrayAdapter
 import android.widget.SeekBar
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
-import com.mapbox.mapboxsdk.constants.MapboxConstants
-import com.mapbox.mapboxsdk.geometry.LatLng
-import com.mapbox.mapboxsdk.geometry.LatLngBounds
-import com.mapbox.mapboxsdk.maps.Style
-import com.mapbox.mapboxsdk.offline.OfflineTilePyramidRegionDefinition
 import com.mapbox.mapboxsdk.plugins.offline.model.NotificationOptions
 import com.mapbox.mapboxsdk.plugins.offline.model.OfflineDownloadOptions
 import com.mapbox.mapboxsdk.plugins.offline.offline.OfflinePlugin
 import com.mapbox.mapboxsdk.plugins.offline.utils.OfflineUtils
 import com.mapbox.mapboxsdk.plugins.testapp.R
 import com.mapbox.mapboxsdk.plugins.testapp.databinding.ActivityOfflineDownloadBinding
+import org.maplibre.android.constants.MapLibreConstants
+import org.maplibre.android.geometry.LatLng
+import org.maplibre.android.geometry.LatLngBounds
+import org.maplibre.android.maps.Style
+import org.maplibre.android.offline.OfflineTilePyramidRegionDefinition
 import java.util.ArrayList
 
 /**
@@ -61,7 +61,7 @@ class OfflineDownloadActivity : AppCompatActivity() {
     }
 
     private fun initSeekbars() {
-        val maxZoom = MapboxConstants.MAXIMUM_ZOOM.toInt()
+        val maxZoom = MapLibreConstants.MAXIMUM_ZOOM.toInt()
         binding.seekbarMinZoom.max = maxZoom
         binding.seekbarMinZoom.progress = 16
         binding.seekbarMaxZoom.max = maxZoom

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/offline/OfflineRegionDetailActivity.kt
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/offline/OfflineRegionDetailActivity.kt
@@ -144,11 +144,11 @@ class OfflineRegionDetailActivity : AppCompatActivity(), OfflineDownloadChangeLi
 
     private fun setupUI(definition: OfflineRegionDefinition) {
         // update map
-        mapView?.getMapAsync { mapboxMap ->
+        mapView?.getMapAsync { maplibreMap ->
             // correct style
-            mapboxMap.setOfflineRegionDefinition(definition) { _ ->
+            maplibreMap.setOfflineRegionDefinition(definition) { _ ->
                 // restrict camera movement
-                mapboxMap.setLatLngBoundsForCameraTarget(definition.bounds)
+                maplibreMap.setLatLngBoundsForCameraTarget(definition.bounds)
 
                 // update textview data
                 offlineRegion?.metadata?.let {

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/offline/OfflineRegionDetailActivity.kt
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/offline/OfflineRegionDetailActivity.kt
@@ -4,11 +4,6 @@ import android.os.Bundle
 import android.view.View
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
-import com.mapbox.mapboxsdk.maps.MapView
-import com.mapbox.mapboxsdk.offline.OfflineManager
-import com.mapbox.mapboxsdk.offline.OfflineRegion
-import com.mapbox.mapboxsdk.offline.OfflineRegionDefinition
-import com.mapbox.mapboxsdk.offline.OfflineRegionStatus
 import com.mapbox.mapboxsdk.plugins.offline.model.OfflineDownloadOptions
 import com.mapbox.mapboxsdk.plugins.offline.offline.OfflineConstants.KEY_BUNDLE
 import com.mapbox.mapboxsdk.plugins.offline.offline.OfflineDownloadChangeListener
@@ -16,6 +11,11 @@ import com.mapbox.mapboxsdk.plugins.offline.offline.OfflinePlugin
 import com.mapbox.mapboxsdk.plugins.offline.utils.OfflineUtils
 import com.mapbox.mapboxsdk.plugins.testapp.R
 import com.mapbox.mapboxsdk.plugins.testapp.databinding.ActivityOfflineRegionDetailBinding
+import org.maplibre.android.maps.MapView
+import org.maplibre.android.offline.OfflineManager
+import org.maplibre.android.offline.OfflineRegion
+import org.maplibre.android.offline.OfflineRegionDefinition
+import org.maplibre.android.offline.OfflineRegionStatus
 import timber.log.Timber
 
 /**

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/offline/OfflineRegionListActivity.kt
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/offline/OfflineRegionListActivity.kt
@@ -7,11 +7,11 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.*
 import androidx.appcompat.app.AppCompatActivity
-import com.mapbox.mapboxsdk.offline.OfflineManager
-import com.mapbox.mapboxsdk.offline.OfflineRegion
-import com.mapbox.mapboxsdk.offline.OfflineRegionDefinition
 import com.mapbox.mapboxsdk.plugins.offline.utils.OfflineUtils
 import com.mapbox.mapboxsdk.plugins.testapp.R
+import org.maplibre.android.offline.OfflineManager
+import org.maplibre.android.offline.OfflineRegion
+import org.maplibre.android.offline.OfflineRegionDefinition
 import java.util.*
 
 /**

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/offline/OfflineUiComponentsActivity.kt
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/offline/OfflineUiComponentsActivity.kt
@@ -5,14 +5,14 @@ import android.content.Intent
 import android.os.Bundle
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
-import com.mapbox.mapboxsdk.camera.CameraPosition
-import com.mapbox.mapboxsdk.geometry.LatLng
 import com.mapbox.mapboxsdk.plugins.offline.OfflineRegionSelector
 import com.mapbox.mapboxsdk.plugins.offline.model.NotificationOptions
 import com.mapbox.mapboxsdk.plugins.offline.model.RegionSelectionOptions
 import com.mapbox.mapboxsdk.plugins.offline.offline.OfflinePlugin
 import com.mapbox.mapboxsdk.plugins.testapp.R
 import com.mapbox.mapboxsdk.plugins.testapp.databinding.ActivityOfflineUiComponentsBinding
+import org.maplibre.android.camera.CameraPosition
+import org.maplibre.android.geometry.LatLng
 import java.util.Locale
 
 class OfflineUiComponentsActivity : AppCompatActivity() {

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/scalebar/ScalebarActivity.kt
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/scalebar/ScalebarActivity.kt
@@ -2,19 +2,18 @@ package com.mapbox.mapboxsdk.plugins.testapp.activity.scalebar
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
-import com.mapbox.geojson.LineString
-import com.mapbox.geojson.Point
-import com.mapbox.mapboxsdk.maps.MapView
-import com.mapbox.mapboxsdk.maps.MapboxMap
-import com.mapbox.mapboxsdk.maps.Style
-import com.mapbox.mapboxsdk.plugins.testapp.R
 import com.mapbox.mapboxsdk.plugins.testapp.databinding.ActivityScalebarBinding
-import com.mapbox.mapboxsdk.style.layers.LineLayer
-import com.mapbox.mapboxsdk.style.sources.GeoJsonSource
 import com.mapbox.pluginscalebar.ScaleBarOptions
 import com.mapbox.pluginscalebar.ScaleBarPlugin
-import com.mapbox.turf.TurfConstants
-import com.mapbox.turf.TurfMeasurement
+import org.maplibre.android.maps.MapLibreMap
+import org.maplibre.android.maps.MapView
+import org.maplibre.android.maps.Style
+import org.maplibre.android.style.layers.LineLayer
+import org.maplibre.android.style.sources.GeoJsonSource
+import org.maplibre.geojson.LineString
+import org.maplibre.geojson.Point
+import org.maplibre.turf.TurfConstants
+import org.maplibre.turf.TurfMeasurement
 
 /**
  * Activity showing a scalebar used on a MapView.
@@ -37,8 +36,8 @@ class ScalebarActivity : AppCompatActivity() {
         }
     }
 
-    private fun addScalebar(mapboxMap: MapboxMap) {
-        val scaleBarPlugin = ScaleBarPlugin(mapView, mapboxMap)
+    private fun addScalebar(maplibreMap: MapLibreMap) {
+        val scaleBarPlugin = ScaleBarPlugin(mapView, maplibreMap)
         val scaleBarOptions = ScaleBarOptions(this)
         scaleBarOptions
             .setTextColor(android.R.color.black)

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/scalebar/ScalebarActivity.kt
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/scalebar/ScalebarActivity.kt
@@ -28,9 +28,9 @@ class ScalebarActivity : AppCompatActivity() {
 
         mapView = binding.mapView
         mapView.onCreate(savedInstanceState)
-        mapView.getMapAsync { mapboxMap ->
-            mapboxMap.setStyle("https://api.maptiler.com/maps/basic-v2/style.json?key=FTNrjsa7Nahw874tmMi7") {
-                addScalebar(mapboxMap)
+        mapView.getMapAsync { maplibreMap ->
+            maplibreMap.setStyle("https://api.maptiler.com/maps/basic-v2/style.json?key=FTNrjsa7Nahw874tmMi7") {
+                addScalebar(maplibreMap)
                 setupTestLine(it)
             }
         }

--- a/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/scalebar/ScalebarActivity.kt
+++ b/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/scalebar/ScalebarActivity.kt
@@ -29,7 +29,7 @@ class ScalebarActivity : AppCompatActivity() {
         mapView = binding.mapView
         mapView.onCreate(savedInstanceState)
         mapView.getMapAsync { mapboxMap ->
-            mapboxMap.setStyle(Style.getPredefinedStyle("Streets")) {
+            mapboxMap.setStyle("https://api.maptiler.com/maps/basic-v2/style.json?key=FTNrjsa7Nahw874tmMi7") {
                 addScalebar(mapboxMap)
                 setupTestLine(it)
             }

--- a/app/src/main/res/layout/activity_annotation.xml
+++ b/app/src/main/res/layout/activity_annotation.xml
@@ -6,7 +6,7 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-    <com.mapbox.mapboxsdk.maps.MapView
+    <org.maplibre.android.maps.MapView
             android:id="@+id/mapView"
             android:layout_width="match_parent"
             android:layout_height="match_parent"/>

--- a/app/src/main/res/layout/activity_cluster.xml
+++ b/app/src/main/res/layout/activity_cluster.xml
@@ -6,7 +6,7 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-    <com.mapbox.mapboxsdk.maps.MapView
+    <org.maplibre.android.maps.MapView
             android:id="@+id/mapView"
             android:layout_width="match_parent"
             android:layout_height="match_parent"/>

--- a/app/src/main/res/layout/activity_localization.xml
+++ b/app/src/main/res/layout/activity_localization.xml
@@ -6,7 +6,7 @@
   android:layout_height="match_parent"
   android:orientation="vertical">
 
-  <com.mapbox.mapboxsdk.maps.MapView
+  <org.maplibre.android.maps.MapView
     android:id="@+id/mapView"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -16,7 +16,7 @@
     app:maplibre_cameraZoom="2.5"
     app:maplibre_uiAttribution="false">
 
-  </com.mapbox.mapboxsdk.maps.MapView>
+  </org.maplibre.android.maps.MapView>
 
   <com.google.android.material.floatingactionbutton.FloatingActionButton
       android:id="@+id/fabStyles"

--- a/app/src/main/res/layout/activity_maps_ktx.xml
+++ b/app/src/main/res/layout/activity_maps_ktx.xml
@@ -6,7 +6,7 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-    <com.mapbox.mapboxsdk.maps.MapView
+    <org.maplibre.android.maps.MapView
             android:id="@+id/mapView"
             android:layout_width="match_parent"
             android:layout_height="match_parent"

--- a/app/src/main/res/layout/activity_offline_region_detail.xml
+++ b/app/src/main/res/layout/activity_offline_region_detail.xml
@@ -11,7 +11,7 @@
         android:layout_height="match_parent"
         android:orientation="vertical">
 
-        <com.mapbox.mapboxsdk.maps.MapView
+        <org.maplibre.android.maps.MapView
             android:id="@+id/mapView"
             android:layout_width="match_parent"
             android:layout_height="224dp"

--- a/app/src/main/res/layout/activity_scalebar.xml
+++ b/app/src/main/res/layout/activity_scalebar.xml
@@ -6,7 +6,7 @@
     android:layout_height="match_parent"
     tools:context=".activity.scalebar.ScalebarActivity">
 
-    <com.mapbox.mapboxsdk.maps.MapView
+    <org.maplibre.android.maps.MapView
         android:id="@+id/mapView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -7,7 +7,7 @@
   ]
 
   version = [
-      mapLibreAndroidSdk : '10.0.2',
+      mapLibreAndroidSdk : '11.0.0-pre3',
       mapLibreJava       : '5.9.0',
       mapLibreTurf       : '5.9.0',
       playLocation       : '16.0.0',
@@ -33,7 +33,7 @@
   pluginVersion = [
       checkstyle: '8.10.1',
       gradle    : '7.4.0',
-      kotlin    : '1.8.10',
+      kotlin    : '1.9.0',
       dokka     : '0.9.17',
       kotlinLint: '8.1.0',
       gradleNexus: "1.1.0"

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -7,7 +7,7 @@
   ]
 
   version = [
-      mapLibreAndroidSdk : '11.0.0-pre3',
+      mapLibreAndroidSdk : '11.0.0',
       mapLibreJava       : '5.9.0',
       mapLibreTurf       : '5.9.0',
       playLocation       : '16.0.0',

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -33,7 +33,7 @@
   pluginVersion = [
       checkstyle: '8.10.1',
       gradle    : '7.4.0',
-      kotlin    : '1.9.0',
+      kotlin    : '1.8.10',
       dokka     : '0.9.17',
       kotlinLint: '8.1.0',
       gradleNexus: "1.1.0"

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -3,7 +3,7 @@
   androidVersions = [
       minSdkVersion    : 21,
       targetSdkVersion : 30,
-      compileSdkVersion: 31,
+      compileSdkVersion: 33,
   ]
 
   version = [

--- a/ktx-mapbox-maps/src/main/java/com/mapbox/mapboxsdk/plugins/maps/Geometry.kt
+++ b/ktx-mapbox-maps/src/main/java/com/mapbox/mapboxsdk/plugins/maps/Geometry.kt
@@ -1,7 +1,7 @@
 package com.mapbox.mapboxsdk.plugins.maps
 
-import com.mapbox.geojson.Point
-import com.mapbox.mapboxsdk.geometry.LatLng
+import org.maplibre.android.geometry.LatLng
+import org.maplibre.geojson.Point
 
 /**
  * Returns a LatLng representation

--- a/ktx-mapbox-maps/src/main/java/com/mapbox/mapboxsdk/plugins/maps/Maps.kt
+++ b/ktx-mapbox-maps/src/main/java/com/mapbox/mapboxsdk/plugins/maps/Maps.kt
@@ -1,11 +1,11 @@
 package com.mapbox.mapboxsdk.plugins.maps
 
 import android.graphics.RectF
-import com.mapbox.geojson.Feature
-import com.mapbox.mapboxsdk.geometry.LatLng
-import com.mapbox.mapboxsdk.geometry.LatLngBounds
-import com.mapbox.mapboxsdk.maps.MapboxMap
-import com.mapbox.mapboxsdk.style.expressions.Expression
+import org.maplibre.android.geometry.LatLng
+import org.maplibre.android.geometry.LatLngBounds
+import org.maplibre.android.maps.MapLibreMap
+import org.maplibre.android.style.expressions.Expression
+import org.maplibre.geojson.Feature
 
 /**
  * Queries the map for rendered features
@@ -14,7 +14,7 @@ import com.mapbox.mapboxsdk.style.expressions.Expression
  * @param layerIds    optionally - only query these layers
  * @return the list of feature
  */
-inline fun MapboxMap.queryRenderedFeatures(
+inline fun MapLibreMap.queryRenderedFeatures(
     latLng: LatLng,
     vararg layerIds: String,
 ): List<Feature> {
@@ -29,7 +29,7 @@ inline fun MapboxMap.queryRenderedFeatures(
  * @param layerIds    optionally - only query these layers
  * @return the list of feature
  */
-inline fun MapboxMap.queryRenderedFeatures(
+inline fun MapLibreMap.queryRenderedFeatures(
     latLng: LatLng,
     filter: Expression?,
     vararg layerIds: String,
@@ -44,7 +44,7 @@ inline fun MapboxMap.queryRenderedFeatures(
  * @param layerIds     optionally - only query these layers
  * @return the list of feature
  */
-inline fun MapboxMap.queryRenderedFeatures(
+inline fun MapLibreMap.queryRenderedFeatures(
     latLngBounds: LatLngBounds,
     vararg layerIds: String,
 ): List<Feature> {
@@ -58,7 +58,7 @@ inline fun MapboxMap.queryRenderedFeatures(
  * @param layerIds     optionally - only query these layers
  * @return the list of feature
  */
-inline fun MapboxMap.queryRenderedFeatures(
+inline fun MapLibreMap.queryRenderedFeatures(
     latLngBounds: LatLngBounds,
     filter: Expression?,
     vararg layerIds: String,

--- a/ktx-mapbox-maps/src/test/java/com/mapbox/mapboxsdk/plugins/maps/GeometryTest.kt
+++ b/ktx-mapbox-maps/src/test/java/com/mapbox/mapboxsdk/plugins/maps/GeometryTest.kt
@@ -1,11 +1,11 @@
 package com.mapbox.mapboxsdk.plugins.maps
 
-import com.mapbox.geojson.Point
-import com.mapbox.mapboxsdk.geometry.LatLng
 import junit.framework.Assert
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
+import org.maplibre.android.geometry.LatLng
+import org.maplibre.geojson.Point
 
 @RunWith(JUnit4::class)
 class GeometryTest {

--- a/plugin-annotation/scripts/annotation.java.ejs
+++ b/plugin-annotation/scripts/annotation.java.ejs
@@ -17,7 +17,7 @@ import android.graphics.PointF;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonNull;
 import com.google.gson.JsonObject;
-import com.mapbox.geojson.*;
+import org.maplibre.geojson.*;
 import org.maplibre.android.geometry.LatLng;
 import org.maplibre.android.style.layers.Property;
 import org.maplibre.android.style.layers.PropertyFactory;

--- a/plugin-annotation/scripts/annotation.java.ejs
+++ b/plugin-annotation/scripts/annotation.java.ejs
@@ -18,18 +18,18 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonNull;
 import com.google.gson.JsonObject;
 import com.mapbox.geojson.*;
-import com.mapbox.mapboxsdk.geometry.LatLng;
-import com.mapbox.mapboxsdk.style.layers.Property;
-import com.mapbox.mapboxsdk.style.layers.PropertyFactory;
-import com.mapbox.mapboxsdk.utils.ColorUtils;
+import org.maplibre.android.geometry.LatLng;
+import org.maplibre.android.style.layers.Property;
+import org.maplibre.android.style.layers.PropertyFactory;
+import org.maplibre.android.utils.ColorUtils;
 import com.mapbox.android.gestures.MoveDistancesObject;
-import com.mapbox.mapboxsdk.maps.Projection;
+import org.maplibre.android.maps.Projection;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.mapbox.mapboxsdk.constants.GeometryConstants.MAX_MERCATOR_LATITUDE;
-import static com.mapbox.mapboxsdk.constants.GeometryConstants.MIN_MERCATOR_LATITUDE;
+import static org.maplibre.android.constants.GeometryConstants.MAX_MERCATOR_LATITUDE;
+import static org.maplibre.android.constants.GeometryConstants.MIN_MERCATOR_LATITUDE;
 
 @UiThread
 public class <%- camelize(type) %> extends Annotation<<%- geometryType(type) %>> {

--- a/plugin-annotation/scripts/annotation_element_provider.java.ejs
+++ b/plugin-annotation/scripts/annotation_element_provider.java.ejs
@@ -9,9 +9,9 @@ package com.mapbox.mapboxsdk.plugins.annotation;
 
 import androidx.annotation.Nullable;
 
-import com.mapbox.mapboxsdk.style.layers.<%- camelize(type) %>Layer;
-import com.mapbox.mapboxsdk.style.sources.GeoJsonOptions;
-import com.mapbox.mapboxsdk.style.sources.GeoJsonSource;
+import org.maplibre.android.style.layers.<%- camelize(type) %>Layer;
+import org.maplibre.android.style.sources.GeoJsonOptions;
+import org.maplibre.android.style.sources.GeoJsonSource;
 
 import java.util.concurrent.atomic.AtomicLong;
 

--- a/plugin-annotation/scripts/annotation_instrumentation_test.junit.ejs
+++ b/plugin-annotation/scripts/annotation_instrumentation_test.junit.ejs
@@ -45,8 +45,8 @@ public class <%- camelize(type) %>Test extends BaseActivityTest {
 
     private void setupAnnotation() {
         Timber.i("Retrieving layer");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
-            <%- camelize(type) %>Manager <%- type %>Manager = new <%- camelize(type) %>Manager(idlingResource.getMapView(), mapboxMap, Objects.requireNonNull(mapboxMap.getStyle()));
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
+            <%- camelize(type) %>Manager <%- type %>Manager = new <%- camelize(type) %>Manager(idlingResource.getMapView(), maplibreMap, Objects.requireNonNull(maplibreMap.getStyle()));
 <% if (type === "circle" || type === "symbol") { -%>
             <%- type %> = <%- type %>Manager.create(new <%- camelize(type) %>Options().withLatLng(new LatLng()));
 <% } else if (type === "line") { -%>
@@ -74,7 +74,7 @@ public class <%- camelize(type) %>Test extends BaseActivityTest {
         validateTestSetup();
         setupAnnotation();
         Timber.i("<%- property.name %>");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertNotNull(<%- type %>);
 
             <%- type %>.set<%- camelize(property.name) %>(new PointF(1.0f, 1.0f));
@@ -88,7 +88,7 @@ public class <%- camelize(type) %>Test extends BaseActivityTest {
         validateTestSetup();
         setupAnnotation();
         Timber.i("<%- property.name %>");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertNotNull(<%- type %>);
 
             <%- type %>.set<%- camelize(property.name) %>(<%- defaultValueJava(property) %>);
@@ -101,7 +101,7 @@ public class <%- camelize(type) %>Test extends BaseActivityTest {
         validateTestSetup();
         setupAnnotation();
         Timber.i("<%- property.name %>");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertNotNull(<%- type %>);
             <%- type %>.set<%- camelize(property.name) %>(ColorUtils.rgbaToColor(<%- defaultValueJava(property) %>));
             assertEquals(<%- type %>.get<%- camelize(property.name) %>AsInt(), ColorUtils.rgbaToColor(<%- defaultValueJava(property) %>));
@@ -115,7 +115,7 @@ public class <%- camelize(type) %>Test extends BaseActivityTest {
         validateTestSetup();
         setupAnnotation();
         Timber.i("<%- property.name %>");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertNotNull(<%- type %>);
 
             <%- type %>.set<%- camelize(property.name) %>(<%- defaultValueJava(property) %>);

--- a/plugin-annotation/scripts/annotation_instrumentation_test.junit.ejs
+++ b/plugin-annotation/scripts/annotation_instrumentation_test.junit.ejs
@@ -1,3 +1,4 @@
+
 <%
   const type = locals.type;
   const properties = locals.properties;
@@ -10,7 +11,7 @@ import android.graphics.PointF;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
-import com.mapbox.mapboxsdk.geometry.LatLng;
+import org.maplibre.android.geometry.LatLng;
 import com.mapbox.mapboxsdk.plugins.BaseActivityTest;
 import com.mapbox.mapboxsdk.plugins.testapp.activity.TestActivity;
 import com.mapbox.mapboxsdk.utils.ColorUtils;
@@ -24,7 +25,7 @@ import java.util.Objects;
 
 import static com.mapbox.mapboxsdk.plugins.annotation.MapboxMapAction.invoke;
 import static org.junit.Assert.*;
-import static com.mapbox.mapboxsdk.style.layers.Property.*;
+import static org.maplibre.android.style.layers.Property.*;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/plugin-annotation/scripts/annotation_instrumentation_test.junit.ejs
+++ b/plugin-annotation/scripts/annotation_instrumentation_test.junit.ejs
@@ -14,7 +14,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 import org.maplibre.android.geometry.LatLng;
 import com.mapbox.mapboxsdk.plugins.BaseActivityTest;
 import com.mapbox.mapboxsdk.plugins.testapp.activity.TestActivity;
-import com.mapbox.mapboxsdk.utils.ColorUtils;
+import org.maplibre.android.utils.ColorUtils;
 
 import timber.log.Timber;
 

--- a/plugin-annotation/scripts/annotation_manager.java.ejs
+++ b/plugin-annotation/scripts/annotation_manager.java.ejs
@@ -12,8 +12,8 @@ import androidx.annotation.Nullable;
 import androidx.annotation.UiThread;
 import androidx.annotation.VisibleForTesting;
 
-import com.mapbox.geojson.Feature;
-import com.mapbox.geojson.FeatureCollection;
+import org.maplibre.geojson.Feature;
+import org.maplibre.geojson.FeatureCollection;
 import org.maplibre.android.maps.MapView;
 import org.maplibre.android.maps.MapLibreMap;
 import org.maplibre.android.maps.Style;

--- a/plugin-annotation/scripts/annotation_manager.java.ejs
+++ b/plugin-annotation/scripts/annotation_manager.java.ejs
@@ -14,21 +14,21 @@ import androidx.annotation.VisibleForTesting;
 
 import com.mapbox.geojson.Feature;
 import com.mapbox.geojson.FeatureCollection;
-import com.mapbox.mapboxsdk.maps.MapView;
-import com.mapbox.mapboxsdk.maps.MapboxMap;
-import com.mapbox.mapboxsdk.maps.Style;
-import com.mapbox.mapboxsdk.style.expressions.Expression;
-import com.mapbox.mapboxsdk.style.layers.<%- camelize(type) %>Layer;
-import com.mapbox.mapboxsdk.style.layers.PropertyValue;
-import com.mapbox.mapboxsdk.style.layers.PropertyFactory;
-import com.mapbox.mapboxsdk.style.sources.GeoJsonOptions;
-import com.mapbox.mapboxsdk.style.layers.Property;
+import org.maplibre.android.maps.MapView;
+import org.maplibre.android.maps.MapLibreMap;
+import org.maplibre.android.maps.Style;
+import org.maplibre.android.style.expressions.Expression;
+import org.maplibre.android.style.layers.<%- camelize(type) %>Layer;
+import org.maplibre.android.style.layers.PropertyValue;
+import org.maplibre.android.style.layers.PropertyFactory;
+import org.maplibre.android.style.sources.GeoJsonOptions;
+import org.maplibre.android.style.layers.Property;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.mapbox.mapboxsdk.style.expressions.Expression.get;
-import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.*;
+import static org.maplibre.android.style.expressions.Expression.get;
+import static org.maplibre.android.style.layers.PropertyFactory.*;
 
 /**
  * The <%- type %> manager allows to add <%- type %>s to a map.
@@ -44,61 +44,61 @@ public class <%- camelize(type) %>Manager extends AnnotationManager<<%- camelize
     /**
      * Create a <%- type %> manager, used to manage <%- type %>s.
      *
-     * @param mapboxMap the map object to add <%- type %>s to
+     * @param maplibreMap the map object to add <%- type %>s to
      * @param style     a valid a fully loaded style object
      */
     @UiThread
-    public <%- camelize(type) %>Manager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style) {
-        this(mapView, mapboxMap, style, null, null, (GeoJsonOptions) null);
+    public <%- camelize(type) %>Manager(@NonNull MapView mapView, @NonNull MapLibreMap maplibreMap, @NonNull Style style) {
+        this(mapView, maplibreMap, style, null, null, (GeoJsonOptions) null);
     }
 
     /**
      * Create a <%- type %> manager, used to manage <%- type %>s.
      *
-     * @param mapboxMap    the map object to add <%- type %>s to
+     * @param maplibreMap    the map object to add <%- type %>s to
      * @param style        a valid a fully loaded style object
      * @param belowLayerId the id of the layer above the <%- type %> layer
      * @param aboveLayerId the id of the layer below the <%- type %> layer
      */
     @UiThread
-    public <%- camelize(type) %>Manager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @Nullable String belowLayerId, @Nullable String aboveLayerId) {
-        this(mapView, mapboxMap, style, belowLayerId, aboveLayerId, (GeoJsonOptions) null);
+    public <%- camelize(type) %>Manager(@NonNull MapView mapView, @NonNull MapLibreMap maplibreMap, @NonNull Style style, @Nullable String belowLayerId, @Nullable String aboveLayerId) {
+        this(mapView, maplibreMap, style, belowLayerId, aboveLayerId, (GeoJsonOptions) null);
     }
 
     /**
      * Create a <%- type %> manager, used to manage <%- type %>s.
      *
-     * @param mapboxMap      the map object to add <%- type %>s to
+     * @param maplibreMap      the map object to add <%- type %>s to
      * @param style          a valid a fully loaded style object
      * @param belowLayerId   the id of the layer above the <%- type %> layer
      * @param aboveLayerId   the id of the layer below the <%- type %> layer
      * @param geoJsonOptions options for the internal source
      */
     @UiThread
-    public <%- camelize(type) %>Manager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @Nullable String belowLayerId, @Nullable String aboveLayerId, @Nullable GeoJsonOptions geoJsonOptions) {
-        this(mapView, mapboxMap, style, new <%- camelize(type) %>ElementProvider(), belowLayerId, aboveLayerId, geoJsonOptions, DraggableAnnotationController.getInstance(mapView, mapboxMap));
+    public <%- camelize(type) %>Manager(@NonNull MapView mapView, @NonNull MapLibreMap maplibreMap, @NonNull Style style, @Nullable String belowLayerId, @Nullable String aboveLayerId, @Nullable GeoJsonOptions geoJsonOptions) {
+        this(mapView, maplibreMap, style, new <%- camelize(type) %>ElementProvider(), belowLayerId, aboveLayerId, geoJsonOptions, DraggableAnnotationController.getInstance(mapView, maplibreMap));
     }
 <% if (type === "symbol") { -%>
 
     /**
      * Create a <%- type %> manager, used to manage <%- type %>s.
      *
-     * @param mapboxMap      the map object to add <%- type %>s to
+     * @param maplibreMap      the map object to add <%- type %>s to
      * @param style          a valid a fully loaded style object
      * @param belowLayerId   the id of the layer above the <%- type %> layer
      * @param aboveLayerId   the id of the layer below the <%- type %> layer
      * @param clusterOptions options for the clustering configuration
      */
     @UiThread
-    public <%- camelize(type) %>Manager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @Nullable String belowLayerId, @Nullable String aboveLayerId, @NonNull ClusterOptions clusterOptions) {
-        this(mapView, mapboxMap, style, new SymbolElementProvider(), belowLayerId, aboveLayerId, new GeoJsonOptions().withCluster(true).withClusterRadius(clusterOptions.getClusterRadius()).withClusterMaxZoom(clusterOptions.getClusterMaxZoom()), DraggableAnnotationController.getInstance(mapView, mapboxMap));
+    public <%- camelize(type) %>Manager(@NonNull MapView mapView, @NonNull MapLibreMap maplibreMap, @NonNull Style style, @Nullable String belowLayerId, @Nullable String aboveLayerId, @NonNull ClusterOptions clusterOptions) {
+        this(mapView, maplibreMap, style, new SymbolElementProvider(), belowLayerId, aboveLayerId, new GeoJsonOptions().withCluster(true).withClusterRadius(clusterOptions.getClusterRadius()).withClusterMaxZoom(clusterOptions.getClusterMaxZoom()), DraggableAnnotationController.getInstance(mapView, maplibreMap));
         clusterOptions.apply(style, coreElementProvider.getSourceId());
     }
 <% } -%>
 
     @UiThread
-    <%- camelize(type) %>Manager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @NonNull CoreElementProvider<<%- camelize(type) %>Layer> coreElementProvider, @Nullable String belowLayerId, @Nullable String aboveLayerId, @Nullable GeoJsonOptions geoJsonOptions, DraggableAnnotationController draggableAnnotationController) {
-        super(mapView, mapboxMap, style, coreElementProvider, draggableAnnotationController, belowLayerId, aboveLayerId, geoJsonOptions);
+    <%- camelize(type) %>Manager(@NonNull MapView mapView, @NonNull MapLibreMap maplibreMap, @NonNull Style style, @NonNull CoreElementProvider<<%- camelize(type) %>Layer> coreElementProvider, @Nullable String belowLayerId, @Nullable String aboveLayerId, @Nullable GeoJsonOptions geoJsonOptions, DraggableAnnotationController draggableAnnotationController) {
+        super(mapView, maplibreMap, style, coreElementProvider, draggableAnnotationController, belowLayerId, aboveLayerId, geoJsonOptions);
     }
 
     @Override

--- a/plugin-annotation/scripts/annotation_manager_instrumentation_test.junit.ejs
+++ b/plugin-annotation/scripts/annotation_manager_instrumentation_test.junit.ejs
@@ -38,8 +38,8 @@ public class <%- camelize(type) %>ManagerTest extends BaseActivityTest {
 
     private void setup<%- camelize(type) %>Manager() {
         Timber.i("Retrieving layer");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
-            <%- type %>Manager = new <%- camelize(type) %>Manager(idlingResource.getMapView(), mapboxMap, Objects.requireNonNull(mapboxMap.getStyle()));
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
+            <%- type %>Manager = new <%- camelize(type) %>Manager(idlingResource.getMapView(), maplibreMap, Objects.requireNonNull(maplibreMap.getStyle()));
         });
     }
 <% for (const property of properties) { -%>
@@ -50,7 +50,7 @@ public class <%- camelize(type) %>ManagerTest extends BaseActivityTest {
         validateTestSetup();
         setup<%- camelize(type) %>Manager();
         Timber.i("<%- property.name %>");
-        invoke(mapboxMap, (uiController, mapboxMap) -> {
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
             assertNotNull(<%- type %>Manager);
 
             <%- type %>Manager.set<%- camelize(property.name) %>(<%- defaultValueJava(property) %>);

--- a/plugin-annotation/scripts/annotation_manager_instrumentation_test.junit.ejs
+++ b/plugin-annotation/scripts/annotation_manager_instrumentation_test.junit.ejs
@@ -8,7 +8,7 @@ package com.mapbox.mapboxsdk.plugins.annotation;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
-import com.mapbox.mapboxsdk.geometry.LatLng;
+import org.maplibre.android.geometry.LatLng;
 import com.mapbox.mapboxsdk.plugins.testapp.activity.TestActivity;
 import com.mapbox.mapboxsdk.plugins.BaseActivityTest;
 
@@ -21,7 +21,7 @@ import java.util.Objects;
 
 import static com.mapbox.mapboxsdk.plugins.annotation.MapboxMapAction.invoke;
 import static org.junit.Assert.*;
-import static com.mapbox.mapboxsdk.style.layers.Property.*;
+import static org.maplibre.android.style.layers.Property.*;
 
 /**
  * Basic smoke tests for <%- camelize(type) %>Manager

--- a/plugin-annotation/scripts/annotation_manager_unit_test.junit.ejs
+++ b/plugin-annotation/scripts/annotation_manager_unit_test.junit.ejs
@@ -11,15 +11,15 @@ import android.graphics.PointF;
 
 import com.google.gson.JsonPrimitive;
 import com.mapbox.geojson.*;
-import com.mapbox.mapboxsdk.geometry.LatLng;
-import com.mapbox.mapboxsdk.maps.MapView;
-import com.mapbox.mapboxsdk.maps.MapboxMap;
-import com.mapbox.mapboxsdk.maps.Style;
-import com.mapbox.mapboxsdk.style.expressions.Expression;
-import com.mapbox.mapboxsdk.style.layers.*;
-import com.mapbox.mapboxsdk.style.sources.GeoJsonOptions;
-import com.mapbox.mapboxsdk.style.sources.GeoJsonSource;
-import com.mapbox.mapboxsdk.utils.ColorUtils;
+import org.maplibre.android.geometry.LatLng;
+import org.maplibre.android.maps.MapView;
+import org.maplibre.android.maps.MapLibreMap;
+import org.maplibre.android.maps.Style;
+import org.maplibre.android.style.expressions.Expression;
+import org.maplibre.android.style.layers.*;
+import org.maplibre.android.style.sources.GeoJsonOptions;
+import org.maplibre.android.style.sources.GeoJsonSource;
+import org.maplibre.android.utils.ColorUtils;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -30,9 +30,9 @@ import java.util.List;
 import java.util.Arrays;
 
 import static com.mapbox.mapboxsdk.plugins.annotation.ConvertUtils.convertArray;
-import static com.mapbox.mapboxsdk.style.expressions.Expression.get;
-import static com.mapbox.mapboxsdk.style.layers.Property.*;
-import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.*;
+import static org.maplibre.android.style.expressions.Expression.get;
+import static org.maplibre.android.style.layers.Property.*;
+import static org.maplibre.android.style.layers.PropertyFactory.*;
 import static junit.framework.Assert.*;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.*;
@@ -41,7 +41,7 @@ public class <%- camelize(type) %>ManagerTest {
 
     private DraggableAnnotationController draggableAnnotationController = mock(DraggableAnnotationController.class);
     private MapView mapView = mock(MapView.class);
-    private MapboxMap mapboxMap = mock(MapboxMap.class);
+    private MapLibreMap mapboxMap = mock(MapLibreMap.class);
     private Style style = mock(Style.class);
     private GeoJsonSource geoJsonSource = mock(GeoJsonSource.class);
     private GeoJsonSource optionedGeoJsonSource = mock(GeoJsonSource.class);

--- a/plugin-annotation/scripts/annotation_manager_unit_test.junit.ejs
+++ b/plugin-annotation/scripts/annotation_manager_unit_test.junit.ejs
@@ -41,7 +41,7 @@ public class <%- camelize(type) %>ManagerTest {
 
     private DraggableAnnotationController draggableAnnotationController = mock(DraggableAnnotationController.class);
     private MapView mapView = mock(MapView.class);
-    private MapLibreMap mapboxMap = mock(MapLibreMap.class);
+    private MapLibreMap maplibreMap = mock(MapLibreMap.class);
     private Style style = mock(Style.class);
     private GeoJsonSource geoJsonSource = mock(GeoJsonSource.class);
     private GeoJsonSource optionedGeoJsonSource = mock(GeoJsonSource.class);
@@ -62,7 +62,7 @@ public class <%- camelize(type) %>ManagerTest {
 
     @Test
     public void testInitialization() {
-        <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(style).addSource(geoJsonSource);
         verify(style).addLayer(<%- type  %>Layer);
         assertTrue(<%- type  %>Manager.dataDrivenPropertyUsageMap.size() > 0);
@@ -75,7 +75,7 @@ public class <%- camelize(type) %>ManagerTest {
 
     @Test
     public void testInitializationOnStyleReload() {
-        <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(style).addSource(geoJsonSource);
         verify(style).addLayer(<%- type  %>Layer);
         assertTrue(<%- type  %>Manager.dataDrivenPropertyUsageMap.size() > 0);
@@ -92,7 +92,7 @@ public class <%- camelize(type) %>ManagerTest {
         loadingArgumentCaptor.getValue().onDidFinishLoadingStyle();
 
         ArgumentCaptor<Style.OnStyleLoaded> styleLoadedArgumentCaptor = ArgumentCaptor.forClass(Style.OnStyleLoaded.class);
-        verify(mapboxMap).getStyle(styleLoadedArgumentCaptor.capture());
+        verify(maplibreMap).getStyle(styleLoadedArgumentCaptor.capture());
 
         Style newStyle = mock(Style.class);
         when(newStyle.isFullyLoaded()).thenReturn(true);
@@ -114,7 +114,7 @@ public class <%- camelize(type) %>ManagerTest {
 
     @Test
     public void testLayerBelowInitialization() {
-        <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, "test_layer", null, null, draggableAnnotationController);
+        <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, maplibreMap, style, coreElementProvider, "test_layer", null, null, draggableAnnotationController);
         verify(style).addSource(geoJsonSource);
         verify(style).addLayerBelow(<%- type  %>Layer, "test_layer");
         assertTrue(<%- type  %>Manager.dataDrivenPropertyUsageMap.size() > 0);
@@ -126,7 +126,7 @@ public class <%- camelize(type) %>ManagerTest {
 
     @Test
     public void testGeoJsonOptionsInitialization() {
-        <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, geoJsonOptions, draggableAnnotationController);
+        <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, maplibreMap, style, coreElementProvider, null, null, geoJsonOptions, draggableAnnotationController);
         verify(style).addSource(optionedGeoJsonSource);
         verify(style).addLayer(<%- type  %>Layer);
         assertTrue(<%- type  %>Manager.dataDrivenPropertyUsageMap.size() > 0);
@@ -139,13 +139,13 @@ public class <%- camelize(type) %>ManagerTest {
 
     @Test
     public void testLayerId() {
-        <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         assertEquals(layerId, <%- type  %>Manager.getLayerId());
     }
 
     @Test
     public void testAdd<%- camelize(type) %>() {
-        <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
 <% if (type === "circle" || type === "symbol") { -%>
         <%- camelize(type) %> <%- type %> = <%- type %>Manager.create(new <%- camelize(type) %>Options().withLatLng(new LatLng()));
 <% } else if (type === "line") { -%>
@@ -168,7 +168,7 @@ public class <%- camelize(type) %>ManagerTest {
 
     @Test
     public void add<%- camelize(type) %>FromFeatureCollection() {
-        <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
 <% if (type === "circle" || type === "symbol") { -%>
         Geometry geometry = Point.fromLngLat(10, 10);
 <% } else if (type === "line") { -%>
@@ -227,7 +227,7 @@ public class <%- camelize(type) %>ManagerTest {
 
     @Test
     public void add<%- camelize(type) %>s() {
-        <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
 <% if (type === "circle" || type === "symbol") { -%>
         List<LatLng> latLngList = new ArrayList<>();
         latLngList.add(new LatLng());
@@ -287,7 +287,7 @@ public class <%- camelize(type) %>ManagerTest {
 
     @Test
     public void testDelete<%- camelize(type) %>() {
-        <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
 <% if (type === "circle" || type === "symbol") { -%>
         <%- camelize(type) %> <%- type %> = <%- type %>Manager.create(new <%- camelize(type) %>Options().withLatLng(new LatLng()));
 <% } else if (type === "line") { -%>
@@ -310,7 +310,7 @@ public class <%- camelize(type) %>ManagerTest {
 
     @Test
     public void testGeometry<%- camelize(type) %>() {
-        <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
 <% if (type === "circle" || type === "symbol") { -%>
         LatLng latLng = new LatLng(12, 34);
         <%- camelize(type) %>Options options = new <%- camelize(type) %>Options().withLatLng(latLng);
@@ -365,7 +365,7 @@ public class <%- camelize(type) %>ManagerTest {
 
     @Test
     public void testFeatureId<%- camelize(type) %>() {
-        <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
 <% if (type === "circle" || type === "symbol") { -%>
         <%- camelize(type) %> <%- type %>Zero = <%- type %>Manager.create(new <%- camelize(type) %>Options().withLatLng(new LatLng()));
         <%- camelize(type) %> <%- type %>One = <%- type %>Manager.create(new <%- camelize(type) %>Options().withLatLng(new LatLng()));
@@ -391,7 +391,7 @@ public class <%- camelize(type) %>ManagerTest {
 
     @Test
     public void test<%- camelize(type) %>DraggableFlag() {
-        <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
 <% if (type === "circle" || type === "symbol") { -%>
         <%- camelize(type) %> <%- type %>Zero = <%- type %>Manager.create(new <%- camelize(type) %>Options().withLatLng(new LatLng()));
 <% } else if (type === "line") { -%>
@@ -421,7 +421,7 @@ public class <%- camelize(type) %>ManagerTest {
 
     @Test
     public void test<%- camelize(property.name) %>LayerProperty() {
-        <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(<%- type  %>Layer, times(0)).setProperties(argThat(new PropertyValueMatcher(<%- camelizeWithLeadingLowercase(property.name) %>(get("<%- property.name %>")))));
 
 <% if (type === "circle" || type === "symbol") { -%>
@@ -452,7 +452,7 @@ public class <%- camelize(type) %>ManagerTest {
 
     @Test
     public void test<%- camelize(type) %>LayerFilter() {
-        <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         Expression expression = Expression.eq(Expression.get("test"), "selected");
         verify(<%- type %>Layer, times(0)).setFilter(expression);
 
@@ -467,7 +467,7 @@ public class <%- camelize(type) %>ManagerTest {
     @Test
     public void testClickListener() {
         On<%- camelize(type) %>ClickListener listener = mock(On<%- camelize(type) %>ClickListener.class);
-        <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         assertTrue(<%- type  %>Manager.getClickListeners().isEmpty());
         <%- type  %>Manager.addClickListener(listener);
         assertTrue(<%- type  %>Manager.getClickListeners().contains(listener));
@@ -478,7 +478,7 @@ public class <%- camelize(type) %>ManagerTest {
     @Test
     public void testLongClickListener() {
         On<%- camelize(type) %>LongClickListener listener = mock(On<%- camelize(type) %>LongClickListener.class);
-        <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         assertTrue(<%- type  %>Manager.getLongClickListeners().isEmpty());
         <%- type  %>Manager.addLongClickListener(listener);
         assertTrue(<%- type  %>Manager.getLongClickListeners().contains(listener));
@@ -489,7 +489,7 @@ public class <%- camelize(type) %>ManagerTest {
     @Test
     public void testDragListener() {
         On<%- camelize(type) %>DragListener listener = mock(On<%- camelize(type) %>DragListener.class);
-        <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         assertTrue(<%- type  %>Manager.getDragListeners().isEmpty());
         <%- type  %>Manager.addDragListener(listener);
         assertTrue(<%- type  %>Manager.getDragListeners().contains(listener));
@@ -499,7 +499,7 @@ public class <%- camelize(type) %>ManagerTest {
 
     @Test
     public void testCustomData() {
-        <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
 <% if (type === "circle" || type === "symbol") { -%>
         <%- camelize(type) %>Options options = new <%- camelize(type) %>Options().withLatLng(new LatLng());
 <% } else if (type === "line") { -%>
@@ -523,7 +523,7 @@ public class <%- camelize(type) %>ManagerTest {
 
     @Test
     public void testClearAll() {
-        <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
 <% if (type === "circle" || type === "symbol") { -%>
         <%- camelize(type) %>Options options = new <%- camelize(type) %>Options().withLatLng(new LatLng());
 <% } else if (type === "line") { -%>
@@ -548,7 +548,7 @@ public class <%- camelize(type) %>ManagerTest {
 
     @Test
     public void testIgnoreClearedAnnotations() {
-        <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        <%- type  %>Manager = new <%- camelize(type) %>Manager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
 <% if (type === "circle" || type === "symbol") { -%>
         <%- camelize(type) %>Options options = new <%- camelize(type) %>Options().withLatLng(new LatLng());
 <% } else if (type === "line") { -%>

--- a/plugin-annotation/scripts/annotation_manager_unit_test.junit.ejs
+++ b/plugin-annotation/scripts/annotation_manager_unit_test.junit.ejs
@@ -10,7 +10,7 @@ package com.mapbox.mapboxsdk.plugins.annotation;
 import android.graphics.PointF;
 
 import com.google.gson.JsonPrimitive;
-import com.mapbox.geojson.*;
+import org.maplibre.geojson.*;
 import org.maplibre.android.geometry.LatLng;
 import org.maplibre.android.maps.MapView;
 import org.maplibre.android.maps.MapLibreMap;

--- a/plugin-annotation/scripts/annotation_options.java.ejs
+++ b/plugin-annotation/scripts/annotation_options.java.ejs
@@ -11,11 +11,11 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.google.gson.*;
-import com.mapbox.geojson.Geometry;
+import org.maplibre.geojson.Geometry;
 import org.maplibre.android.style.layers.Property;
 import org.maplibre.android.style.layers.PropertyFactory;
 
-import com.mapbox.geojson.*;
+import org.maplibre.geojson.*;
 import org.maplibre.android.geometry.LatLng;
 
 import java.util.ArrayList;

--- a/plugin-annotation/scripts/annotation_options.java.ejs
+++ b/plugin-annotation/scripts/annotation_options.java.ejs
@@ -12,11 +12,11 @@ import androidx.annotation.Nullable;
 
 import com.google.gson.*;
 import com.mapbox.geojson.Geometry;
-import com.mapbox.mapboxsdk.style.layers.Property;
-import com.mapbox.mapboxsdk.style.layers.PropertyFactory;
+import org.maplibre.android.style.layers.Property;
+import org.maplibre.android.style.layers.PropertyFactory;
 
 import com.mapbox.geojson.*;
-import com.mapbox.mapboxsdk.geometry.LatLng;
+import org.maplibre.android.geometry.LatLng;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/Annotation.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/Annotation.java
@@ -3,7 +3,7 @@ package com.mapbox.mapboxsdk.plugins.annotation;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.mapbox.android.gestures.MoveDistancesObject;
-import com.mapbox.geojson.Geometry;
+import org.maplibre.geojson.Geometry;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/Annotation.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/Annotation.java
@@ -4,10 +4,10 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.mapbox.android.gestures.MoveDistancesObject;
 import com.mapbox.geojson.Geometry;
-import com.mapbox.mapboxsdk.maps.Projection;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import org.maplibre.android.maps.Projection;
 
 public abstract class Annotation<T extends Geometry> {
 

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/AnnotationManager.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/AnnotationManager.java
@@ -47,7 +47,7 @@ public abstract class AnnotationManager<
     private static final String TAG = "AnnotationManager";
 
     private final MapView mapView;
-    protected final MapLibreMap mapboxMap;
+    protected final MapLibreMap maplibreMap;
     protected final LongSparseArray<T> annotations = new LongSparseArray<>();
     final Map<String, Boolean> dataDrivenPropertyUsageMap = new HashMap<>();
     final Map<String, PropertyValue> constantPropertyUsageMap = new HashMap<>();
@@ -70,12 +70,12 @@ public abstract class AnnotationManager<
     private AtomicBoolean isSourceUpToDate = new AtomicBoolean(true);
 
     @UiThread
-    protected AnnotationManager(MapView mapView, final MapLibreMap mapboxMap, Style style,
+    protected AnnotationManager(MapView mapView, final MapLibreMap maplibreMap, Style style,
                                 CoreElementProvider<L> coreElementProvider,
                                 DraggableAnnotationController draggableAnnotationController,
                                 String belowLayerId, String aboveLayerId, final GeoJsonOptions geoJsonOptions) {
         this.mapView = mapView;
-        this.mapboxMap = mapboxMap;
+        this.maplibreMap = maplibreMap;
         this.style = style;
         this.belowLayerId = belowLayerId;
         this.aboveLayerId = aboveLayerId;
@@ -86,8 +86,8 @@ public abstract class AnnotationManager<
             throw new RuntimeException("The style has to be non-null and fully loaded.");
         }
 
-        mapboxMap.addOnMapClickListener(mapClickResolver = new MapClickResolver());
-        mapboxMap.addOnMapLongClickListener(mapClickResolver);
+        maplibreMap.addOnMapClickListener(mapClickResolver = new MapClickResolver());
+        maplibreMap.addOnMapLongClickListener(mapClickResolver);
 
         initializeSourcesAndLayers(geoJsonOptions);
         draggableAnnotationController.addAnnotationManager(this);
@@ -95,7 +95,7 @@ public abstract class AnnotationManager<
         mapView.addOnDidFinishLoadingStyleListener(new MapView.OnDidFinishLoadingStyleListener() {
             @Override
             public void onDidFinishLoadingStyle() {
-                mapboxMap.getStyle(new Style.OnStyleLoaded() {
+                maplibreMap.getStyle(new Style.OnStyleLoaded() {
                     @Override
                     public void onStyleLoaded(@NonNull Style loadedStyle) {
                         AnnotationManager.this.style = loadedStyle;
@@ -360,8 +360,8 @@ public abstract class AnnotationManager<
      */
     @UiThread
     public void onDestroy() {
-        mapboxMap.removeOnMapClickListener(mapClickResolver);
-        mapboxMap.removeOnMapLongClickListener(mapClickResolver);
+        maplibreMap.removeOnMapClickListener(mapClickResolver);
+        maplibreMap.removeOnMapLongClickListener(mapClickResolver);
         draggableAnnotationController.removeAnnotationManager(this);
         dragListeners.clear();
         clickListeners.clear();
@@ -442,12 +442,12 @@ public abstract class AnnotationManager<
 
     @Nullable
     private T queryMapForFeatures(@NonNull LatLng point) {
-        return queryMapForFeatures(mapboxMap.getProjection().toScreenLocation(point));
+        return queryMapForFeatures(maplibreMap.getProjection().toScreenLocation(point));
     }
 
     @Nullable
     T queryMapForFeatures(@NonNull PointF point) {
-        List<Feature> features = mapboxMap.queryRenderedFeatures(point, coreElementProvider.getLayerId());
+        List<Feature> features = maplibreMap.queryRenderedFeatures(point, coreElementProvider.getLayerId());
         if (!features.isEmpty()) {
             long id = features.get(0).getProperty(getAnnotationIdKey()).getAsLong();
             return annotations.get(id);

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/AnnotationManager.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/AnnotationManager.java
@@ -4,16 +4,11 @@ import android.graphics.PointF;
 
 import com.mapbox.geojson.Feature;
 import com.mapbox.geojson.FeatureCollection;
-import com.mapbox.mapboxsdk.geometry.LatLng;
-import com.mapbox.mapboxsdk.log.Logger;
-import com.mapbox.mapboxsdk.maps.MapView;
-import com.mapbox.mapboxsdk.maps.MapboxMap;
-import com.mapbox.mapboxsdk.maps.Style;
-import com.mapbox.mapboxsdk.style.expressions.Expression;
-import com.mapbox.mapboxsdk.style.layers.Layer;
-import com.mapbox.mapboxsdk.style.layers.PropertyValue;
-import com.mapbox.mapboxsdk.style.sources.GeoJsonOptions;
-import com.mapbox.mapboxsdk.style.sources.GeoJsonSource;
+import org.maplibre.android.geometry.LatLng;
+import org.maplibre.android.log.Logger;
+import org.maplibre.android.maps.MapLibreMap;
+import org.maplibre.android.maps.MapView;
+import org.maplibre.android.maps.Style;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -26,6 +21,11 @@ import androidx.annotation.Nullable;
 import androidx.annotation.UiThread;
 import androidx.annotation.VisibleForTesting;
 import androidx.collection.LongSparseArray;
+import org.maplibre.android.style.expressions.Expression;
+import org.maplibre.android.style.layers.Layer;
+import org.maplibre.android.style.layers.PropertyValue;
+import org.maplibre.android.style.sources.GeoJsonOptions;
+import org.maplibre.android.style.sources.GeoJsonSource;
 
 /**
  * Generic AnnotationManager, can be used to create annotation specific managers.
@@ -47,7 +47,7 @@ public abstract class AnnotationManager<
     private static final String TAG = "AnnotationManager";
 
     private final MapView mapView;
-    protected final MapboxMap mapboxMap;
+    protected final MapLibreMap mapboxMap;
     protected final LongSparseArray<T> annotations = new LongSparseArray<>();
     final Map<String, Boolean> dataDrivenPropertyUsageMap = new HashMap<>();
     final Map<String, PropertyValue> constantPropertyUsageMap = new HashMap<>();
@@ -70,7 +70,7 @@ public abstract class AnnotationManager<
     private AtomicBoolean isSourceUpToDate = new AtomicBoolean(true);
 
     @UiThread
-    protected AnnotationManager(MapView mapView, final MapboxMap mapboxMap, Style style,
+    protected AnnotationManager(MapView mapView, final MapLibreMap mapboxMap, Style style,
                                 CoreElementProvider<L> coreElementProvider,
                                 DraggableAnnotationController draggableAnnotationController,
                                 String belowLayerId, String aboveLayerId, final GeoJsonOptions geoJsonOptions) {
@@ -403,7 +403,7 @@ public abstract class AnnotationManager<
     /**
      * Inner class for transforming map click events into annotation clicks
      */
-    private class MapClickResolver implements MapboxMap.OnMapClickListener, MapboxMap.OnMapLongClickListener {
+    private class MapClickResolver implements MapLibreMap.OnMapClickListener, MapLibreMap.OnMapLongClickListener {
 
         @Override
         public boolean onMapClick(@NonNull LatLng point) {

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/AnnotationManager.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/AnnotationManager.java
@@ -2,8 +2,8 @@ package com.mapbox.mapboxsdk.plugins.annotation;
 
 import android.graphics.PointF;
 
-import com.mapbox.geojson.Feature;
-import com.mapbox.geojson.FeatureCollection;
+import org.maplibre.geojson.Feature;
+import org.maplibre.geojson.FeatureCollection;
 import org.maplibre.android.geometry.LatLng;
 import org.maplibre.android.log.Logger;
 import org.maplibre.android.maps.MapLibreMap;

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/Circle.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/Circle.java
@@ -9,22 +9,17 @@ import androidx.annotation.UiThread;
 
 import android.graphics.PointF;
 
-import com.google.gson.JsonArray;
 import com.google.gson.JsonNull;
 import com.google.gson.JsonObject;
 import com.mapbox.geojson.*;
-import com.mapbox.mapboxsdk.geometry.LatLng;
-import com.mapbox.mapboxsdk.style.layers.Property;
-import com.mapbox.mapboxsdk.style.layers.PropertyFactory;
-import com.mapbox.mapboxsdk.utils.ColorUtils;
 import com.mapbox.android.gestures.MoveDistancesObject;
-import com.mapbox.mapboxsdk.maps.Projection;
+import org.maplibre.android.geometry.LatLng;
+import org.maplibre.android.maps.Projection;
+import org.maplibre.android.style.layers.PropertyFactory;
+import org.maplibre.android.utils.ColorUtils;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import static com.mapbox.mapboxsdk.constants.GeometryConstants.MAX_MERCATOR_LATITUDE;
-import static com.mapbox.mapboxsdk.constants.GeometryConstants.MIN_MERCATOR_LATITUDE;
+import static org.maplibre.android.constants.GeometryConstants.MAX_MERCATOR_LATITUDE;
+import static org.maplibre.android.constants.GeometryConstants.MIN_MERCATOR_LATITUDE;
 
 @UiThread
 public class Circle extends Annotation<Point> {

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/Circle.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/Circle.java
@@ -12,7 +12,7 @@ import android.graphics.PointF;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonNull;
 import com.google.gson.JsonObject;
-import com.mapbox.geojson.*;
+import org.maplibre.geojson.*;
 import org.maplibre.android.geometry.LatLng;
 import org.maplibre.android.style.layers.Property;
 import org.maplibre.android.style.layers.PropertyFactory;

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/Circle.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/Circle.java
@@ -9,14 +9,19 @@ import androidx.annotation.UiThread;
 
 import android.graphics.PointF;
 
+import com.google.gson.JsonArray;
 import com.google.gson.JsonNull;
 import com.google.gson.JsonObject;
 import com.mapbox.geojson.*;
-import com.mapbox.android.gestures.MoveDistancesObject;
 import org.maplibre.android.geometry.LatLng;
-import org.maplibre.android.maps.Projection;
+import org.maplibre.android.style.layers.Property;
 import org.maplibre.android.style.layers.PropertyFactory;
 import org.maplibre.android.utils.ColorUtils;
+import com.mapbox.android.gestures.MoveDistancesObject;
+import org.maplibre.android.maps.Projection;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.maplibre.android.constants.GeometryConstants.MAX_MERCATOR_LATITUDE;
 import static org.maplibre.android.constants.GeometryConstants.MIN_MERCATOR_LATITUDE;

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/CircleElementProvider.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/CircleElementProvider.java
@@ -3,10 +3,9 @@
 package com.mapbox.mapboxsdk.plugins.annotation;
 
 import androidx.annotation.Nullable;
-
-import com.mapbox.mapboxsdk.style.layers.CircleLayer;
-import com.mapbox.mapboxsdk.style.sources.GeoJsonOptions;
-import com.mapbox.mapboxsdk.style.sources.GeoJsonSource;
+import org.maplibre.android.style.layers.CircleLayer;
+import org.maplibre.android.style.sources.GeoJsonOptions;
+import org.maplibre.android.style.sources.GeoJsonSource;
 
 import java.util.concurrent.atomic.AtomicLong;
 

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/CircleElementProvider.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/CircleElementProvider.java
@@ -3,6 +3,7 @@
 package com.mapbox.mapboxsdk.plugins.annotation;
 
 import androidx.annotation.Nullable;
+
 import org.maplibre.android.style.layers.CircleLayer;
 import org.maplibre.android.style.sources.GeoJsonOptions;
 import org.maplibre.android.style.sources.GeoJsonSource;

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/CircleManager.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/CircleManager.java
@@ -9,21 +9,21 @@ import androidx.annotation.VisibleForTesting;
 
 import com.mapbox.geojson.Feature;
 import com.mapbox.geojson.FeatureCollection;
-import com.mapbox.mapboxsdk.maps.MapView;
-import com.mapbox.mapboxsdk.maps.MapboxMap;
-import com.mapbox.mapboxsdk.maps.Style;
-import com.mapbox.mapboxsdk.style.expressions.Expression;
-import com.mapbox.mapboxsdk.style.layers.CircleLayer;
-import com.mapbox.mapboxsdk.style.layers.PropertyValue;
-import com.mapbox.mapboxsdk.style.layers.PropertyFactory;
-import com.mapbox.mapboxsdk.style.sources.GeoJsonOptions;
-import com.mapbox.mapboxsdk.style.layers.Property;
+import org.maplibre.android.maps.MapLibreMap;
+import org.maplibre.android.maps.MapView;
+import org.maplibre.android.maps.Style;
+import org.maplibre.android.style.expressions.Expression;
+import org.maplibre.android.style.layers.CircleLayer;
+import org.maplibre.android.style.layers.Property;
+import org.maplibre.android.style.layers.PropertyFactory;
+import org.maplibre.android.style.layers.PropertyValue;
+import org.maplibre.android.style.sources.GeoJsonOptions;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.mapbox.mapboxsdk.style.expressions.Expression.get;
-import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.*;
+import static org.maplibre.android.style.expressions.Expression.get;
+import static org.maplibre.android.style.layers.PropertyFactory.*;
 
 /**
  * The circle manager allows to add circles to a map.
@@ -42,7 +42,7 @@ public class CircleManager extends AnnotationManager<CircleLayer, Circle, Circle
      * @param style     a valid a fully loaded style object
      */
     @UiThread
-    public CircleManager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style) {
+    public CircleManager(@NonNull MapView mapView, @NonNull MapLibreMap mapboxMap, @NonNull Style style) {
         this(mapView, mapboxMap, style, null, null, (GeoJsonOptions) null);
     }
 
@@ -55,7 +55,7 @@ public class CircleManager extends AnnotationManager<CircleLayer, Circle, Circle
      * @param aboveLayerId the id of the layer below the circle layer
      */
     @UiThread
-    public CircleManager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @Nullable String belowLayerId, @Nullable String aboveLayerId) {
+    public CircleManager(@NonNull MapView mapView, @NonNull MapLibreMap mapboxMap, @NonNull Style style, @Nullable String belowLayerId, @Nullable String aboveLayerId) {
         this(mapView, mapboxMap, style, belowLayerId, aboveLayerId, (GeoJsonOptions) null);
     }
 
@@ -69,12 +69,12 @@ public class CircleManager extends AnnotationManager<CircleLayer, Circle, Circle
      * @param geoJsonOptions options for the internal source
      */
     @UiThread
-    public CircleManager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @Nullable String belowLayerId, @Nullable String aboveLayerId, @Nullable GeoJsonOptions geoJsonOptions) {
+    public CircleManager(@NonNull MapView mapView, @NonNull MapLibreMap mapboxMap, @NonNull Style style, @Nullable String belowLayerId, @Nullable String aboveLayerId, @Nullable GeoJsonOptions geoJsonOptions) {
         this(mapView, mapboxMap, style, new CircleElementProvider(), belowLayerId, aboveLayerId, geoJsonOptions, DraggableAnnotationController.getInstance(mapView, mapboxMap));
     }
 
     @UiThread
-    CircleManager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @NonNull CoreElementProvider<CircleLayer> coreElementProvider, @Nullable String belowLayerId, @Nullable String aboveLayerId, @Nullable GeoJsonOptions geoJsonOptions, DraggableAnnotationController draggableAnnotationController) {
+    CircleManager(@NonNull MapView mapView, @NonNull MapLibreMap mapboxMap, @NonNull Style style, @NonNull CoreElementProvider<CircleLayer> coreElementProvider, @Nullable String belowLayerId, @Nullable String aboveLayerId, @Nullable GeoJsonOptions geoJsonOptions, DraggableAnnotationController draggableAnnotationController) {
         super(mapView, mapboxMap, style, coreElementProvider, draggableAnnotationController, belowLayerId, aboveLayerId, geoJsonOptions);
     }
 

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/CircleManager.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/CircleManager.java
@@ -9,15 +9,15 @@ import androidx.annotation.VisibleForTesting;
 
 import com.mapbox.geojson.Feature;
 import com.mapbox.geojson.FeatureCollection;
-import org.maplibre.android.maps.MapLibreMap;
 import org.maplibre.android.maps.MapView;
+import org.maplibre.android.maps.MapLibreMap;
 import org.maplibre.android.maps.Style;
 import org.maplibre.android.style.expressions.Expression;
 import org.maplibre.android.style.layers.CircleLayer;
-import org.maplibre.android.style.layers.Property;
-import org.maplibre.android.style.layers.PropertyFactory;
 import org.maplibre.android.style.layers.PropertyValue;
+import org.maplibre.android.style.layers.PropertyFactory;
 import org.maplibre.android.style.sources.GeoJsonOptions;
+import org.maplibre.android.style.layers.Property;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -38,44 +38,44 @@ public class CircleManager extends AnnotationManager<CircleLayer, Circle, Circle
     /**
      * Create a circle manager, used to manage circles.
      *
-     * @param mapboxMap the map object to add circles to
+     * @param maplibreMap the map object to add circles to
      * @param style     a valid a fully loaded style object
      */
     @UiThread
-    public CircleManager(@NonNull MapView mapView, @NonNull MapLibreMap mapboxMap, @NonNull Style style) {
-        this(mapView, mapboxMap, style, null, null, (GeoJsonOptions) null);
+    public CircleManager(@NonNull MapView mapView, @NonNull MapLibreMap maplibreMap, @NonNull Style style) {
+        this(mapView, maplibreMap, style, null, null, (GeoJsonOptions) null);
     }
 
     /**
      * Create a circle manager, used to manage circles.
      *
-     * @param mapboxMap    the map object to add circles to
+     * @param maplibreMap    the map object to add circles to
      * @param style        a valid a fully loaded style object
      * @param belowLayerId the id of the layer above the circle layer
      * @param aboveLayerId the id of the layer below the circle layer
      */
     @UiThread
-    public CircleManager(@NonNull MapView mapView, @NonNull MapLibreMap mapboxMap, @NonNull Style style, @Nullable String belowLayerId, @Nullable String aboveLayerId) {
-        this(mapView, mapboxMap, style, belowLayerId, aboveLayerId, (GeoJsonOptions) null);
+    public CircleManager(@NonNull MapView mapView, @NonNull MapLibreMap maplibreMap, @NonNull Style style, @Nullable String belowLayerId, @Nullable String aboveLayerId) {
+        this(mapView, maplibreMap, style, belowLayerId, aboveLayerId, (GeoJsonOptions) null);
     }
 
     /**
      * Create a circle manager, used to manage circles.
      *
-     * @param mapboxMap      the map object to add circles to
+     * @param maplibreMap      the map object to add circles to
      * @param style          a valid a fully loaded style object
      * @param belowLayerId   the id of the layer above the circle layer
      * @param aboveLayerId   the id of the layer below the circle layer
      * @param geoJsonOptions options for the internal source
      */
     @UiThread
-    public CircleManager(@NonNull MapView mapView, @NonNull MapLibreMap mapboxMap, @NonNull Style style, @Nullable String belowLayerId, @Nullable String aboveLayerId, @Nullable GeoJsonOptions geoJsonOptions) {
-        this(mapView, mapboxMap, style, new CircleElementProvider(), belowLayerId, aboveLayerId, geoJsonOptions, DraggableAnnotationController.getInstance(mapView, mapboxMap));
+    public CircleManager(@NonNull MapView mapView, @NonNull MapLibreMap maplibreMap, @NonNull Style style, @Nullable String belowLayerId, @Nullable String aboveLayerId, @Nullable GeoJsonOptions geoJsonOptions) {
+        this(mapView, maplibreMap, style, new CircleElementProvider(), belowLayerId, aboveLayerId, geoJsonOptions, DraggableAnnotationController.getInstance(mapView, maplibreMap));
     }
 
     @UiThread
-    CircleManager(@NonNull MapView mapView, @NonNull MapLibreMap mapboxMap, @NonNull Style style, @NonNull CoreElementProvider<CircleLayer> coreElementProvider, @Nullable String belowLayerId, @Nullable String aboveLayerId, @Nullable GeoJsonOptions geoJsonOptions, DraggableAnnotationController draggableAnnotationController) {
-        super(mapView, mapboxMap, style, coreElementProvider, draggableAnnotationController, belowLayerId, aboveLayerId, geoJsonOptions);
+    CircleManager(@NonNull MapView mapView, @NonNull MapLibreMap maplibreMap, @NonNull Style style, @NonNull CoreElementProvider<CircleLayer> coreElementProvider, @Nullable String belowLayerId, @Nullable String aboveLayerId, @Nullable GeoJsonOptions geoJsonOptions, DraggableAnnotationController draggableAnnotationController) {
+        super(mapView, maplibreMap, style, coreElementProvider, draggableAnnotationController, belowLayerId, aboveLayerId, geoJsonOptions);
     }
 
     @Override

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/CircleManager.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/CircleManager.java
@@ -7,8 +7,8 @@ import androidx.annotation.Nullable;
 import androidx.annotation.UiThread;
 import androidx.annotation.VisibleForTesting;
 
-import com.mapbox.geojson.Feature;
-import com.mapbox.geojson.FeatureCollection;
+import org.maplibre.geojson.Feature;
+import org.maplibre.geojson.FeatureCollection;
 import org.maplibre.android.maps.MapView;
 import org.maplibre.android.maps.MapLibreMap;
 import org.maplibre.android.maps.Style;

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/CircleOptions.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/CircleOptions.java
@@ -6,10 +6,19 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.google.gson.*;
+import com.mapbox.geojson.Geometry;
+import org.maplibre.android.style.layers.Property;
+import org.maplibre.android.style.layers.PropertyFactory;
 
 import com.mapbox.geojson.*;
 import org.maplibre.android.geometry.LatLng;
-import org.maplibre.android.style.layers.PropertyFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.mapbox.mapboxsdk.plugins.annotation.ConvertUtils.convertArray;
+import static com.mapbox.mapboxsdk.plugins.annotation.ConvertUtils.toFloatArray;
+import static com.mapbox.mapboxsdk.plugins.annotation.ConvertUtils.toStringArray;
 
 /**
  * Builder class from which a circle is created.

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/CircleOptions.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/CircleOptions.java
@@ -6,19 +6,10 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.google.gson.*;
-import com.mapbox.geojson.Geometry;
-import com.mapbox.mapboxsdk.style.layers.Property;
-import com.mapbox.mapboxsdk.style.layers.PropertyFactory;
 
 import com.mapbox.geojson.*;
-import com.mapbox.mapboxsdk.geometry.LatLng;
-
-import java.util.ArrayList;
-import java.util.List;
-
-import static com.mapbox.mapboxsdk.plugins.annotation.ConvertUtils.convertArray;
-import static com.mapbox.mapboxsdk.plugins.annotation.ConvertUtils.toFloatArray;
-import static com.mapbox.mapboxsdk.plugins.annotation.ConvertUtils.toStringArray;
+import org.maplibre.android.geometry.LatLng;
+import org.maplibre.android.style.layers.PropertyFactory;
 
 /**
  * Builder class from which a circle is created.

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/CircleOptions.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/CircleOptions.java
@@ -6,11 +6,11 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.google.gson.*;
-import com.mapbox.geojson.Geometry;
+import org.maplibre.geojson.Geometry;
 import org.maplibre.android.style.layers.Property;
 import org.maplibre.android.style.layers.PropertyFactory;
 
-import com.mapbox.geojson.*;
+import org.maplibre.geojson.*;
 import org.maplibre.android.geometry.LatLng;
 
 import java.util.ArrayList;

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/ClusterOptions.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/ClusterOptions.java
@@ -5,26 +5,13 @@ import android.graphics.Color;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.util.Pair;
+import org.maplibre.android.maps.Style;
+import org.maplibre.android.style.expressions.Expression;
+import org.maplibre.android.style.layers.CircleLayer;
+import org.maplibre.android.style.layers.SymbolLayer;
 
-import com.mapbox.mapboxsdk.maps.Style;
-import com.mapbox.mapboxsdk.style.expressions.Expression;
-import com.mapbox.mapboxsdk.style.layers.CircleLayer;
-import com.mapbox.mapboxsdk.style.layers.SymbolLayer;
-
-import static com.mapbox.mapboxsdk.style.expressions.Expression.all;
-import static com.mapbox.mapboxsdk.style.expressions.Expression.get;
-import static com.mapbox.mapboxsdk.style.expressions.Expression.gt;
-import static com.mapbox.mapboxsdk.style.expressions.Expression.gte;
-import static com.mapbox.mapboxsdk.style.expressions.Expression.has;
-import static com.mapbox.mapboxsdk.style.expressions.Expression.literal;
-import static com.mapbox.mapboxsdk.style.expressions.Expression.lt;
-import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.circleColor;
-import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.circleRadius;
-import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.textAllowOverlap;
-import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.textColor;
-import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.textField;
-import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.textIgnorePlacement;
-import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.textSize;
+import static org.maplibre.android.style.expressions.Expression.*;
+import static org.maplibre.android.style.layers.PropertyFactory.*;
 
 /**
  * Options to show and configure symbol clustering with using SymbolManager.

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/CoreElementProvider.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/CoreElementProvider.java
@@ -1,9 +1,8 @@
 package com.mapbox.mapboxsdk.plugins.annotation;
 
-import com.mapbox.mapboxsdk.style.layers.Layer;
-import com.mapbox.mapboxsdk.style.sources.GeoJsonOptions;
-import com.mapbox.mapboxsdk.style.sources.GeoJsonSource;
-
+import org.maplibre.android.style.layers.Layer;
+import org.maplibre.android.style.sources.GeoJsonSource;
+import org.maplibre.android.style.sources.GeoJsonOptions;
 import androidx.annotation.Nullable;
 
 interface CoreElementProvider<L extends Layer> {

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/DraggableAnnotationController.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/DraggableAnnotationController.java
@@ -13,7 +13,7 @@ import androidx.annotation.VisibleForTesting;
 import com.mapbox.android.gestures.AndroidGesturesManager;
 import com.mapbox.android.gestures.MoveDistancesObject;
 import com.mapbox.android.gestures.MoveGestureDetector;
-import com.mapbox.geojson.Geometry;
+import org.maplibre.geojson.Geometry;
 import org.maplibre.android.maps.MapLibreMap;
 import org.maplibre.android.maps.MapView;
 

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/DraggableAnnotationController.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/DraggableAnnotationController.java
@@ -14,8 +14,8 @@ import com.mapbox.android.gestures.AndroidGesturesManager;
 import com.mapbox.android.gestures.MoveDistancesObject;
 import com.mapbox.android.gestures.MoveGestureDetector;
 import com.mapbox.geojson.Geometry;
-import com.mapbox.mapboxsdk.maps.MapView;
-import com.mapbox.mapboxsdk.maps.MapboxMap;
+import org.maplibre.android.maps.MapLibreMap;
+import org.maplibre.android.maps.MapView;
 
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -26,7 +26,7 @@ final class DraggableAnnotationController {
 
     private static DraggableAnnotationController INSTANCE = null;
 
-    public static DraggableAnnotationController getInstance(MapView mapView, MapboxMap mapboxMap) {
+    public static DraggableAnnotationController getInstance(MapView mapView, MapLibreMap mapboxMap) {
         if (INSTANCE == null || INSTANCE.mapView != mapView || INSTANCE.mapboxMap != mapboxMap) {
             INSTANCE = new DraggableAnnotationController(mapView, mapboxMap);
         }
@@ -42,7 +42,7 @@ final class DraggableAnnotationController {
     }
 
     private MapView mapView;
-    private MapboxMap mapboxMap;
+    private MapLibreMap mapboxMap;
     private List<AnnotationManager> annotationManagers = new LinkedList<>();
     private HashMap<String, AnnotationManager> annotationManagersById = new HashMap<>();
 
@@ -57,13 +57,13 @@ final class DraggableAnnotationController {
     private AnnotationManager draggedAnnotationManager;
 
     @SuppressLint("ClickableViewAccessibility")
-    DraggableAnnotationController(MapView mapView, MapboxMap mapboxMap) {
+    DraggableAnnotationController(MapView mapView, MapLibreMap mapboxMap) {
         this(mapView, mapboxMap, new AndroidGesturesManager(mapView.getContext(), false),
             mapView.getScrollX(), mapView.getScrollY(), mapView.getMeasuredWidth(), mapView.getMeasuredHeight());
     }
 
     @VisibleForTesting
-    public DraggableAnnotationController(MapView mapView, MapboxMap mapboxMap,
+    public DraggableAnnotationController(MapView mapView, MapLibreMap mapboxMap,
                                          final AndroidGesturesManager androidGesturesManager,
                                          int touchAreaShiftX, int touchAreaShiftY,
                                          int touchAreaMaxX, int touchAreaMaxY) {

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/DraggableAnnotationController.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/DraggableAnnotationController.java
@@ -26,9 +26,9 @@ final class DraggableAnnotationController {
 
     private static DraggableAnnotationController INSTANCE = null;
 
-    public static DraggableAnnotationController getInstance(MapView mapView, MapLibreMap mapboxMap) {
-        if (INSTANCE == null || INSTANCE.mapView != mapView || INSTANCE.mapboxMap != mapboxMap) {
-            INSTANCE = new DraggableAnnotationController(mapView, mapboxMap);
+    public static DraggableAnnotationController getInstance(MapView mapView, MapLibreMap maplibreMap) {
+        if (INSTANCE == null || INSTANCE.mapView != mapView || INSTANCE.maplibreMap != maplibreMap) {
+            INSTANCE = new DraggableAnnotationController(mapView, maplibreMap);
         }
         return INSTANCE;
     }
@@ -36,13 +36,13 @@ final class DraggableAnnotationController {
     private static void clearInstance() {
         if (INSTANCE != null) {
             INSTANCE.mapView = null;
-            INSTANCE.mapboxMap = null;
+            INSTANCE.maplibreMap = null;
             INSTANCE = null;
         }
     }
 
     private MapView mapView;
-    private MapLibreMap mapboxMap;
+    private MapLibreMap maplibreMap;
     private List<AnnotationManager> annotationManagers = new LinkedList<>();
     private HashMap<String, AnnotationManager> annotationManagersById = new HashMap<>();
 
@@ -57,18 +57,18 @@ final class DraggableAnnotationController {
     private AnnotationManager draggedAnnotationManager;
 
     @SuppressLint("ClickableViewAccessibility")
-    DraggableAnnotationController(MapView mapView, MapLibreMap mapboxMap) {
-        this(mapView, mapboxMap, new AndroidGesturesManager(mapView.getContext(), false),
+    DraggableAnnotationController(MapView mapView, MapLibreMap maplibreMap) {
+        this(mapView, maplibreMap, new AndroidGesturesManager(mapView.getContext(), false),
             mapView.getScrollX(), mapView.getScrollY(), mapView.getMeasuredWidth(), mapView.getMeasuredHeight());
     }
 
     @VisibleForTesting
-    public DraggableAnnotationController(MapView mapView, MapLibreMap mapboxMap,
+    public DraggableAnnotationController(MapView mapView, MapLibreMap maplibreMap,
                                          final AndroidGesturesManager androidGesturesManager,
                                          int touchAreaShiftX, int touchAreaShiftY,
                                          int touchAreaMaxX, int touchAreaMaxY) {
         this.mapView = mapView;
-        this.mapboxMap = mapboxMap;
+        this.maplibreMap = maplibreMap;
         this.touchAreaShiftX = touchAreaShiftX;
         this.touchAreaShiftY = touchAreaShiftY;
         this.touchAreaMaxX = touchAreaMaxX;
@@ -155,7 +155,7 @@ final class DraggableAnnotationController {
             }
 
             Geometry shiftedGeometry = draggedAnnotation.getOffsetGeometry(
-                mapboxMap.getProjection(), moveObject, touchAreaShiftX, touchAreaShiftY
+                maplibreMap.getProjection(), moveObject, touchAreaShiftX, touchAreaShiftY
             );
 
             if (shiftedGeometry != null) {

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/Fill.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/Fill.java
@@ -12,7 +12,7 @@ import android.graphics.PointF;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonNull;
 import com.google.gson.JsonObject;
-import com.mapbox.geojson.*;
+import org.maplibre.geojson.*;
 import org.maplibre.android.geometry.LatLng;
 import org.maplibre.android.style.layers.Property;
 import org.maplibre.android.style.layers.PropertyFactory;

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/Fill.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/Fill.java
@@ -13,11 +13,12 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonNull;
 import com.google.gson.JsonObject;
 import com.mapbox.geojson.*;
-import com.mapbox.android.gestures.MoveDistancesObject;
 import org.maplibre.android.geometry.LatLng;
-import org.maplibre.android.maps.Projection;
+import org.maplibre.android.style.layers.Property;
 import org.maplibre.android.style.layers.PropertyFactory;
 import org.maplibre.android.utils.ColorUtils;
+import com.mapbox.android.gestures.MoveDistancesObject;
+import org.maplibre.android.maps.Projection;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/Fill.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/Fill.java
@@ -13,18 +13,17 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonNull;
 import com.google.gson.JsonObject;
 import com.mapbox.geojson.*;
-import com.mapbox.mapboxsdk.geometry.LatLng;
-import com.mapbox.mapboxsdk.style.layers.Property;
-import com.mapbox.mapboxsdk.style.layers.PropertyFactory;
-import com.mapbox.mapboxsdk.utils.ColorUtils;
 import com.mapbox.android.gestures.MoveDistancesObject;
-import com.mapbox.mapboxsdk.maps.Projection;
+import org.maplibre.android.geometry.LatLng;
+import org.maplibre.android.maps.Projection;
+import org.maplibre.android.style.layers.PropertyFactory;
+import org.maplibre.android.utils.ColorUtils;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.mapbox.mapboxsdk.constants.GeometryConstants.MAX_MERCATOR_LATITUDE;
-import static com.mapbox.mapboxsdk.constants.GeometryConstants.MIN_MERCATOR_LATITUDE;
+import static org.maplibre.android.constants.GeometryConstants.MAX_MERCATOR_LATITUDE;
+import static org.maplibre.android.constants.GeometryConstants.MIN_MERCATOR_LATITUDE;
 
 @UiThread
 public class Fill extends Annotation<Polygon> {

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/FillElementProvider.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/FillElementProvider.java
@@ -3,10 +3,9 @@
 package com.mapbox.mapboxsdk.plugins.annotation;
 
 import androidx.annotation.Nullable;
-
-import com.mapbox.mapboxsdk.style.layers.FillLayer;
-import com.mapbox.mapboxsdk.style.sources.GeoJsonOptions;
-import com.mapbox.mapboxsdk.style.sources.GeoJsonSource;
+import org.maplibre.android.style.layers.FillLayer;
+import org.maplibre.android.style.sources.GeoJsonOptions;
+import org.maplibre.android.style.sources.GeoJsonSource;
 
 import java.util.concurrent.atomic.AtomicLong;
 

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/FillElementProvider.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/FillElementProvider.java
@@ -3,6 +3,7 @@
 package com.mapbox.mapboxsdk.plugins.annotation;
 
 import androidx.annotation.Nullable;
+
 import org.maplibre.android.style.layers.FillLayer;
 import org.maplibre.android.style.sources.GeoJsonOptions;
 import org.maplibre.android.style.sources.GeoJsonSource;

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/FillManager.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/FillManager.java
@@ -9,21 +9,21 @@ import androidx.annotation.VisibleForTesting;
 
 import com.mapbox.geojson.Feature;
 import com.mapbox.geojson.FeatureCollection;
-import com.mapbox.mapboxsdk.maps.MapView;
-import com.mapbox.mapboxsdk.maps.MapboxMap;
-import com.mapbox.mapboxsdk.maps.Style;
-import com.mapbox.mapboxsdk.style.expressions.Expression;
-import com.mapbox.mapboxsdk.style.layers.FillLayer;
-import com.mapbox.mapboxsdk.style.layers.PropertyValue;
-import com.mapbox.mapboxsdk.style.layers.PropertyFactory;
-import com.mapbox.mapboxsdk.style.sources.GeoJsonOptions;
-import com.mapbox.mapboxsdk.style.layers.Property;
+import org.maplibre.android.maps.MapLibreMap;
+import org.maplibre.android.maps.MapView;
+import org.maplibre.android.maps.Style;
+import org.maplibre.android.style.expressions.Expression;
+import org.maplibre.android.style.layers.FillLayer;
+import org.maplibre.android.style.layers.Property;
+import org.maplibre.android.style.layers.PropertyFactory;
+import org.maplibre.android.style.layers.PropertyValue;
+import org.maplibre.android.style.sources.GeoJsonOptions;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.mapbox.mapboxsdk.style.expressions.Expression.get;
-import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.*;
+import static org.maplibre.android.style.expressions.Expression.get;
+import static org.maplibre.android.style.layers.PropertyFactory.*;
 
 /**
  * The fill manager allows to add fills to a map.
@@ -41,7 +41,7 @@ public class FillManager extends AnnotationManager<FillLayer, Fill, FillOptions,
      * @param style     a valid a fully loaded style object
      */
     @UiThread
-    public FillManager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style) {
+    public FillManager(@NonNull MapView mapView, @NonNull MapLibreMap mapboxMap, @NonNull Style style) {
         this(mapView, mapboxMap, style, null, null, (GeoJsonOptions) null);
     }
 
@@ -54,7 +54,7 @@ public class FillManager extends AnnotationManager<FillLayer, Fill, FillOptions,
      * @param aboveLayerId the id of the layer below the fill layer
      */
     @UiThread
-    public FillManager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @Nullable String belowLayerId, @Nullable String aboveLayerId) {
+    public FillManager(@NonNull MapView mapView, @NonNull MapLibreMap mapboxMap, @NonNull Style style, @Nullable String belowLayerId, @Nullable String aboveLayerId) {
         this(mapView, mapboxMap, style, belowLayerId, aboveLayerId, (GeoJsonOptions) null);
     }
 
@@ -68,12 +68,12 @@ public class FillManager extends AnnotationManager<FillLayer, Fill, FillOptions,
      * @param geoJsonOptions options for the internal source
      */
     @UiThread
-    public FillManager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @Nullable String belowLayerId, @Nullable String aboveLayerId, @Nullable GeoJsonOptions geoJsonOptions) {
+    public FillManager(@NonNull MapView mapView, @NonNull MapLibreMap mapboxMap, @NonNull Style style, @Nullable String belowLayerId, @Nullable String aboveLayerId, @Nullable GeoJsonOptions geoJsonOptions) {
         this(mapView, mapboxMap, style, new FillElementProvider(), belowLayerId, aboveLayerId, geoJsonOptions, DraggableAnnotationController.getInstance(mapView, mapboxMap));
     }
 
     @UiThread
-    FillManager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @NonNull CoreElementProvider<FillLayer> coreElementProvider, @Nullable String belowLayerId, @Nullable String aboveLayerId, @Nullable GeoJsonOptions geoJsonOptions, DraggableAnnotationController draggableAnnotationController) {
+    FillManager(@NonNull MapView mapView, @NonNull MapLibreMap mapboxMap, @NonNull Style style, @NonNull CoreElementProvider<FillLayer> coreElementProvider, @Nullable String belowLayerId, @Nullable String aboveLayerId, @Nullable GeoJsonOptions geoJsonOptions, DraggableAnnotationController draggableAnnotationController) {
         super(mapView, mapboxMap, style, coreElementProvider, draggableAnnotationController, belowLayerId, aboveLayerId, geoJsonOptions);
     }
 

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/FillManager.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/FillManager.java
@@ -9,15 +9,15 @@ import androidx.annotation.VisibleForTesting;
 
 import com.mapbox.geojson.Feature;
 import com.mapbox.geojson.FeatureCollection;
-import org.maplibre.android.maps.MapLibreMap;
 import org.maplibre.android.maps.MapView;
+import org.maplibre.android.maps.MapLibreMap;
 import org.maplibre.android.maps.Style;
 import org.maplibre.android.style.expressions.Expression;
 import org.maplibre.android.style.layers.FillLayer;
-import org.maplibre.android.style.layers.Property;
-import org.maplibre.android.style.layers.PropertyFactory;
 import org.maplibre.android.style.layers.PropertyValue;
+import org.maplibre.android.style.layers.PropertyFactory;
 import org.maplibre.android.style.sources.GeoJsonOptions;
+import org.maplibre.android.style.layers.Property;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -37,44 +37,44 @@ public class FillManager extends AnnotationManager<FillLayer, Fill, FillOptions,
     /**
      * Create a fill manager, used to manage fills.
      *
-     * @param mapboxMap the map object to add fills to
+     * @param maplibreMap the map object to add fills to
      * @param style     a valid a fully loaded style object
      */
     @UiThread
-    public FillManager(@NonNull MapView mapView, @NonNull MapLibreMap mapboxMap, @NonNull Style style) {
-        this(mapView, mapboxMap, style, null, null, (GeoJsonOptions) null);
+    public FillManager(@NonNull MapView mapView, @NonNull MapLibreMap maplibreMap, @NonNull Style style) {
+        this(mapView, maplibreMap, style, null, null, (GeoJsonOptions) null);
     }
 
     /**
      * Create a fill manager, used to manage fills.
      *
-     * @param mapboxMap    the map object to add fills to
+     * @param maplibreMap    the map object to add fills to
      * @param style        a valid a fully loaded style object
      * @param belowLayerId the id of the layer above the fill layer
      * @param aboveLayerId the id of the layer below the fill layer
      */
     @UiThread
-    public FillManager(@NonNull MapView mapView, @NonNull MapLibreMap mapboxMap, @NonNull Style style, @Nullable String belowLayerId, @Nullable String aboveLayerId) {
-        this(mapView, mapboxMap, style, belowLayerId, aboveLayerId, (GeoJsonOptions) null);
+    public FillManager(@NonNull MapView mapView, @NonNull MapLibreMap maplibreMap, @NonNull Style style, @Nullable String belowLayerId, @Nullable String aboveLayerId) {
+        this(mapView, maplibreMap, style, belowLayerId, aboveLayerId, (GeoJsonOptions) null);
     }
 
     /**
      * Create a fill manager, used to manage fills.
      *
-     * @param mapboxMap      the map object to add fills to
+     * @param maplibreMap      the map object to add fills to
      * @param style          a valid a fully loaded style object
      * @param belowLayerId   the id of the layer above the fill layer
      * @param aboveLayerId   the id of the layer below the fill layer
      * @param geoJsonOptions options for the internal source
      */
     @UiThread
-    public FillManager(@NonNull MapView mapView, @NonNull MapLibreMap mapboxMap, @NonNull Style style, @Nullable String belowLayerId, @Nullable String aboveLayerId, @Nullable GeoJsonOptions geoJsonOptions) {
-        this(mapView, mapboxMap, style, new FillElementProvider(), belowLayerId, aboveLayerId, geoJsonOptions, DraggableAnnotationController.getInstance(mapView, mapboxMap));
+    public FillManager(@NonNull MapView mapView, @NonNull MapLibreMap maplibreMap, @NonNull Style style, @Nullable String belowLayerId, @Nullable String aboveLayerId, @Nullable GeoJsonOptions geoJsonOptions) {
+        this(mapView, maplibreMap, style, new FillElementProvider(), belowLayerId, aboveLayerId, geoJsonOptions, DraggableAnnotationController.getInstance(mapView, maplibreMap));
     }
 
     @UiThread
-    FillManager(@NonNull MapView mapView, @NonNull MapLibreMap mapboxMap, @NonNull Style style, @NonNull CoreElementProvider<FillLayer> coreElementProvider, @Nullable String belowLayerId, @Nullable String aboveLayerId, @Nullable GeoJsonOptions geoJsonOptions, DraggableAnnotationController draggableAnnotationController) {
-        super(mapView, mapboxMap, style, coreElementProvider, draggableAnnotationController, belowLayerId, aboveLayerId, geoJsonOptions);
+    FillManager(@NonNull MapView mapView, @NonNull MapLibreMap maplibreMap, @NonNull Style style, @NonNull CoreElementProvider<FillLayer> coreElementProvider, @Nullable String belowLayerId, @Nullable String aboveLayerId, @Nullable GeoJsonOptions geoJsonOptions, DraggableAnnotationController draggableAnnotationController) {
+        super(mapView, maplibreMap, style, coreElementProvider, draggableAnnotationController, belowLayerId, aboveLayerId, geoJsonOptions);
     }
 
     @Override

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/FillManager.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/FillManager.java
@@ -7,8 +7,8 @@ import androidx.annotation.Nullable;
 import androidx.annotation.UiThread;
 import androidx.annotation.VisibleForTesting;
 
-import com.mapbox.geojson.Feature;
-import com.mapbox.geojson.FeatureCollection;
+import org.maplibre.geojson.Feature;
+import org.maplibre.geojson.FeatureCollection;
 import org.maplibre.android.maps.MapView;
 import org.maplibre.android.maps.MapLibreMap;
 import org.maplibre.android.maps.Style;

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/FillOptions.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/FillOptions.java
@@ -6,19 +6,13 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.google.gson.*;
-import com.mapbox.geojson.Geometry;
-import com.mapbox.mapboxsdk.style.layers.Property;
-import com.mapbox.mapboxsdk.style.layers.PropertyFactory;
 
 import com.mapbox.geojson.*;
-import com.mapbox.mapboxsdk.geometry.LatLng;
+import org.maplibre.android.geometry.LatLng;
+import org.maplibre.android.style.layers.PropertyFactory;
 
 import java.util.ArrayList;
 import java.util.List;
-
-import static com.mapbox.mapboxsdk.plugins.annotation.ConvertUtils.convertArray;
-import static com.mapbox.mapboxsdk.plugins.annotation.ConvertUtils.toFloatArray;
-import static com.mapbox.mapboxsdk.plugins.annotation.ConvertUtils.toStringArray;
 
 /**
  * Builder class from which a fill is created.

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/FillOptions.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/FillOptions.java
@@ -6,13 +6,19 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.google.gson.*;
+import com.mapbox.geojson.Geometry;
+import org.maplibre.android.style.layers.Property;
+import org.maplibre.android.style.layers.PropertyFactory;
 
 import com.mapbox.geojson.*;
 import org.maplibre.android.geometry.LatLng;
-import org.maplibre.android.style.layers.PropertyFactory;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import static com.mapbox.mapboxsdk.plugins.annotation.ConvertUtils.convertArray;
+import static com.mapbox.mapboxsdk.plugins.annotation.ConvertUtils.toFloatArray;
+import static com.mapbox.mapboxsdk.plugins.annotation.ConvertUtils.toStringArray;
 
 /**
  * Builder class from which a fill is created.

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/FillOptions.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/FillOptions.java
@@ -6,11 +6,11 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.google.gson.*;
-import com.mapbox.geojson.Geometry;
+import org.maplibre.geojson.Geometry;
 import org.maplibre.android.style.layers.Property;
 import org.maplibre.android.style.layers.PropertyFactory;
 
-import com.mapbox.geojson.*;
+import org.maplibre.geojson.*;
 import org.maplibre.android.geometry.LatLng;
 
 import java.util.ArrayList;

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/Line.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/Line.java
@@ -13,18 +13,17 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonNull;
 import com.google.gson.JsonObject;
 import com.mapbox.geojson.*;
-import com.mapbox.mapboxsdk.geometry.LatLng;
-import com.mapbox.mapboxsdk.style.layers.Property;
-import com.mapbox.mapboxsdk.style.layers.PropertyFactory;
-import com.mapbox.mapboxsdk.utils.ColorUtils;
 import com.mapbox.android.gestures.MoveDistancesObject;
-import com.mapbox.mapboxsdk.maps.Projection;
+import org.maplibre.android.geometry.LatLng;
+import org.maplibre.android.maps.Projection;
+import org.maplibre.android.style.layers.Property;
+import org.maplibre.android.utils.ColorUtils;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.mapbox.mapboxsdk.constants.GeometryConstants.MAX_MERCATOR_LATITUDE;
-import static com.mapbox.mapboxsdk.constants.GeometryConstants.MIN_MERCATOR_LATITUDE;
+import static org.maplibre.android.constants.GeometryConstants.MAX_MERCATOR_LATITUDE;
+import static org.maplibre.android.constants.GeometryConstants.MIN_MERCATOR_LATITUDE;
 
 @UiThread
 public class Line extends Annotation<LineString> {

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/Line.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/Line.java
@@ -12,7 +12,7 @@ import android.graphics.PointF;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonNull;
 import com.google.gson.JsonObject;
-import com.mapbox.geojson.*;
+import org.maplibre.geojson.*;
 import org.maplibre.android.geometry.LatLng;
 import org.maplibre.android.style.layers.Property;
 import org.maplibre.android.style.layers.PropertyFactory;

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/Line.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/Line.java
@@ -13,11 +13,12 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonNull;
 import com.google.gson.JsonObject;
 import com.mapbox.geojson.*;
-import com.mapbox.android.gestures.MoveDistancesObject;
 import org.maplibre.android.geometry.LatLng;
-import org.maplibre.android.maps.Projection;
 import org.maplibre.android.style.layers.Property;
+import org.maplibre.android.style.layers.PropertyFactory;
 import org.maplibre.android.utils.ColorUtils;
+import com.mapbox.android.gestures.MoveDistancesObject;
+import org.maplibre.android.maps.Projection;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/LineElementProvider.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/LineElementProvider.java
@@ -4,11 +4,10 @@ package com.mapbox.mapboxsdk.plugins.annotation;
 
 import androidx.annotation.Nullable;
 
-import com.mapbox.mapboxsdk.style.layers.LineLayer;
-import com.mapbox.mapboxsdk.style.sources.GeoJsonOptions;
-import com.mapbox.mapboxsdk.style.sources.GeoJsonSource;
-
 import java.util.concurrent.atomic.AtomicLong;
+import org.maplibre.android.style.layers.LineLayer;
+import org.maplibre.android.style.sources.GeoJsonOptions;
+import org.maplibre.android.style.sources.GeoJsonSource;
 
 /**
  * Concrete instance of a core element provider for Line.

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/LineElementProvider.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/LineElementProvider.java
@@ -4,10 +4,11 @@ package com.mapbox.mapboxsdk.plugins.annotation;
 
 import androidx.annotation.Nullable;
 
-import java.util.concurrent.atomic.AtomicLong;
 import org.maplibre.android.style.layers.LineLayer;
 import org.maplibre.android.style.sources.GeoJsonOptions;
 import org.maplibre.android.style.sources.GeoJsonSource;
+
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * Concrete instance of a core element provider for Line.

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/LineManager.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/LineManager.java
@@ -9,21 +9,21 @@ import androidx.annotation.VisibleForTesting;
 
 import com.mapbox.geojson.Feature;
 import com.mapbox.geojson.FeatureCollection;
-import com.mapbox.mapboxsdk.maps.MapView;
-import com.mapbox.mapboxsdk.maps.MapboxMap;
-import com.mapbox.mapboxsdk.maps.Style;
-import com.mapbox.mapboxsdk.style.expressions.Expression;
-import com.mapbox.mapboxsdk.style.layers.LineLayer;
-import com.mapbox.mapboxsdk.style.layers.PropertyValue;
-import com.mapbox.mapboxsdk.style.layers.PropertyFactory;
-import com.mapbox.mapboxsdk.style.sources.GeoJsonOptions;
-import com.mapbox.mapboxsdk.style.layers.Property;
+import org.maplibre.android.maps.MapLibreMap;
+import org.maplibre.android.maps.MapView;
+import org.maplibre.android.maps.Style;
+import org.maplibre.android.style.expressions.Expression;
+import org.maplibre.android.style.layers.LineLayer;
+import org.maplibre.android.style.layers.Property;
+import org.maplibre.android.style.layers.PropertyFactory;
+import org.maplibre.android.style.layers.PropertyValue;
+import org.maplibre.android.style.sources.GeoJsonOptions;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.mapbox.mapboxsdk.style.expressions.Expression.get;
-import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.*;
+import static org.maplibre.android.style.expressions.Expression.get;
+import static org.maplibre.android.style.layers.PropertyFactory.*;
 
 /**
  * The line manager allows to add lines to a map.
@@ -44,7 +44,7 @@ public class LineManager extends AnnotationManager<LineLayer, Line, LineOptions,
      * @param style     a valid a fully loaded style object
      */
     @UiThread
-    public LineManager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style) {
+    public LineManager(@NonNull MapView mapView, @NonNull MapLibreMap mapboxMap, @NonNull Style style) {
         this(mapView, mapboxMap, style, null, null, (GeoJsonOptions) null);
     }
 
@@ -57,7 +57,7 @@ public class LineManager extends AnnotationManager<LineLayer, Line, LineOptions,
      * @param aboveLayerId the id of the layer below the line layer
      */
     @UiThread
-    public LineManager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @Nullable String belowLayerId, @Nullable String aboveLayerId) {
+    public LineManager(@NonNull MapView mapView, @NonNull MapLibreMap mapboxMap, @NonNull Style style, @Nullable String belowLayerId, @Nullable String aboveLayerId) {
         this(mapView, mapboxMap, style, belowLayerId, aboveLayerId, (GeoJsonOptions) null);
     }
 
@@ -71,12 +71,12 @@ public class LineManager extends AnnotationManager<LineLayer, Line, LineOptions,
      * @param geoJsonOptions options for the internal source
      */
     @UiThread
-    public LineManager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @Nullable String belowLayerId, @Nullable String aboveLayerId, @Nullable GeoJsonOptions geoJsonOptions) {
+    public LineManager(@NonNull MapView mapView, @NonNull MapLibreMap mapboxMap, @NonNull Style style, @Nullable String belowLayerId, @Nullable String aboveLayerId, @Nullable GeoJsonOptions geoJsonOptions) {
         this(mapView, mapboxMap, style, new LineElementProvider(), belowLayerId, aboveLayerId, geoJsonOptions, DraggableAnnotationController.getInstance(mapView, mapboxMap));
     }
 
     @UiThread
-    LineManager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @NonNull CoreElementProvider<LineLayer> coreElementProvider, @Nullable String belowLayerId, @Nullable String aboveLayerId, @Nullable GeoJsonOptions geoJsonOptions, DraggableAnnotationController draggableAnnotationController) {
+    LineManager(@NonNull MapView mapView, @NonNull MapLibreMap mapboxMap, @NonNull Style style, @NonNull CoreElementProvider<LineLayer> coreElementProvider, @Nullable String belowLayerId, @Nullable String aboveLayerId, @Nullable GeoJsonOptions geoJsonOptions, DraggableAnnotationController draggableAnnotationController) {
         super(mapView, mapboxMap, style, coreElementProvider, draggableAnnotationController, belowLayerId, aboveLayerId, geoJsonOptions);
     }
 

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/LineManager.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/LineManager.java
@@ -9,15 +9,15 @@ import androidx.annotation.VisibleForTesting;
 
 import com.mapbox.geojson.Feature;
 import com.mapbox.geojson.FeatureCollection;
-import org.maplibre.android.maps.MapLibreMap;
 import org.maplibre.android.maps.MapView;
+import org.maplibre.android.maps.MapLibreMap;
 import org.maplibre.android.maps.Style;
 import org.maplibre.android.style.expressions.Expression;
 import org.maplibre.android.style.layers.LineLayer;
-import org.maplibre.android.style.layers.Property;
-import org.maplibre.android.style.layers.PropertyFactory;
 import org.maplibre.android.style.layers.PropertyValue;
+import org.maplibre.android.style.layers.PropertyFactory;
 import org.maplibre.android.style.sources.GeoJsonOptions;
+import org.maplibre.android.style.layers.Property;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -40,44 +40,44 @@ public class LineManager extends AnnotationManager<LineLayer, Line, LineOptions,
     /**
      * Create a line manager, used to manage lines.
      *
-     * @param mapboxMap the map object to add lines to
+     * @param maplibreMap the map object to add lines to
      * @param style     a valid a fully loaded style object
      */
     @UiThread
-    public LineManager(@NonNull MapView mapView, @NonNull MapLibreMap mapboxMap, @NonNull Style style) {
-        this(mapView, mapboxMap, style, null, null, (GeoJsonOptions) null);
+    public LineManager(@NonNull MapView mapView, @NonNull MapLibreMap maplibreMap, @NonNull Style style) {
+        this(mapView, maplibreMap, style, null, null, (GeoJsonOptions) null);
     }
 
     /**
      * Create a line manager, used to manage lines.
      *
-     * @param mapboxMap    the map object to add lines to
+     * @param maplibreMap    the map object to add lines to
      * @param style        a valid a fully loaded style object
      * @param belowLayerId the id of the layer above the line layer
      * @param aboveLayerId the id of the layer below the line layer
      */
     @UiThread
-    public LineManager(@NonNull MapView mapView, @NonNull MapLibreMap mapboxMap, @NonNull Style style, @Nullable String belowLayerId, @Nullable String aboveLayerId) {
-        this(mapView, mapboxMap, style, belowLayerId, aboveLayerId, (GeoJsonOptions) null);
+    public LineManager(@NonNull MapView mapView, @NonNull MapLibreMap maplibreMap, @NonNull Style style, @Nullable String belowLayerId, @Nullable String aboveLayerId) {
+        this(mapView, maplibreMap, style, belowLayerId, aboveLayerId, (GeoJsonOptions) null);
     }
 
     /**
      * Create a line manager, used to manage lines.
      *
-     * @param mapboxMap      the map object to add lines to
+     * @param maplibreMap      the map object to add lines to
      * @param style          a valid a fully loaded style object
      * @param belowLayerId   the id of the layer above the line layer
      * @param aboveLayerId   the id of the layer below the line layer
      * @param geoJsonOptions options for the internal source
      */
     @UiThread
-    public LineManager(@NonNull MapView mapView, @NonNull MapLibreMap mapboxMap, @NonNull Style style, @Nullable String belowLayerId, @Nullable String aboveLayerId, @Nullable GeoJsonOptions geoJsonOptions) {
-        this(mapView, mapboxMap, style, new LineElementProvider(), belowLayerId, aboveLayerId, geoJsonOptions, DraggableAnnotationController.getInstance(mapView, mapboxMap));
+    public LineManager(@NonNull MapView mapView, @NonNull MapLibreMap maplibreMap, @NonNull Style style, @Nullable String belowLayerId, @Nullable String aboveLayerId, @Nullable GeoJsonOptions geoJsonOptions) {
+        this(mapView, maplibreMap, style, new LineElementProvider(), belowLayerId, aboveLayerId, geoJsonOptions, DraggableAnnotationController.getInstance(mapView, maplibreMap));
     }
 
     @UiThread
-    LineManager(@NonNull MapView mapView, @NonNull MapLibreMap mapboxMap, @NonNull Style style, @NonNull CoreElementProvider<LineLayer> coreElementProvider, @Nullable String belowLayerId, @Nullable String aboveLayerId, @Nullable GeoJsonOptions geoJsonOptions, DraggableAnnotationController draggableAnnotationController) {
-        super(mapView, mapboxMap, style, coreElementProvider, draggableAnnotationController, belowLayerId, aboveLayerId, geoJsonOptions);
+    LineManager(@NonNull MapView mapView, @NonNull MapLibreMap maplibreMap, @NonNull Style style, @NonNull CoreElementProvider<LineLayer> coreElementProvider, @Nullable String belowLayerId, @Nullable String aboveLayerId, @Nullable GeoJsonOptions geoJsonOptions, DraggableAnnotationController draggableAnnotationController) {
+        super(mapView, maplibreMap, style, coreElementProvider, draggableAnnotationController, belowLayerId, aboveLayerId, geoJsonOptions);
     }
 
     @Override

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/LineManager.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/LineManager.java
@@ -7,8 +7,8 @@ import androidx.annotation.Nullable;
 import androidx.annotation.UiThread;
 import androidx.annotation.VisibleForTesting;
 
-import com.mapbox.geojson.Feature;
-import com.mapbox.geojson.FeatureCollection;
+import org.maplibre.geojson.Feature;
+import org.maplibre.geojson.FeatureCollection;
 import org.maplibre.android.maps.MapView;
 import org.maplibre.android.maps.MapLibreMap;
 import org.maplibre.android.maps.Style;

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/LineOptions.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/LineOptions.java
@@ -6,19 +6,13 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.google.gson.*;
-import com.mapbox.geojson.Geometry;
-import com.mapbox.mapboxsdk.style.layers.Property;
-import com.mapbox.mapboxsdk.style.layers.PropertyFactory;
 
 import com.mapbox.geojson.*;
-import com.mapbox.mapboxsdk.geometry.LatLng;
+import org.maplibre.android.geometry.LatLng;
+import org.maplibre.android.style.layers.Property;
 
 import java.util.ArrayList;
 import java.util.List;
-
-import static com.mapbox.mapboxsdk.plugins.annotation.ConvertUtils.convertArray;
-import static com.mapbox.mapboxsdk.plugins.annotation.ConvertUtils.toFloatArray;
-import static com.mapbox.mapboxsdk.plugins.annotation.ConvertUtils.toStringArray;
 
 /**
  * Builder class from which a line is created.

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/LineOptions.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/LineOptions.java
@@ -6,11 +6,11 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.google.gson.*;
-import com.mapbox.geojson.Geometry;
+import org.maplibre.geojson.Geometry;
 import org.maplibre.android.style.layers.Property;
 import org.maplibre.android.style.layers.PropertyFactory;
 
-import com.mapbox.geojson.*;
+import org.maplibre.geojson.*;
 import org.maplibre.android.geometry.LatLng;
 
 import java.util.ArrayList;

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/LineOptions.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/LineOptions.java
@@ -6,13 +6,19 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.google.gson.*;
+import com.mapbox.geojson.Geometry;
+import org.maplibre.android.style.layers.Property;
+import org.maplibre.android.style.layers.PropertyFactory;
 
 import com.mapbox.geojson.*;
 import org.maplibre.android.geometry.LatLng;
-import org.maplibre.android.style.layers.Property;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import static com.mapbox.mapboxsdk.plugins.annotation.ConvertUtils.convertArray;
+import static com.mapbox.mapboxsdk.plugins.annotation.ConvertUtils.toFloatArray;
+import static com.mapbox.mapboxsdk.plugins.annotation.ConvertUtils.toStringArray;
 
 /**
  * Builder class from which a line is created.

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/Symbol.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/Symbol.java
@@ -12,7 +12,7 @@ import android.graphics.PointF;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonNull;
 import com.google.gson.JsonObject;
-import com.mapbox.geojson.*;
+import org.maplibre.geojson.*;
 import org.maplibre.android.geometry.LatLng;
 import org.maplibre.android.style.layers.Property;
 import org.maplibre.android.style.layers.PropertyFactory;

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/Symbol.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/Symbol.java
@@ -13,18 +13,18 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonNull;
 import com.google.gson.JsonObject;
 import com.mapbox.geojson.*;
-import com.mapbox.mapboxsdk.geometry.LatLng;
-import com.mapbox.mapboxsdk.style.layers.Property;
-import com.mapbox.mapboxsdk.style.layers.PropertyFactory;
-import com.mapbox.mapboxsdk.utils.ColorUtils;
 import com.mapbox.android.gestures.MoveDistancesObject;
-import com.mapbox.mapboxsdk.maps.Projection;
+import org.maplibre.android.geometry.LatLng;
+import org.maplibre.android.maps.Projection;
+import org.maplibre.android.style.layers.Property;
+import org.maplibre.android.style.layers.PropertyFactory;
+import org.maplibre.android.utils.ColorUtils;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.mapbox.mapboxsdk.constants.GeometryConstants.MAX_MERCATOR_LATITUDE;
-import static com.mapbox.mapboxsdk.constants.GeometryConstants.MIN_MERCATOR_LATITUDE;
+import static org.maplibre.android.constants.GeometryConstants.MAX_MERCATOR_LATITUDE;
+import static org.maplibre.android.constants.GeometryConstants.MIN_MERCATOR_LATITUDE;
 
 @UiThread
 public class Symbol extends Annotation<Point> {

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/Symbol.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/Symbol.java
@@ -13,12 +13,12 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonNull;
 import com.google.gson.JsonObject;
 import com.mapbox.geojson.*;
-import com.mapbox.android.gestures.MoveDistancesObject;
 import org.maplibre.android.geometry.LatLng;
-import org.maplibre.android.maps.Projection;
 import org.maplibre.android.style.layers.Property;
 import org.maplibre.android.style.layers.PropertyFactory;
 import org.maplibre.android.utils.ColorUtils;
+import com.mapbox.android.gestures.MoveDistancesObject;
+import org.maplibre.android.maps.Projection;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/SymbolElementProvider.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/SymbolElementProvider.java
@@ -3,6 +3,7 @@
 package com.mapbox.mapboxsdk.plugins.annotation;
 
 import androidx.annotation.Nullable;
+
 import org.maplibre.android.style.layers.SymbolLayer;
 import org.maplibre.android.style.sources.GeoJsonOptions;
 import org.maplibre.android.style.sources.GeoJsonSource;

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/SymbolElementProvider.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/SymbolElementProvider.java
@@ -3,10 +3,9 @@
 package com.mapbox.mapboxsdk.plugins.annotation;
 
 import androidx.annotation.Nullable;
-
-import com.mapbox.mapboxsdk.style.layers.SymbolLayer;
-import com.mapbox.mapboxsdk.style.sources.GeoJsonOptions;
-import com.mapbox.mapboxsdk.style.sources.GeoJsonSource;
+import org.maplibre.android.style.layers.SymbolLayer;
+import org.maplibre.android.style.sources.GeoJsonOptions;
+import org.maplibre.android.style.sources.GeoJsonSource;
 
 import java.util.concurrent.atomic.AtomicLong;
 

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/SymbolManager.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/SymbolManager.java
@@ -9,21 +9,21 @@ import androidx.annotation.VisibleForTesting;
 
 import com.mapbox.geojson.Feature;
 import com.mapbox.geojson.FeatureCollection;
-import com.mapbox.mapboxsdk.maps.MapView;
-import com.mapbox.mapboxsdk.maps.MapboxMap;
-import com.mapbox.mapboxsdk.maps.Style;
-import com.mapbox.mapboxsdk.style.expressions.Expression;
-import com.mapbox.mapboxsdk.style.layers.SymbolLayer;
-import com.mapbox.mapboxsdk.style.layers.PropertyValue;
-import com.mapbox.mapboxsdk.style.layers.PropertyFactory;
-import com.mapbox.mapboxsdk.style.sources.GeoJsonOptions;
-import com.mapbox.mapboxsdk.style.layers.Property;
+import org.maplibre.android.maps.MapLibreMap;
+import org.maplibre.android.maps.MapView;
+import org.maplibre.android.maps.Style;
+import org.maplibre.android.style.expressions.Expression;
+import org.maplibre.android.style.layers.Property;
+import org.maplibre.android.style.layers.PropertyFactory;
+import org.maplibre.android.style.layers.PropertyValue;
+import org.maplibre.android.style.layers.SymbolLayer;
+import org.maplibre.android.style.sources.GeoJsonOptions;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.mapbox.mapboxsdk.style.expressions.Expression.get;
-import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.*;
+import static org.maplibre.android.style.expressions.Expression.get;
+import static org.maplibre.android.style.layers.PropertyFactory.*;
 
 /**
  * The symbol manager allows to add symbols to a map.
@@ -64,7 +64,7 @@ public class SymbolManager extends AnnotationManager<SymbolLayer, Symbol, Symbol
      * @param style     a valid a fully loaded style object
      */
     @UiThread
-    public SymbolManager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style) {
+    public SymbolManager(@NonNull MapView mapView, @NonNull MapLibreMap mapboxMap, @NonNull Style style) {
         this(mapView, mapboxMap, style, null, null, (GeoJsonOptions) null);
     }
 
@@ -77,7 +77,7 @@ public class SymbolManager extends AnnotationManager<SymbolLayer, Symbol, Symbol
      * @param aboveLayerId the id of the layer below the symbol layer
      */
     @UiThread
-    public SymbolManager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @Nullable String belowLayerId, @Nullable String aboveLayerId) {
+    public SymbolManager(@NonNull MapView mapView, @NonNull MapLibreMap mapboxMap, @NonNull Style style, @Nullable String belowLayerId, @Nullable String aboveLayerId) {
         this(mapView, mapboxMap, style, belowLayerId, aboveLayerId, (GeoJsonOptions) null);
     }
 
@@ -91,7 +91,7 @@ public class SymbolManager extends AnnotationManager<SymbolLayer, Symbol, Symbol
      * @param geoJsonOptions options for the internal source
      */
     @UiThread
-    public SymbolManager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @Nullable String belowLayerId, @Nullable String aboveLayerId, @Nullable GeoJsonOptions geoJsonOptions) {
+    public SymbolManager(@NonNull MapView mapView, @NonNull MapLibreMap mapboxMap, @NonNull Style style, @Nullable String belowLayerId, @Nullable String aboveLayerId, @Nullable GeoJsonOptions geoJsonOptions) {
         this(mapView, mapboxMap, style, new SymbolElementProvider(), belowLayerId, aboveLayerId, geoJsonOptions, DraggableAnnotationController.getInstance(mapView, mapboxMap));
     }
 
@@ -105,13 +105,13 @@ public class SymbolManager extends AnnotationManager<SymbolLayer, Symbol, Symbol
      * @param clusterOptions options for the clustering configuration
      */
     @UiThread
-    public SymbolManager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @Nullable String belowLayerId, @Nullable String aboveLayerId, @NonNull ClusterOptions clusterOptions) {
+    public SymbolManager(@NonNull MapView mapView, @NonNull MapLibreMap mapboxMap, @NonNull Style style, @Nullable String belowLayerId, @Nullable String aboveLayerId, @NonNull ClusterOptions clusterOptions) {
         this(mapView, mapboxMap, style, new SymbolElementProvider(), belowLayerId, aboveLayerId, new GeoJsonOptions().withCluster(true).withClusterRadius(clusterOptions.getClusterRadius()).withClusterMaxZoom(clusterOptions.getClusterMaxZoom()), DraggableAnnotationController.getInstance(mapView, mapboxMap));
         clusterOptions.apply(style, coreElementProvider.getSourceId());
     }
 
     @UiThread
-    SymbolManager(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @NonNull Style style, @NonNull CoreElementProvider<SymbolLayer> coreElementProvider, @Nullable String belowLayerId, @Nullable String aboveLayerId, @Nullable GeoJsonOptions geoJsonOptions, DraggableAnnotationController draggableAnnotationController) {
+    SymbolManager(@NonNull MapView mapView, @NonNull MapLibreMap mapboxMap, @NonNull Style style, @NonNull CoreElementProvider<SymbolLayer> coreElementProvider, @Nullable String belowLayerId, @Nullable String aboveLayerId, @Nullable GeoJsonOptions geoJsonOptions, DraggableAnnotationController draggableAnnotationController) {
         super(mapView, mapboxMap, style, coreElementProvider, draggableAnnotationController, belowLayerId, aboveLayerId, geoJsonOptions);
     }
 

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/SymbolManager.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/SymbolManager.java
@@ -9,15 +9,15 @@ import androidx.annotation.VisibleForTesting;
 
 import com.mapbox.geojson.Feature;
 import com.mapbox.geojson.FeatureCollection;
-import org.maplibre.android.maps.MapLibreMap;
 import org.maplibre.android.maps.MapView;
+import org.maplibre.android.maps.MapLibreMap;
 import org.maplibre.android.maps.Style;
 import org.maplibre.android.style.expressions.Expression;
-import org.maplibre.android.style.layers.Property;
-import org.maplibre.android.style.layers.PropertyFactory;
-import org.maplibre.android.style.layers.PropertyValue;
 import org.maplibre.android.style.layers.SymbolLayer;
+import org.maplibre.android.style.layers.PropertyValue;
+import org.maplibre.android.style.layers.PropertyFactory;
 import org.maplibre.android.style.sources.GeoJsonOptions;
+import org.maplibre.android.style.layers.Property;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -60,59 +60,59 @@ public class SymbolManager extends AnnotationManager<SymbolLayer, Symbol, Symbol
     /**
      * Create a symbol manager, used to manage symbols.
      *
-     * @param mapboxMap the map object to add symbols to
+     * @param maplibreMap the map object to add symbols to
      * @param style     a valid a fully loaded style object
      */
     @UiThread
-    public SymbolManager(@NonNull MapView mapView, @NonNull MapLibreMap mapboxMap, @NonNull Style style) {
-        this(mapView, mapboxMap, style, null, null, (GeoJsonOptions) null);
+    public SymbolManager(@NonNull MapView mapView, @NonNull MapLibreMap maplibreMap, @NonNull Style style) {
+        this(mapView, maplibreMap, style, null, null, (GeoJsonOptions) null);
     }
 
     /**
      * Create a symbol manager, used to manage symbols.
      *
-     * @param mapboxMap    the map object to add symbols to
+     * @param maplibreMap    the map object to add symbols to
      * @param style        a valid a fully loaded style object
      * @param belowLayerId the id of the layer above the symbol layer
      * @param aboveLayerId the id of the layer below the symbol layer
      */
     @UiThread
-    public SymbolManager(@NonNull MapView mapView, @NonNull MapLibreMap mapboxMap, @NonNull Style style, @Nullable String belowLayerId, @Nullable String aboveLayerId) {
-        this(mapView, mapboxMap, style, belowLayerId, aboveLayerId, (GeoJsonOptions) null);
+    public SymbolManager(@NonNull MapView mapView, @NonNull MapLibreMap maplibreMap, @NonNull Style style, @Nullable String belowLayerId, @Nullable String aboveLayerId) {
+        this(mapView, maplibreMap, style, belowLayerId, aboveLayerId, (GeoJsonOptions) null);
     }
 
     /**
      * Create a symbol manager, used to manage symbols.
      *
-     * @param mapboxMap      the map object to add symbols to
+     * @param maplibreMap      the map object to add symbols to
      * @param style          a valid a fully loaded style object
      * @param belowLayerId   the id of the layer above the symbol layer
      * @param aboveLayerId   the id of the layer below the symbol layer
      * @param geoJsonOptions options for the internal source
      */
     @UiThread
-    public SymbolManager(@NonNull MapView mapView, @NonNull MapLibreMap mapboxMap, @NonNull Style style, @Nullable String belowLayerId, @Nullable String aboveLayerId, @Nullable GeoJsonOptions geoJsonOptions) {
-        this(mapView, mapboxMap, style, new SymbolElementProvider(), belowLayerId, aboveLayerId, geoJsonOptions, DraggableAnnotationController.getInstance(mapView, mapboxMap));
+    public SymbolManager(@NonNull MapView mapView, @NonNull MapLibreMap maplibreMap, @NonNull Style style, @Nullable String belowLayerId, @Nullable String aboveLayerId, @Nullable GeoJsonOptions geoJsonOptions) {
+        this(mapView, maplibreMap, style, new SymbolElementProvider(), belowLayerId, aboveLayerId, geoJsonOptions, DraggableAnnotationController.getInstance(mapView, maplibreMap));
     }
 
     /**
      * Create a symbol manager, used to manage symbols.
      *
-     * @param mapboxMap      the map object to add symbols to
+     * @param maplibreMap      the map object to add symbols to
      * @param style          a valid a fully loaded style object
      * @param belowLayerId   the id of the layer above the symbol layer
      * @param aboveLayerId   the id of the layer below the symbol layer
      * @param clusterOptions options for the clustering configuration
      */
     @UiThread
-    public SymbolManager(@NonNull MapView mapView, @NonNull MapLibreMap mapboxMap, @NonNull Style style, @Nullable String belowLayerId, @Nullable String aboveLayerId, @NonNull ClusterOptions clusterOptions) {
-        this(mapView, mapboxMap, style, new SymbolElementProvider(), belowLayerId, aboveLayerId, new GeoJsonOptions().withCluster(true).withClusterRadius(clusterOptions.getClusterRadius()).withClusterMaxZoom(clusterOptions.getClusterMaxZoom()), DraggableAnnotationController.getInstance(mapView, mapboxMap));
+    public SymbolManager(@NonNull MapView mapView, @NonNull MapLibreMap maplibreMap, @NonNull Style style, @Nullable String belowLayerId, @Nullable String aboveLayerId, @NonNull ClusterOptions clusterOptions) {
+        this(mapView, maplibreMap, style, new SymbolElementProvider(), belowLayerId, aboveLayerId, new GeoJsonOptions().withCluster(true).withClusterRadius(clusterOptions.getClusterRadius()).withClusterMaxZoom(clusterOptions.getClusterMaxZoom()), DraggableAnnotationController.getInstance(mapView, maplibreMap));
         clusterOptions.apply(style, coreElementProvider.getSourceId());
     }
 
     @UiThread
-    SymbolManager(@NonNull MapView mapView, @NonNull MapLibreMap mapboxMap, @NonNull Style style, @NonNull CoreElementProvider<SymbolLayer> coreElementProvider, @Nullable String belowLayerId, @Nullable String aboveLayerId, @Nullable GeoJsonOptions geoJsonOptions, DraggableAnnotationController draggableAnnotationController) {
-        super(mapView, mapboxMap, style, coreElementProvider, draggableAnnotationController, belowLayerId, aboveLayerId, geoJsonOptions);
+    SymbolManager(@NonNull MapView mapView, @NonNull MapLibreMap maplibreMap, @NonNull Style style, @NonNull CoreElementProvider<SymbolLayer> coreElementProvider, @Nullable String belowLayerId, @Nullable String aboveLayerId, @Nullable GeoJsonOptions geoJsonOptions, DraggableAnnotationController draggableAnnotationController) {
+        super(mapView, maplibreMap, style, coreElementProvider, draggableAnnotationController, belowLayerId, aboveLayerId, geoJsonOptions);
     }
 
     @Override

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/SymbolManager.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/SymbolManager.java
@@ -7,8 +7,8 @@ import androidx.annotation.Nullable;
 import androidx.annotation.UiThread;
 import androidx.annotation.VisibleForTesting;
 
-import com.mapbox.geojson.Feature;
-import com.mapbox.geojson.FeatureCollection;
+import org.maplibre.geojson.Feature;
+import org.maplibre.geojson.FeatureCollection;
 import org.maplibre.android.maps.MapView;
 import org.maplibre.android.maps.MapLibreMap;
 import org.maplibre.android.maps.Style;

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/SymbolOptions.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/SymbolOptions.java
@@ -6,11 +6,12 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.google.gson.*;
+import com.mapbox.geojson.Geometry;
+import org.maplibre.android.style.layers.Property;
+import org.maplibre.android.style.layers.PropertyFactory;
 
 import com.mapbox.geojson.*;
 import org.maplibre.android.geometry.LatLng;
-import org.maplibre.android.style.layers.Property;
-import org.maplibre.android.style.layers.PropertyFactory;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/SymbolOptions.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/SymbolOptions.java
@@ -6,12 +6,11 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.google.gson.*;
-import com.mapbox.geojson.Geometry;
-import com.mapbox.mapboxsdk.style.layers.Property;
-import com.mapbox.mapboxsdk.style.layers.PropertyFactory;
 
 import com.mapbox.geojson.*;
-import com.mapbox.mapboxsdk.geometry.LatLng;
+import org.maplibre.android.geometry.LatLng;
+import org.maplibre.android.style.layers.Property;
+import org.maplibre.android.style.layers.PropertyFactory;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/SymbolOptions.java
+++ b/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/SymbolOptions.java
@@ -6,11 +6,11 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.google.gson.*;
-import com.mapbox.geojson.Geometry;
+import org.maplibre.geojson.Geometry;
 import org.maplibre.android.style.layers.Property;
 import org.maplibre.android.style.layers.PropertyFactory;
 
-import com.mapbox.geojson.*;
+import org.maplibre.geojson.*;
 import org.maplibre.android.geometry.LatLng;
 
 import java.util.ArrayList;

--- a/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/CircleManagerTest.java
+++ b/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/CircleManagerTest.java
@@ -5,7 +5,7 @@ package com.mapbox.mapboxsdk.plugins.annotation;
 import android.graphics.PointF;
 
 import com.google.gson.JsonPrimitive;
-import com.mapbox.geojson.*;
+import org.maplibre.geojson.*;
 import org.maplibre.android.geometry.LatLng;
 import org.maplibre.android.maps.MapView;
 import org.maplibre.android.maps.MapLibreMap;

--- a/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/CircleManagerTest.java
+++ b/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/CircleManagerTest.java
@@ -6,29 +6,25 @@ import android.graphics.PointF;
 
 import com.google.gson.JsonPrimitive;
 import com.mapbox.geojson.*;
-import com.mapbox.mapboxsdk.geometry.LatLng;
-import com.mapbox.mapboxsdk.maps.MapView;
-import com.mapbox.mapboxsdk.maps.MapboxMap;
-import com.mapbox.mapboxsdk.maps.Style;
-import com.mapbox.mapboxsdk.style.expressions.Expression;
-import com.mapbox.mapboxsdk.style.layers.*;
-import com.mapbox.mapboxsdk.style.sources.GeoJsonOptions;
-import com.mapbox.mapboxsdk.style.sources.GeoJsonSource;
-import com.mapbox.mapboxsdk.utils.ColorUtils;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.maplibre.android.geometry.LatLng;
+import org.maplibre.android.maps.MapLibreMap;
+import org.maplibre.android.maps.MapView;
+import org.maplibre.android.maps.Style;
+import org.maplibre.android.style.expressions.Expression;
+import org.maplibre.android.style.layers.CircleLayer;
+import org.maplibre.android.style.layers.PropertyValue;
+import org.maplibre.android.style.sources.GeoJsonOptions;
+import org.maplibre.android.style.sources.GeoJsonSource;
 import org.mockito.ArgumentCaptor;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Arrays;
-
-import static com.mapbox.mapboxsdk.plugins.annotation.ConvertUtils.convertArray;
-import static com.mapbox.mapboxsdk.style.expressions.Expression.get;
-import static com.mapbox.mapboxsdk.style.layers.Property.*;
-import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.*;
 import static junit.framework.Assert.*;
+import static org.maplibre.android.style.expressions.Expression.get;
+import static org.maplibre.android.style.layers.PropertyFactory.*;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.*;
 
@@ -36,7 +32,7 @@ public class CircleManagerTest {
 
     private DraggableAnnotationController draggableAnnotationController = mock(DraggableAnnotationController.class);
     private MapView mapView = mock(MapView.class);
-    private MapboxMap mapboxMap = mock(MapboxMap.class);
+    private MapLibreMap mapboxMap = mock(MapLibreMap.class);
     private Style style = mock(Style.class);
     private GeoJsonSource geoJsonSource = mock(GeoJsonSource.class);
     private GeoJsonSource optionedGeoJsonSource = mock(GeoJsonSource.class);
@@ -332,7 +328,7 @@ public class CircleManagerTest {
     @Test
     public void testCircleLayerFilter() {
         circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
-        Expression expression = Expression.eq(Expression.get("test"), "selected");
+        Expression expression = Expression.eq(get("test"), "selected");
         verify(circleLayer, times(0)).setFilter(expression);
 
         circleManager.setFilter(expression);

--- a/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/CircleManagerTest.java
+++ b/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/CircleManagerTest.java
@@ -36,7 +36,7 @@ public class CircleManagerTest {
 
     private DraggableAnnotationController draggableAnnotationController = mock(DraggableAnnotationController.class);
     private MapView mapView = mock(MapView.class);
-    private MapLibreMap mapboxMap = mock(MapLibreMap.class);
+    private MapLibreMap maplibreMap = mock(MapLibreMap.class);
     private Style style = mock(Style.class);
     private GeoJsonSource geoJsonSource = mock(GeoJsonSource.class);
     private GeoJsonSource optionedGeoJsonSource = mock(GeoJsonSource.class);
@@ -57,7 +57,7 @@ public class CircleManagerTest {
 
     @Test
     public void testInitialization() {
-        circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        circleManager = new CircleManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(style).addSource(geoJsonSource);
         verify(style).addLayer(circleLayer);
         assertTrue(circleManager.dataDrivenPropertyUsageMap.size() > 0);
@@ -70,7 +70,7 @@ public class CircleManagerTest {
 
     @Test
     public void testInitializationOnStyleReload() {
-        circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        circleManager = new CircleManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(style).addSource(geoJsonSource);
         verify(style).addLayer(circleLayer);
         assertTrue(circleManager.dataDrivenPropertyUsageMap.size() > 0);
@@ -87,7 +87,7 @@ public class CircleManagerTest {
         loadingArgumentCaptor.getValue().onDidFinishLoadingStyle();
 
         ArgumentCaptor<Style.OnStyleLoaded> styleLoadedArgumentCaptor = ArgumentCaptor.forClass(Style.OnStyleLoaded.class);
-        verify(mapboxMap).getStyle(styleLoadedArgumentCaptor.capture());
+        verify(maplibreMap).getStyle(styleLoadedArgumentCaptor.capture());
 
         Style newStyle = mock(Style.class);
         when(newStyle.isFullyLoaded()).thenReturn(true);
@@ -109,7 +109,7 @@ public class CircleManagerTest {
 
     @Test
     public void testLayerBelowInitialization() {
-        circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, "test_layer", null, null, draggableAnnotationController);
+        circleManager = new CircleManager(mapView, maplibreMap, style, coreElementProvider, "test_layer", null, null, draggableAnnotationController);
         verify(style).addSource(geoJsonSource);
         verify(style).addLayerBelow(circleLayer, "test_layer");
         assertTrue(circleManager.dataDrivenPropertyUsageMap.size() > 0);
@@ -121,7 +121,7 @@ public class CircleManagerTest {
 
     @Test
     public void testGeoJsonOptionsInitialization() {
-        circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, geoJsonOptions, draggableAnnotationController);
+        circleManager = new CircleManager(mapView, maplibreMap, style, coreElementProvider, null, null, geoJsonOptions, draggableAnnotationController);
         verify(style).addSource(optionedGeoJsonSource);
         verify(style).addLayer(circleLayer);
         assertTrue(circleManager.dataDrivenPropertyUsageMap.size() > 0);
@@ -134,20 +134,20 @@ public class CircleManagerTest {
 
     @Test
     public void testLayerId() {
-        circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        circleManager = new CircleManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         assertEquals(layerId, circleManager.getLayerId());
     }
 
     @Test
     public void testAddCircle() {
-        circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        circleManager = new CircleManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         Circle circle = circleManager.create(new CircleOptions().withLatLng(new LatLng()));
         assertEquals(circleManager.getAnnotations().get(0), circle);
     }
 
     @Test
     public void addCircleFromFeatureCollection() {
-        circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        circleManager = new CircleManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         Geometry geometry = Point.fromLngLat(10, 10);
 
         Feature feature = Feature.fromGeometry(geometry);
@@ -176,7 +176,7 @@ public class CircleManagerTest {
 
     @Test
     public void addCircles() {
-        circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        circleManager = new CircleManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         List<LatLng> latLngList = new ArrayList<>();
         latLngList.add(new LatLng());
         latLngList.add(new LatLng(1, 1));
@@ -191,7 +191,7 @@ public class CircleManagerTest {
 
     @Test
     public void testDeleteCircle() {
-        circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        circleManager = new CircleManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         Circle circle = circleManager.create(new CircleOptions().withLatLng(new LatLng()));
         circleManager.delete(circle);
         assertTrue(circleManager.getAnnotations().size() == 0);
@@ -199,7 +199,7 @@ public class CircleManagerTest {
 
     @Test
     public void testGeometryCircle() {
-        circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        circleManager = new CircleManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         LatLng latLng = new LatLng(12, 34);
         CircleOptions options = new CircleOptions().withLatLng(latLng);
         Circle circle = circleManager.create(options);
@@ -211,7 +211,7 @@ public class CircleManagerTest {
 
     @Test
     public void testFeatureIdCircle() {
-        circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        circleManager = new CircleManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         Circle circleZero = circleManager.create(new CircleOptions().withLatLng(new LatLng()));
         Circle circleOne = circleManager.create(new CircleOptions().withLatLng(new LatLng()));
         assertEquals(circleZero.getFeature().get(Circle.ID_KEY).getAsLong(), 0);
@@ -220,7 +220,7 @@ public class CircleManagerTest {
 
     @Test
     public void testCircleDraggableFlag() {
-        circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        circleManager = new CircleManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         Circle circleZero = circleManager.create(new CircleOptions().withLatLng(new LatLng()));
 
         assertFalse(circleZero.isDraggable());
@@ -233,7 +233,7 @@ public class CircleManagerTest {
 
     @Test
     public void testCircleRadiusLayerProperty() {
-        circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        circleManager = new CircleManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(circleLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(circleRadius(get("circle-radius")))));
 
         CircleOptions options = new CircleOptions().withLatLng(new LatLng()).withCircleRadius(2.0f);
@@ -247,7 +247,7 @@ public class CircleManagerTest {
 
     @Test
     public void testCircleColorLayerProperty() {
-        circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        circleManager = new CircleManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(circleLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(circleColor(get("circle-color")))));
 
         CircleOptions options = new CircleOptions().withLatLng(new LatLng()).withCircleColor("rgba(0, 0, 0, 1)");
@@ -261,7 +261,7 @@ public class CircleManagerTest {
 
     @Test
     public void testCircleBlurLayerProperty() {
-        circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        circleManager = new CircleManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(circleLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(circleBlur(get("circle-blur")))));
 
         CircleOptions options = new CircleOptions().withLatLng(new LatLng()).withCircleBlur(2.0f);
@@ -275,7 +275,7 @@ public class CircleManagerTest {
 
     @Test
     public void testCircleOpacityLayerProperty() {
-        circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        circleManager = new CircleManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(circleLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(circleOpacity(get("circle-opacity")))));
 
         CircleOptions options = new CircleOptions().withLatLng(new LatLng()).withCircleOpacity(2.0f);
@@ -289,7 +289,7 @@ public class CircleManagerTest {
 
     @Test
     public void testCircleStrokeWidthLayerProperty() {
-        circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        circleManager = new CircleManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(circleLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(circleStrokeWidth(get("circle-stroke-width")))));
 
         CircleOptions options = new CircleOptions().withLatLng(new LatLng()).withCircleStrokeWidth(2.0f);
@@ -303,7 +303,7 @@ public class CircleManagerTest {
 
     @Test
     public void testCircleStrokeColorLayerProperty() {
-        circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        circleManager = new CircleManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(circleLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(circleStrokeColor(get("circle-stroke-color")))));
 
         CircleOptions options = new CircleOptions().withLatLng(new LatLng()).withCircleStrokeColor("rgba(0, 0, 0, 1)");
@@ -317,7 +317,7 @@ public class CircleManagerTest {
 
     @Test
     public void testCircleStrokeOpacityLayerProperty() {
-        circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        circleManager = new CircleManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(circleLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(circleStrokeOpacity(get("circle-stroke-opacity")))));
 
         CircleOptions options = new CircleOptions().withLatLng(new LatLng()).withCircleStrokeOpacity(2.0f);
@@ -331,7 +331,7 @@ public class CircleManagerTest {
 
     @Test
     public void testCircleLayerFilter() {
-        circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        circleManager = new CircleManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         Expression expression = Expression.eq(Expression.get("test"), "selected");
         verify(circleLayer, times(0)).setFilter(expression);
 
@@ -346,7 +346,7 @@ public class CircleManagerTest {
     @Test
     public void testClickListener() {
         OnCircleClickListener listener = mock(OnCircleClickListener.class);
-        circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        circleManager = new CircleManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         assertTrue(circleManager.getClickListeners().isEmpty());
         circleManager.addClickListener(listener);
         assertTrue(circleManager.getClickListeners().contains(listener));
@@ -357,7 +357,7 @@ public class CircleManagerTest {
     @Test
     public void testLongClickListener() {
         OnCircleLongClickListener listener = mock(OnCircleLongClickListener.class);
-        circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        circleManager = new CircleManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         assertTrue(circleManager.getLongClickListeners().isEmpty());
         circleManager.addLongClickListener(listener);
         assertTrue(circleManager.getLongClickListeners().contains(listener));
@@ -368,7 +368,7 @@ public class CircleManagerTest {
     @Test
     public void testDragListener() {
         OnCircleDragListener listener = mock(OnCircleDragListener.class);
-        circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        circleManager = new CircleManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         assertTrue(circleManager.getDragListeners().isEmpty());
         circleManager.addDragListener(listener);
         assertTrue(circleManager.getDragListeners().contains(listener));
@@ -378,7 +378,7 @@ public class CircleManagerTest {
 
     @Test
     public void testCustomData() {
-        circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        circleManager = new CircleManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         CircleOptions options = new CircleOptions().withLatLng(new LatLng());
         options.withData(new JsonPrimitive("hello"));
         Circle circle = circleManager.create(options);
@@ -387,7 +387,7 @@ public class CircleManagerTest {
 
     @Test
     public void testClearAll() {
-        circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        circleManager = new CircleManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         CircleOptions options = new CircleOptions().withLatLng(new LatLng());
         circleManager.create(options);
         assertEquals(1, circleManager.getAnnotations().size());
@@ -397,7 +397,7 @@ public class CircleManagerTest {
 
     @Test
     public void testIgnoreClearedAnnotations() {
-        circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        circleManager = new CircleManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         CircleOptions options = new CircleOptions().withLatLng(new LatLng());
         Circle circle = circleManager.create(options);
         assertEquals(1, circleManager.annotations.size());

--- a/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/CircleManagerTest.java
+++ b/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/CircleManagerTest.java
@@ -6,25 +6,29 @@ import android.graphics.PointF;
 
 import com.google.gson.JsonPrimitive;
 import com.mapbox.geojson.*;
+import org.maplibre.android.geometry.LatLng;
+import org.maplibre.android.maps.MapView;
+import org.maplibre.android.maps.MapLibreMap;
+import org.maplibre.android.maps.Style;
+import org.maplibre.android.style.expressions.Expression;
+import org.maplibre.android.style.layers.*;
+import org.maplibre.android.style.sources.GeoJsonOptions;
+import org.maplibre.android.style.sources.GeoJsonSource;
+import org.maplibre.android.utils.ColorUtils;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.maplibre.android.geometry.LatLng;
-import org.maplibre.android.maps.MapLibreMap;
-import org.maplibre.android.maps.MapView;
-import org.maplibre.android.maps.Style;
-import org.maplibre.android.style.expressions.Expression;
-import org.maplibre.android.style.layers.CircleLayer;
-import org.maplibre.android.style.layers.PropertyValue;
-import org.maplibre.android.style.sources.GeoJsonOptions;
-import org.maplibre.android.style.sources.GeoJsonSource;
 import org.mockito.ArgumentCaptor;
 
 import java.util.ArrayList;
 import java.util.List;
-import static junit.framework.Assert.*;
+import java.util.Arrays;
+
+import static com.mapbox.mapboxsdk.plugins.annotation.ConvertUtils.convertArray;
 import static org.maplibre.android.style.expressions.Expression.get;
+import static org.maplibre.android.style.layers.Property.*;
 import static org.maplibre.android.style.layers.PropertyFactory.*;
+import static junit.framework.Assert.*;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.*;
 
@@ -328,7 +332,7 @@ public class CircleManagerTest {
     @Test
     public void testCircleLayerFilter() {
         circleManager = new CircleManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
-        Expression expression = Expression.eq(get("test"), "selected");
+        Expression expression = Expression.eq(Expression.get("test"), "selected");
         verify(circleLayer, times(0)).setFilter(expression);
 
         circleManager.setFilter(expression);

--- a/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/DraggableAnnotationControllerTest.java
+++ b/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/DraggableAnnotationControllerTest.java
@@ -5,7 +5,7 @@ import android.graphics.PointF;
 import com.mapbox.android.gestures.AndroidGesturesManager;
 import com.mapbox.android.gestures.MoveDistancesObject;
 import com.mapbox.android.gestures.MoveGestureDetector;
-import com.mapbox.geojson.Geometry;
+import org.maplibre.geojson.Geometry;
 
 import org.junit.Before;
 import org.junit.Test;

--- a/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/DraggableAnnotationControllerTest.java
+++ b/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/DraggableAnnotationControllerTest.java
@@ -6,13 +6,13 @@ import com.mapbox.android.gestures.AndroidGesturesManager;
 import com.mapbox.android.gestures.MoveDistancesObject;
 import com.mapbox.android.gestures.MoveGestureDetector;
 import com.mapbox.geojson.Geometry;
-import com.mapbox.mapboxsdk.maps.MapView;
-import com.mapbox.mapboxsdk.maps.MapboxMap;
-import com.mapbox.mapboxsdk.maps.Projection;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.maplibre.android.maps.MapLibreMap;
+import org.maplibre.android.maps.MapView;
+import org.maplibre.android.maps.Projection;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.robolectric.RobolectricTestRunner;
@@ -37,7 +37,7 @@ public class DraggableAnnotationControllerTest {
     private MapView mapView;
 
     @Mock
-    private MapboxMap mapboxMap;
+    private MapLibreMap mapboxMap;
 
     @Mock
     private Projection projection;

--- a/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/DraggableAnnotationControllerTest.java
+++ b/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/DraggableAnnotationControllerTest.java
@@ -37,7 +37,7 @@ public class DraggableAnnotationControllerTest {
     private MapView mapView;
 
     @Mock
-    private MapLibreMap mapboxMap;
+    private MapLibreMap maplibreMap;
 
     @Mock
     private Projection projection;
@@ -70,7 +70,7 @@ public class DraggableAnnotationControllerTest {
     @Before
     public void before() {
         MockitoAnnotations.initMocks(this);
-        draggableAnnotationController = new DraggableAnnotationController(mapView, mapboxMap, androidGesturesManager,
+        draggableAnnotationController = new DraggableAnnotationController(mapView, maplibreMap, androidGesturesManager,
             0, 0, touchAreaMaxX, touchAreaMaxY);
         draggableAnnotationController.addAnnotationManager(annotationManager);
         dragListenerList = new ArrayList<>();
@@ -237,7 +237,7 @@ public class DraggableAnnotationControllerTest {
         when(moveObject.getCurrentX()).thenReturn(10f);
         when(moveObject.getCurrentY()).thenReturn(10f);
 
-        when(mapboxMap.getProjection()).thenReturn(projection);
+        when(maplibreMap.getProjection()).thenReturn(projection);
         when(annotation.getOffsetGeometry(projection, moveObject, 0, 0)).thenReturn(null);
 
         boolean moved = draggableAnnotationController.onMove(moveGestureDetector);
@@ -258,7 +258,7 @@ public class DraggableAnnotationControllerTest {
         when(moveObject.getCurrentX()).thenReturn(10f);
         when(moveObject.getCurrentY()).thenReturn(10f);
 
-        when(mapboxMap.getProjection()).thenReturn(projection);
+        when(maplibreMap.getProjection()).thenReturn(projection);
         when(annotation.getOffsetGeometry(projection, moveObject, 0, 0)).thenReturn(geometry);
 
         boolean moved = draggableAnnotationController.onMove(moveGestureDetector);
@@ -291,7 +291,7 @@ public class DraggableAnnotationControllerTest {
         when(moveObject.getCurrentX()).thenReturn(10f);
         when(moveObject.getCurrentY()).thenReturn(10f);
 
-        when(mapboxMap.getProjection()).thenReturn(projection);
+        when(maplibreMap.getProjection()).thenReturn(projection);
         when(annotation.getOffsetGeometry(projection, moveObject, 0, 0)).thenReturn(geometry);
 
         boolean moved = draggableAnnotationController.onMove(moveGestureDetector);
@@ -312,7 +312,7 @@ public class DraggableAnnotationControllerTest {
         when(moveObject.getCurrentX()).thenReturn(10f);
         when(moveObject.getCurrentY()).thenReturn(10f);
 
-        when(mapboxMap.getProjection()).thenReturn(projection);
+        when(maplibreMap.getProjection()).thenReturn(projection);
         when(annotation.getOffsetGeometry(projection, moveObject, 0, 0)).thenReturn(geometry);
 
         when(annotation.isDraggable()).thenReturn(false);

--- a/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/FillManagerTest.java
+++ b/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/FillManagerTest.java
@@ -6,18 +6,18 @@ import android.graphics.PointF;
 
 import com.google.gson.JsonPrimitive;
 import com.mapbox.geojson.*;
+import org.maplibre.android.geometry.LatLng;
+import org.maplibre.android.maps.MapView;
+import org.maplibre.android.maps.MapLibreMap;
+import org.maplibre.android.maps.Style;
+import org.maplibre.android.style.expressions.Expression;
+import org.maplibre.android.style.layers.*;
+import org.maplibre.android.style.sources.GeoJsonOptions;
+import org.maplibre.android.style.sources.GeoJsonSource;
+import org.maplibre.android.utils.ColorUtils;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.maplibre.android.geometry.LatLng;
-import org.maplibre.android.maps.MapLibreMap;
-import org.maplibre.android.maps.MapView;
-import org.maplibre.android.maps.Style;
-import org.maplibre.android.style.expressions.Expression;
-import org.maplibre.android.style.layers.FillLayer;
-import org.maplibre.android.style.layers.PropertyValue;
-import org.maplibre.android.style.sources.GeoJsonOptions;
-import org.maplibre.android.style.sources.GeoJsonSource;
 import org.mockito.ArgumentCaptor;
 
 import java.util.ArrayList;
@@ -25,9 +25,10 @@ import java.util.List;
 import java.util.Arrays;
 
 import static com.mapbox.mapboxsdk.plugins.annotation.ConvertUtils.convertArray;
-import static junit.framework.Assert.*;
 import static org.maplibre.android.style.expressions.Expression.get;
+import static org.maplibre.android.style.layers.Property.*;
 import static org.maplibre.android.style.layers.PropertyFactory.*;
+import static junit.framework.Assert.*;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.*;
 
@@ -377,7 +378,7 @@ public class FillManagerTest {
     @Test
     public void testFillLayerFilter() {
         fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
-        Expression expression = Expression.eq(get("test"), "selected");
+        Expression expression = Expression.eq(Expression.get("test"), "selected");
         verify(fillLayer, times(0)).setFilter(expression);
 
         fillManager.setFilter(expression);

--- a/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/FillManagerTest.java
+++ b/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/FillManagerTest.java
@@ -5,7 +5,7 @@ package com.mapbox.mapboxsdk.plugins.annotation;
 import android.graphics.PointF;
 
 import com.google.gson.JsonPrimitive;
-import com.mapbox.geojson.*;
+import org.maplibre.geojson.*;
 import org.maplibre.android.geometry.LatLng;
 import org.maplibre.android.maps.MapView;
 import org.maplibre.android.maps.MapLibreMap;

--- a/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/FillManagerTest.java
+++ b/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/FillManagerTest.java
@@ -6,18 +6,18 @@ import android.graphics.PointF;
 
 import com.google.gson.JsonPrimitive;
 import com.mapbox.geojson.*;
-import com.mapbox.mapboxsdk.geometry.LatLng;
-import com.mapbox.mapboxsdk.maps.MapView;
-import com.mapbox.mapboxsdk.maps.MapboxMap;
-import com.mapbox.mapboxsdk.maps.Style;
-import com.mapbox.mapboxsdk.style.expressions.Expression;
-import com.mapbox.mapboxsdk.style.layers.*;
-import com.mapbox.mapboxsdk.style.sources.GeoJsonOptions;
-import com.mapbox.mapboxsdk.style.sources.GeoJsonSource;
-import com.mapbox.mapboxsdk.utils.ColorUtils;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.maplibre.android.geometry.LatLng;
+import org.maplibre.android.maps.MapLibreMap;
+import org.maplibre.android.maps.MapView;
+import org.maplibre.android.maps.Style;
+import org.maplibre.android.style.expressions.Expression;
+import org.maplibre.android.style.layers.FillLayer;
+import org.maplibre.android.style.layers.PropertyValue;
+import org.maplibre.android.style.sources.GeoJsonOptions;
+import org.maplibre.android.style.sources.GeoJsonSource;
 import org.mockito.ArgumentCaptor;
 
 import java.util.ArrayList;
@@ -25,10 +25,9 @@ import java.util.List;
 import java.util.Arrays;
 
 import static com.mapbox.mapboxsdk.plugins.annotation.ConvertUtils.convertArray;
-import static com.mapbox.mapboxsdk.style.expressions.Expression.get;
-import static com.mapbox.mapboxsdk.style.layers.Property.*;
-import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.*;
 import static junit.framework.Assert.*;
+import static org.maplibre.android.style.expressions.Expression.get;
+import static org.maplibre.android.style.layers.PropertyFactory.*;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.*;
 
@@ -36,7 +35,7 @@ public class FillManagerTest {
 
     private DraggableAnnotationController draggableAnnotationController = mock(DraggableAnnotationController.class);
     private MapView mapView = mock(MapView.class);
-    private MapboxMap mapboxMap = mock(MapboxMap.class);
+    private MapLibreMap mapboxMap = mock(MapLibreMap.class);
     private Style style = mock(Style.class);
     private GeoJsonSource geoJsonSource = mock(GeoJsonSource.class);
     private GeoJsonSource optionedGeoJsonSource = mock(GeoJsonSource.class);
@@ -378,7 +377,7 @@ public class FillManagerTest {
     @Test
     public void testFillLayerFilter() {
         fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
-        Expression expression = Expression.eq(Expression.get("test"), "selected");
+        Expression expression = Expression.eq(get("test"), "selected");
         verify(fillLayer, times(0)).setFilter(expression);
 
         fillManager.setFilter(expression);

--- a/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/FillManagerTest.java
+++ b/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/FillManagerTest.java
@@ -36,7 +36,7 @@ public class FillManagerTest {
 
     private DraggableAnnotationController draggableAnnotationController = mock(DraggableAnnotationController.class);
     private MapView mapView = mock(MapView.class);
-    private MapLibreMap mapboxMap = mock(MapLibreMap.class);
+    private MapLibreMap maplibreMap = mock(MapLibreMap.class);
     private Style style = mock(Style.class);
     private GeoJsonSource geoJsonSource = mock(GeoJsonSource.class);
     private GeoJsonSource optionedGeoJsonSource = mock(GeoJsonSource.class);
@@ -57,7 +57,7 @@ public class FillManagerTest {
 
     @Test
     public void testInitialization() {
-        fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        fillManager = new FillManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(style).addSource(geoJsonSource);
         verify(style).addLayer(fillLayer);
         assertTrue(fillManager.dataDrivenPropertyUsageMap.size() > 0);
@@ -70,7 +70,7 @@ public class FillManagerTest {
 
     @Test
     public void testInitializationOnStyleReload() {
-        fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        fillManager = new FillManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(style).addSource(geoJsonSource);
         verify(style).addLayer(fillLayer);
         assertTrue(fillManager.dataDrivenPropertyUsageMap.size() > 0);
@@ -87,7 +87,7 @@ public class FillManagerTest {
         loadingArgumentCaptor.getValue().onDidFinishLoadingStyle();
 
         ArgumentCaptor<Style.OnStyleLoaded> styleLoadedArgumentCaptor = ArgumentCaptor.forClass(Style.OnStyleLoaded.class);
-        verify(mapboxMap).getStyle(styleLoadedArgumentCaptor.capture());
+        verify(maplibreMap).getStyle(styleLoadedArgumentCaptor.capture());
 
         Style newStyle = mock(Style.class);
         when(newStyle.isFullyLoaded()).thenReturn(true);
@@ -109,7 +109,7 @@ public class FillManagerTest {
 
     @Test
     public void testLayerBelowInitialization() {
-        fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, "test_layer", null, null, draggableAnnotationController);
+        fillManager = new FillManager(mapView, maplibreMap, style, coreElementProvider, "test_layer", null, null, draggableAnnotationController);
         verify(style).addSource(geoJsonSource);
         verify(style).addLayerBelow(fillLayer, "test_layer");
         assertTrue(fillManager.dataDrivenPropertyUsageMap.size() > 0);
@@ -121,7 +121,7 @@ public class FillManagerTest {
 
     @Test
     public void testGeoJsonOptionsInitialization() {
-        fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, geoJsonOptions, draggableAnnotationController);
+        fillManager = new FillManager(mapView, maplibreMap, style, coreElementProvider, null, null, geoJsonOptions, draggableAnnotationController);
         verify(style).addSource(optionedGeoJsonSource);
         verify(style).addLayer(fillLayer);
         assertTrue(fillManager.dataDrivenPropertyUsageMap.size() > 0);
@@ -134,13 +134,13 @@ public class FillManagerTest {
 
     @Test
     public void testLayerId() {
-        fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        fillManager = new FillManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         assertEquals(layerId, fillManager.getLayerId());
     }
 
     @Test
     public void testAddFill() {
-        fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        fillManager = new FillManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         List<LatLng> innerLatLngs = new ArrayList<>();
         innerLatLngs.add(new LatLng());
         innerLatLngs.add(new LatLng(1, 1));
@@ -154,7 +154,7 @@ public class FillManagerTest {
 
     @Test
     public void addFillFromFeatureCollection() {
-        fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        fillManager = new FillManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         List<Point> innerPoints = new ArrayList<>();
         innerPoints.add(Point.fromLngLat(0, 0));
         innerPoints.add(Point.fromLngLat(1, 1));
@@ -184,7 +184,7 @@ public class FillManagerTest {
 
     @Test
     public void addFills() {
-        fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        fillManager = new FillManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         final List<List<LatLng>> latLngListOne = new ArrayList<>();
         latLngListOne.add(new ArrayList<LatLng>() {{
             add(new LatLng(2, 2));
@@ -220,7 +220,7 @@ public class FillManagerTest {
 
     @Test
     public void testDeleteFill() {
-        fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        fillManager = new FillManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         List<LatLng> innerLatLngs = new ArrayList<>();
         innerLatLngs.add(new LatLng());
         innerLatLngs.add(new LatLng(1, 1));
@@ -234,7 +234,7 @@ public class FillManagerTest {
 
     @Test
     public void testGeometryFill() {
-        fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        fillManager = new FillManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         List<LatLng> innerLatLngs = new ArrayList<>();
         innerLatLngs.add(new LatLng());
         innerLatLngs.add(new LatLng(1, 1));
@@ -263,7 +263,7 @@ public class FillManagerTest {
 
     @Test
     public void testFeatureIdFill() {
-        fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        fillManager = new FillManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         List<LatLng> innerLatLngs = new ArrayList<>();
         innerLatLngs.add(new LatLng());
         innerLatLngs.add(new LatLng(1, 1));
@@ -278,7 +278,7 @@ public class FillManagerTest {
 
     @Test
     public void testFillDraggableFlag() {
-        fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        fillManager = new FillManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         List<LatLng> innerLatLngs = new ArrayList<>();
         innerLatLngs.add(new LatLng());
         innerLatLngs.add(new LatLng(1, 1));
@@ -297,7 +297,7 @@ public class FillManagerTest {
 
     @Test
     public void testFillOpacityLayerProperty() {
-        fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        fillManager = new FillManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(fillLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(fillOpacity(get("fill-opacity")))));
 
         List<LatLng> innerLatLngs = new ArrayList<>();
@@ -317,7 +317,7 @@ public class FillManagerTest {
 
     @Test
     public void testFillColorLayerProperty() {
-        fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        fillManager = new FillManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(fillLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(fillColor(get("fill-color")))));
 
         List<LatLng> innerLatLngs = new ArrayList<>();
@@ -337,7 +337,7 @@ public class FillManagerTest {
 
     @Test
     public void testFillOutlineColorLayerProperty() {
-        fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        fillManager = new FillManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(fillLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(fillOutlineColor(get("fill-outline-color")))));
 
         List<LatLng> innerLatLngs = new ArrayList<>();
@@ -357,7 +357,7 @@ public class FillManagerTest {
 
     @Test
     public void testFillPatternLayerProperty() {
-        fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        fillManager = new FillManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(fillLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(fillPattern(get("fill-pattern")))));
 
         List<LatLng> innerLatLngs = new ArrayList<>();
@@ -377,7 +377,7 @@ public class FillManagerTest {
 
     @Test
     public void testFillLayerFilter() {
-        fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        fillManager = new FillManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         Expression expression = Expression.eq(Expression.get("test"), "selected");
         verify(fillLayer, times(0)).setFilter(expression);
 
@@ -392,7 +392,7 @@ public class FillManagerTest {
     @Test
     public void testClickListener() {
         OnFillClickListener listener = mock(OnFillClickListener.class);
-        fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        fillManager = new FillManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         assertTrue(fillManager.getClickListeners().isEmpty());
         fillManager.addClickListener(listener);
         assertTrue(fillManager.getClickListeners().contains(listener));
@@ -403,7 +403,7 @@ public class FillManagerTest {
     @Test
     public void testLongClickListener() {
         OnFillLongClickListener listener = mock(OnFillLongClickListener.class);
-        fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        fillManager = new FillManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         assertTrue(fillManager.getLongClickListeners().isEmpty());
         fillManager.addLongClickListener(listener);
         assertTrue(fillManager.getLongClickListeners().contains(listener));
@@ -414,7 +414,7 @@ public class FillManagerTest {
     @Test
     public void testDragListener() {
         OnFillDragListener listener = mock(OnFillDragListener.class);
-        fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        fillManager = new FillManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         assertTrue(fillManager.getDragListeners().isEmpty());
         fillManager.addDragListener(listener);
         assertTrue(fillManager.getDragListeners().contains(listener));
@@ -424,7 +424,7 @@ public class FillManagerTest {
 
     @Test
     public void testCustomData() {
-        fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        fillManager = new FillManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         List<LatLng> innerLatLngs = new ArrayList<>();
         innerLatLngs.add(new LatLng());
         innerLatLngs.add(new LatLng(1, 1));
@@ -439,7 +439,7 @@ public class FillManagerTest {
 
     @Test
     public void testClearAll() {
-        fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        fillManager = new FillManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         List<LatLng> innerLatLngs = new ArrayList<>();
         innerLatLngs.add(new LatLng());
         innerLatLngs.add(new LatLng(1, 1));
@@ -455,7 +455,7 @@ public class FillManagerTest {
 
     @Test
     public void testIgnoreClearedAnnotations() {
-        fillManager = new FillManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        fillManager = new FillManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         List<LatLng> innerLatLngs = new ArrayList<>();
         innerLatLngs.add(new LatLng());
         innerLatLngs.add(new LatLng(1, 1));

--- a/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/LineManagerTest.java
+++ b/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/LineManagerTest.java
@@ -5,7 +5,7 @@ package com.mapbox.mapboxsdk.plugins.annotation;
 import android.graphics.PointF;
 
 import com.google.gson.JsonPrimitive;
-import com.mapbox.geojson.*;
+import org.maplibre.geojson.*;
 import org.maplibre.android.geometry.LatLng;
 import org.maplibre.android.maps.MapView;
 import org.maplibre.android.maps.MapLibreMap;

--- a/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/LineManagerTest.java
+++ b/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/LineManagerTest.java
@@ -36,7 +36,7 @@ public class LineManagerTest {
 
     private DraggableAnnotationController draggableAnnotationController = mock(DraggableAnnotationController.class);
     private MapView mapView = mock(MapView.class);
-    private MapLibreMap mapboxMap = mock(MapLibreMap.class);
+    private MapLibreMap maplibreMap = mock(MapLibreMap.class);
     private Style style = mock(Style.class);
     private GeoJsonSource geoJsonSource = mock(GeoJsonSource.class);
     private GeoJsonSource optionedGeoJsonSource = mock(GeoJsonSource.class);
@@ -57,7 +57,7 @@ public class LineManagerTest {
 
     @Test
     public void testInitialization() {
-        lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        lineManager = new LineManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(style).addSource(geoJsonSource);
         verify(style).addLayer(lineLayer);
         assertTrue(lineManager.dataDrivenPropertyUsageMap.size() > 0);
@@ -70,7 +70,7 @@ public class LineManagerTest {
 
     @Test
     public void testInitializationOnStyleReload() {
-        lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        lineManager = new LineManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(style).addSource(geoJsonSource);
         verify(style).addLayer(lineLayer);
         assertTrue(lineManager.dataDrivenPropertyUsageMap.size() > 0);
@@ -87,7 +87,7 @@ public class LineManagerTest {
         loadingArgumentCaptor.getValue().onDidFinishLoadingStyle();
 
         ArgumentCaptor<Style.OnStyleLoaded> styleLoadedArgumentCaptor = ArgumentCaptor.forClass(Style.OnStyleLoaded.class);
-        verify(mapboxMap).getStyle(styleLoadedArgumentCaptor.capture());
+        verify(maplibreMap).getStyle(styleLoadedArgumentCaptor.capture());
 
         Style newStyle = mock(Style.class);
         when(newStyle.isFullyLoaded()).thenReturn(true);
@@ -109,7 +109,7 @@ public class LineManagerTest {
 
     @Test
     public void testLayerBelowInitialization() {
-        lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, "test_layer", null, null, draggableAnnotationController);
+        lineManager = new LineManager(mapView, maplibreMap, style, coreElementProvider, "test_layer", null, null, draggableAnnotationController);
         verify(style).addSource(geoJsonSource);
         verify(style).addLayerBelow(lineLayer, "test_layer");
         assertTrue(lineManager.dataDrivenPropertyUsageMap.size() > 0);
@@ -121,7 +121,7 @@ public class LineManagerTest {
 
     @Test
     public void testGeoJsonOptionsInitialization() {
-        lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, geoJsonOptions, draggableAnnotationController);
+        lineManager = new LineManager(mapView, maplibreMap, style, coreElementProvider, null, null, geoJsonOptions, draggableAnnotationController);
         verify(style).addSource(optionedGeoJsonSource);
         verify(style).addLayer(lineLayer);
         assertTrue(lineManager.dataDrivenPropertyUsageMap.size() > 0);
@@ -134,13 +134,13 @@ public class LineManagerTest {
 
     @Test
     public void testLayerId() {
-        lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        lineManager = new LineManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         assertEquals(layerId, lineManager.getLayerId());
     }
 
     @Test
     public void testAddLine() {
-        lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        lineManager = new LineManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         List<LatLng> latLngs = new ArrayList<>();
         latLngs.add(new LatLng());
         latLngs.add(new LatLng(1, 1));
@@ -150,7 +150,7 @@ public class LineManagerTest {
 
     @Test
     public void addLineFromFeatureCollection() {
-        lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        lineManager = new LineManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         List<Point> points = new ArrayList<>();
         points.add(Point.fromLngLat(0, 0));
         points.add(Point.fromLngLat(1, 1));
@@ -184,7 +184,7 @@ public class LineManagerTest {
 
     @Test
     public void addLines() {
-        lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        lineManager = new LineManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         List<List<LatLng>> latLngList = new ArrayList<>();
         latLngList.add(new ArrayList<LatLng>() {{
             add(new LatLng(2, 2));
@@ -205,7 +205,7 @@ public class LineManagerTest {
 
     @Test
     public void testDeleteLine() {
-        lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        lineManager = new LineManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         List<LatLng> latLngs = new ArrayList<>();
         latLngs.add(new LatLng());
         latLngs.add(new LatLng(1, 1));
@@ -216,7 +216,7 @@ public class LineManagerTest {
 
     @Test
     public void testGeometryLine() {
-        lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        lineManager = new LineManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         List<LatLng> latLngs = new ArrayList<>();
         latLngs.add(new LatLng());
         latLngs.add(new LatLng(1, 1));
@@ -236,7 +236,7 @@ public class LineManagerTest {
 
     @Test
     public void testFeatureIdLine() {
-        lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        lineManager = new LineManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         List<LatLng> latLngs = new ArrayList<>();
         latLngs.add(new LatLng());
         latLngs.add(new LatLng(1, 1));
@@ -248,7 +248,7 @@ public class LineManagerTest {
 
     @Test
     public void testLineDraggableFlag() {
-        lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        lineManager = new LineManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         List<LatLng> latLngs = new ArrayList<>();
         latLngs.add(new LatLng());
         latLngs.add(new LatLng(1, 1));
@@ -264,7 +264,7 @@ public class LineManagerTest {
 
     @Test
     public void testLineJoinLayerProperty() {
-        lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        lineManager = new LineManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(lineLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(lineJoin(get("line-join")))));
 
         List<LatLng> latLngs = new ArrayList<>();
@@ -281,7 +281,7 @@ public class LineManagerTest {
 
     @Test
     public void testLineOpacityLayerProperty() {
-        lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        lineManager = new LineManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(lineLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(lineOpacity(get("line-opacity")))));
 
         List<LatLng> latLngs = new ArrayList<>();
@@ -298,7 +298,7 @@ public class LineManagerTest {
 
     @Test
     public void testLineColorLayerProperty() {
-        lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        lineManager = new LineManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(lineLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(lineColor(get("line-color")))));
 
         List<LatLng> latLngs = new ArrayList<>();
@@ -315,7 +315,7 @@ public class LineManagerTest {
 
     @Test
     public void testLineWidthLayerProperty() {
-        lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        lineManager = new LineManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(lineLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(lineWidth(get("line-width")))));
 
         List<LatLng> latLngs = new ArrayList<>();
@@ -332,7 +332,7 @@ public class LineManagerTest {
 
     @Test
     public void testLineGapWidthLayerProperty() {
-        lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        lineManager = new LineManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(lineLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(lineGapWidth(get("line-gap-width")))));
 
         List<LatLng> latLngs = new ArrayList<>();
@@ -349,7 +349,7 @@ public class LineManagerTest {
 
     @Test
     public void testLineOffsetLayerProperty() {
-        lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        lineManager = new LineManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(lineLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(lineOffset(get("line-offset")))));
 
         List<LatLng> latLngs = new ArrayList<>();
@@ -366,7 +366,7 @@ public class LineManagerTest {
 
     @Test
     public void testLineBlurLayerProperty() {
-        lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        lineManager = new LineManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(lineLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(lineBlur(get("line-blur")))));
 
         List<LatLng> latLngs = new ArrayList<>();
@@ -383,7 +383,7 @@ public class LineManagerTest {
 
     @Test
     public void testLinePatternLayerProperty() {
-        lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        lineManager = new LineManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(lineLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(linePattern(get("line-pattern")))));
 
         List<LatLng> latLngs = new ArrayList<>();
@@ -400,7 +400,7 @@ public class LineManagerTest {
 
     @Test
     public void testLineLayerFilter() {
-        lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        lineManager = new LineManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         Expression expression = Expression.eq(Expression.get("test"), "selected");
         verify(lineLayer, times(0)).setFilter(expression);
 
@@ -415,7 +415,7 @@ public class LineManagerTest {
     @Test
     public void testClickListener() {
         OnLineClickListener listener = mock(OnLineClickListener.class);
-        lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        lineManager = new LineManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         assertTrue(lineManager.getClickListeners().isEmpty());
         lineManager.addClickListener(listener);
         assertTrue(lineManager.getClickListeners().contains(listener));
@@ -426,7 +426,7 @@ public class LineManagerTest {
     @Test
     public void testLongClickListener() {
         OnLineLongClickListener listener = mock(OnLineLongClickListener.class);
-        lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        lineManager = new LineManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         assertTrue(lineManager.getLongClickListeners().isEmpty());
         lineManager.addLongClickListener(listener);
         assertTrue(lineManager.getLongClickListeners().contains(listener));
@@ -437,7 +437,7 @@ public class LineManagerTest {
     @Test
     public void testDragListener() {
         OnLineDragListener listener = mock(OnLineDragListener.class);
-        lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        lineManager = new LineManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         assertTrue(lineManager.getDragListeners().isEmpty());
         lineManager.addDragListener(listener);
         assertTrue(lineManager.getDragListeners().contains(listener));
@@ -447,7 +447,7 @@ public class LineManagerTest {
 
     @Test
     public void testCustomData() {
-        lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        lineManager = new LineManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         List<LatLng> latLngs = new ArrayList<>();
         latLngs.add(new LatLng());
         latLngs.add(new LatLng(1, 1));
@@ -459,7 +459,7 @@ public class LineManagerTest {
 
     @Test
     public void testClearAll() {
-        lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        lineManager = new LineManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         List<LatLng> latLngs = new ArrayList<>();
         latLngs.add(new LatLng());
         latLngs.add(new LatLng(1, 1));
@@ -472,7 +472,7 @@ public class LineManagerTest {
 
     @Test
     public void testIgnoreClearedAnnotations() {
-        lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        lineManager = new LineManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         List<LatLng> latLngs = new ArrayList<>();
         latLngs.add(new LatLng());
         latLngs.add(new LatLng(1, 1));

--- a/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/LineManagerTest.java
+++ b/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/LineManagerTest.java
@@ -6,29 +6,26 @@ import android.graphics.PointF;
 
 import com.google.gson.JsonPrimitive;
 import com.mapbox.geojson.*;
-import com.mapbox.mapboxsdk.geometry.LatLng;
-import com.mapbox.mapboxsdk.maps.MapView;
-import com.mapbox.mapboxsdk.maps.MapboxMap;
-import com.mapbox.mapboxsdk.maps.Style;
-import com.mapbox.mapboxsdk.style.expressions.Expression;
-import com.mapbox.mapboxsdk.style.layers.*;
-import com.mapbox.mapboxsdk.style.sources.GeoJsonOptions;
-import com.mapbox.mapboxsdk.style.sources.GeoJsonSource;
-import com.mapbox.mapboxsdk.utils.ColorUtils;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.maplibre.android.geometry.LatLng;
+import org.maplibre.android.maps.MapLibreMap;
+import org.maplibre.android.maps.MapView;
+import org.maplibre.android.maps.Style;
+import org.maplibre.android.style.expressions.Expression;
+import org.maplibre.android.style.layers.LineLayer;
+import org.maplibre.android.style.layers.PropertyValue;
+import org.maplibre.android.style.sources.GeoJsonOptions;
+import org.maplibre.android.style.sources.GeoJsonSource;
 import org.mockito.ArgumentCaptor;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Arrays;
-
-import static com.mapbox.mapboxsdk.plugins.annotation.ConvertUtils.convertArray;
-import static com.mapbox.mapboxsdk.style.expressions.Expression.get;
-import static com.mapbox.mapboxsdk.style.layers.Property.*;
-import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.*;
 import static junit.framework.Assert.*;
+import static org.maplibre.android.style.expressions.Expression.get;
+import static org.maplibre.android.style.layers.Property.LINE_JOIN_BEVEL;
+import static org.maplibre.android.style.layers.PropertyFactory.*;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.*;
 
@@ -36,7 +33,7 @@ public class LineManagerTest {
 
     private DraggableAnnotationController draggableAnnotationController = mock(DraggableAnnotationController.class);
     private MapView mapView = mock(MapView.class);
-    private MapboxMap mapboxMap = mock(MapboxMap.class);
+    private MapLibreMap mapboxMap = mock(MapLibreMap.class);
     private Style style = mock(Style.class);
     private GeoJsonSource geoJsonSource = mock(GeoJsonSource.class);
     private GeoJsonSource optionedGeoJsonSource = mock(GeoJsonSource.class);
@@ -401,7 +398,7 @@ public class LineManagerTest {
     @Test
     public void testLineLayerFilter() {
         lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
-        Expression expression = Expression.eq(Expression.get("test"), "selected");
+        Expression expression = Expression.eq(get("test"), "selected");
         verify(lineLayer, times(0)).setFilter(expression);
 
         lineManager.setFilter(expression);

--- a/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/LineManagerTest.java
+++ b/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/LineManagerTest.java
@@ -6,26 +6,29 @@ import android.graphics.PointF;
 
 import com.google.gson.JsonPrimitive;
 import com.mapbox.geojson.*;
+import org.maplibre.android.geometry.LatLng;
+import org.maplibre.android.maps.MapView;
+import org.maplibre.android.maps.MapLibreMap;
+import org.maplibre.android.maps.Style;
+import org.maplibre.android.style.expressions.Expression;
+import org.maplibre.android.style.layers.*;
+import org.maplibre.android.style.sources.GeoJsonOptions;
+import org.maplibre.android.style.sources.GeoJsonSource;
+import org.maplibre.android.utils.ColorUtils;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.maplibre.android.geometry.LatLng;
-import org.maplibre.android.maps.MapLibreMap;
-import org.maplibre.android.maps.MapView;
-import org.maplibre.android.maps.Style;
-import org.maplibre.android.style.expressions.Expression;
-import org.maplibre.android.style.layers.LineLayer;
-import org.maplibre.android.style.layers.PropertyValue;
-import org.maplibre.android.style.sources.GeoJsonOptions;
-import org.maplibre.android.style.sources.GeoJsonSource;
 import org.mockito.ArgumentCaptor;
 
 import java.util.ArrayList;
 import java.util.List;
-import static junit.framework.Assert.*;
+import java.util.Arrays;
+
+import static com.mapbox.mapboxsdk.plugins.annotation.ConvertUtils.convertArray;
 import static org.maplibre.android.style.expressions.Expression.get;
-import static org.maplibre.android.style.layers.Property.LINE_JOIN_BEVEL;
+import static org.maplibre.android.style.layers.Property.*;
 import static org.maplibre.android.style.layers.PropertyFactory.*;
+import static junit.framework.Assert.*;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.*;
 
@@ -398,7 +401,7 @@ public class LineManagerTest {
     @Test
     public void testLineLayerFilter() {
         lineManager = new LineManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
-        Expression expression = Expression.eq(get("test"), "selected");
+        Expression expression = Expression.eq(Expression.get("test"), "selected");
         verify(lineLayer, times(0)).setFilter(expression);
 
         lineManager.setFilter(expression);

--- a/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/PropertyValueMatcher.java
+++ b/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/PropertyValueMatcher.java
@@ -1,7 +1,6 @@
 package com.mapbox.mapboxsdk.plugins.annotation;
 
-import com.mapbox.mapboxsdk.style.layers.PropertyValue;
-
+import org.maplibre.android.style.layers.PropertyValue;
 import org.mockito.ArgumentMatcher;
 
 import java.util.Arrays;

--- a/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/SymbolManagerTest.java
+++ b/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/SymbolManagerTest.java
@@ -5,7 +5,7 @@ package com.mapbox.mapboxsdk.plugins.annotation;
 import android.graphics.PointF;
 
 import com.google.gson.JsonPrimitive;
-import com.mapbox.geojson.*;
+import org.maplibre.geojson.*;
 import org.maplibre.android.geometry.LatLng;
 import org.maplibre.android.maps.MapView;
 import org.maplibre.android.maps.MapLibreMap;

--- a/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/SymbolManagerTest.java
+++ b/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/SymbolManagerTest.java
@@ -6,18 +6,18 @@ import android.graphics.PointF;
 
 import com.google.gson.JsonPrimitive;
 import com.mapbox.geojson.*;
-import com.mapbox.mapboxsdk.geometry.LatLng;
-import com.mapbox.mapboxsdk.maps.MapView;
-import com.mapbox.mapboxsdk.maps.MapboxMap;
-import com.mapbox.mapboxsdk.maps.Style;
-import com.mapbox.mapboxsdk.style.expressions.Expression;
-import com.mapbox.mapboxsdk.style.layers.*;
-import com.mapbox.mapboxsdk.style.sources.GeoJsonOptions;
-import com.mapbox.mapboxsdk.style.sources.GeoJsonSource;
-import com.mapbox.mapboxsdk.utils.ColorUtils;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.maplibre.android.geometry.LatLng;
+import org.maplibre.android.maps.MapLibreMap;
+import org.maplibre.android.maps.MapView;
+import org.maplibre.android.maps.Style;
+import org.maplibre.android.style.expressions.Expression;
+import org.maplibre.android.style.layers.PropertyValue;
+import org.maplibre.android.style.layers.SymbolLayer;
+import org.maplibre.android.style.sources.GeoJsonOptions;
+import org.maplibre.android.style.sources.GeoJsonSource;
 import org.mockito.ArgumentCaptor;
 
 import java.util.ArrayList;
@@ -25,10 +25,10 @@ import java.util.List;
 import java.util.Arrays;
 
 import static com.mapbox.mapboxsdk.plugins.annotation.ConvertUtils.convertArray;
-import static com.mapbox.mapboxsdk.style.expressions.Expression.get;
-import static com.mapbox.mapboxsdk.style.layers.Property.*;
-import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.*;
 import static junit.framework.Assert.*;
+import static org.maplibre.android.style.expressions.Expression.get;
+import static org.maplibre.android.style.layers.Property.*;
+import static org.maplibre.android.style.layers.PropertyFactory.*;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.*;
 
@@ -36,7 +36,7 @@ public class SymbolManagerTest {
 
     private DraggableAnnotationController draggableAnnotationController = mock(DraggableAnnotationController.class);
     private MapView mapView = mock(MapView.class);
-    private MapboxMap mapboxMap = mock(MapboxMap.class);
+    private MapLibreMap mapboxMap = mock(MapLibreMap.class);
     private Style style = mock(Style.class);
     private GeoJsonSource geoJsonSource = mock(GeoJsonSource.class);
     private GeoJsonSource optionedGeoJsonSource = mock(GeoJsonSource.class);
@@ -656,7 +656,7 @@ public class SymbolManagerTest {
     @Test
     public void testSymbolLayerFilter() {
         symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
-        Expression expression = Expression.eq(Expression.get("test"), "selected");
+        Expression expression = Expression.eq(get("test"), "selected");
         verify(symbolLayer, times(0)).setFilter(expression);
 
         symbolManager.setFilter(expression);

--- a/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/SymbolManagerTest.java
+++ b/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/SymbolManagerTest.java
@@ -6,18 +6,18 @@ import android.graphics.PointF;
 
 import com.google.gson.JsonPrimitive;
 import com.mapbox.geojson.*;
+import org.maplibre.android.geometry.LatLng;
+import org.maplibre.android.maps.MapView;
+import org.maplibre.android.maps.MapLibreMap;
+import org.maplibre.android.maps.Style;
+import org.maplibre.android.style.expressions.Expression;
+import org.maplibre.android.style.layers.*;
+import org.maplibre.android.style.sources.GeoJsonOptions;
+import org.maplibre.android.style.sources.GeoJsonSource;
+import org.maplibre.android.utils.ColorUtils;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.maplibre.android.geometry.LatLng;
-import org.maplibre.android.maps.MapLibreMap;
-import org.maplibre.android.maps.MapView;
-import org.maplibre.android.maps.Style;
-import org.maplibre.android.style.expressions.Expression;
-import org.maplibre.android.style.layers.PropertyValue;
-import org.maplibre.android.style.layers.SymbolLayer;
-import org.maplibre.android.style.sources.GeoJsonOptions;
-import org.maplibre.android.style.sources.GeoJsonSource;
 import org.mockito.ArgumentCaptor;
 
 import java.util.ArrayList;
@@ -25,10 +25,10 @@ import java.util.List;
 import java.util.Arrays;
 
 import static com.mapbox.mapboxsdk.plugins.annotation.ConvertUtils.convertArray;
-import static junit.framework.Assert.*;
 import static org.maplibre.android.style.expressions.Expression.get;
 import static org.maplibre.android.style.layers.Property.*;
 import static org.maplibre.android.style.layers.PropertyFactory.*;
+import static junit.framework.Assert.*;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.*;
 
@@ -656,7 +656,7 @@ public class SymbolManagerTest {
     @Test
     public void testSymbolLayerFilter() {
         symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
-        Expression expression = Expression.eq(get("test"), "selected");
+        Expression expression = Expression.eq(Expression.get("test"), "selected");
         verify(symbolLayer, times(0)).setFilter(expression);
 
         symbolManager.setFilter(expression);

--- a/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/SymbolManagerTest.java
+++ b/plugin-annotation/src/test/java/com/mapbox/mapboxsdk/plugins/annotation/SymbolManagerTest.java
@@ -36,7 +36,7 @@ public class SymbolManagerTest {
 
     private DraggableAnnotationController draggableAnnotationController = mock(DraggableAnnotationController.class);
     private MapView mapView = mock(MapView.class);
-    private MapLibreMap mapboxMap = mock(MapLibreMap.class);
+    private MapLibreMap maplibreMap = mock(MapLibreMap.class);
     private Style style = mock(Style.class);
     private GeoJsonSource geoJsonSource = mock(GeoJsonSource.class);
     private GeoJsonSource optionedGeoJsonSource = mock(GeoJsonSource.class);
@@ -57,7 +57,7 @@ public class SymbolManagerTest {
 
     @Test
     public void testInitialization() {
-        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        symbolManager = new SymbolManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(style).addSource(geoJsonSource);
         verify(style).addLayer(symbolLayer);
         assertTrue(symbolManager.dataDrivenPropertyUsageMap.size() > 0);
@@ -70,7 +70,7 @@ public class SymbolManagerTest {
 
     @Test
     public void testInitializationOnStyleReload() {
-        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        symbolManager = new SymbolManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(style).addSource(geoJsonSource);
         verify(style).addLayer(symbolLayer);
         assertTrue(symbolManager.dataDrivenPropertyUsageMap.size() > 0);
@@ -87,7 +87,7 @@ public class SymbolManagerTest {
         loadingArgumentCaptor.getValue().onDidFinishLoadingStyle();
 
         ArgumentCaptor<Style.OnStyleLoaded> styleLoadedArgumentCaptor = ArgumentCaptor.forClass(Style.OnStyleLoaded.class);
-        verify(mapboxMap).getStyle(styleLoadedArgumentCaptor.capture());
+        verify(maplibreMap).getStyle(styleLoadedArgumentCaptor.capture());
 
         Style newStyle = mock(Style.class);
         when(newStyle.isFullyLoaded()).thenReturn(true);
@@ -109,7 +109,7 @@ public class SymbolManagerTest {
 
     @Test
     public void testLayerBelowInitialization() {
-        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, "test_layer", null, null, draggableAnnotationController);
+        symbolManager = new SymbolManager(mapView, maplibreMap, style, coreElementProvider, "test_layer", null, null, draggableAnnotationController);
         verify(style).addSource(geoJsonSource);
         verify(style).addLayerBelow(symbolLayer, "test_layer");
         assertTrue(symbolManager.dataDrivenPropertyUsageMap.size() > 0);
@@ -121,7 +121,7 @@ public class SymbolManagerTest {
 
     @Test
     public void testGeoJsonOptionsInitialization() {
-        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, geoJsonOptions, draggableAnnotationController);
+        symbolManager = new SymbolManager(mapView, maplibreMap, style, coreElementProvider, null, null, geoJsonOptions, draggableAnnotationController);
         verify(style).addSource(optionedGeoJsonSource);
         verify(style).addLayer(symbolLayer);
         assertTrue(symbolManager.dataDrivenPropertyUsageMap.size() > 0);
@@ -134,20 +134,20 @@ public class SymbolManagerTest {
 
     @Test
     public void testLayerId() {
-        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        symbolManager = new SymbolManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         assertEquals(layerId, symbolManager.getLayerId());
     }
 
     @Test
     public void testAddSymbol() {
-        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        symbolManager = new SymbolManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         Symbol symbol = symbolManager.create(new SymbolOptions().withLatLng(new LatLng()));
         assertEquals(symbolManager.getAnnotations().get(0), symbol);
     }
 
     @Test
     public void addSymbolFromFeatureCollection() {
-        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        symbolManager = new SymbolManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         Geometry geometry = Point.fromLngLat(10, 10);
 
         Feature feature = Feature.fromGeometry(geometry);
@@ -220,7 +220,7 @@ public class SymbolManagerTest {
 
     @Test
     public void addSymbols() {
-        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        symbolManager = new SymbolManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         List<LatLng> latLngList = new ArrayList<>();
         latLngList.add(new LatLng());
         latLngList.add(new LatLng(1, 1));
@@ -235,7 +235,7 @@ public class SymbolManagerTest {
 
     @Test
     public void testDeleteSymbol() {
-        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        symbolManager = new SymbolManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         Symbol symbol = symbolManager.create(new SymbolOptions().withLatLng(new LatLng()));
         symbolManager.delete(symbol);
         assertTrue(symbolManager.getAnnotations().size() == 0);
@@ -243,7 +243,7 @@ public class SymbolManagerTest {
 
     @Test
     public void testGeometrySymbol() {
-        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        symbolManager = new SymbolManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         LatLng latLng = new LatLng(12, 34);
         SymbolOptions options = new SymbolOptions().withLatLng(latLng);
         Symbol symbol = symbolManager.create(options);
@@ -255,7 +255,7 @@ public class SymbolManagerTest {
 
     @Test
     public void testFeatureIdSymbol() {
-        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        symbolManager = new SymbolManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         Symbol symbolZero = symbolManager.create(new SymbolOptions().withLatLng(new LatLng()));
         Symbol symbolOne = symbolManager.create(new SymbolOptions().withLatLng(new LatLng()));
         assertEquals(symbolZero.getFeature().get(Symbol.ID_KEY).getAsLong(), 0);
@@ -264,7 +264,7 @@ public class SymbolManagerTest {
 
     @Test
     public void testSymbolDraggableFlag() {
-        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        symbolManager = new SymbolManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         Symbol symbolZero = symbolManager.create(new SymbolOptions().withLatLng(new LatLng()));
 
         assertFalse(symbolZero.isDraggable());
@@ -277,7 +277,7 @@ public class SymbolManagerTest {
 
     @Test
     public void testSymbolSortKeyLayerProperty() {
-        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        symbolManager = new SymbolManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(symbolLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(symbolSortKey(get("symbol-sort-key")))));
 
         SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withSymbolSortKey(2.0f);
@@ -291,7 +291,7 @@ public class SymbolManagerTest {
 
     @Test
     public void testIconSizeLayerProperty() {
-        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        symbolManager = new SymbolManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(symbolLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(iconSize(get("icon-size")))));
 
         SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withIconSize(2.0f);
@@ -305,7 +305,7 @@ public class SymbolManagerTest {
 
     @Test
     public void testIconImageLayerProperty() {
-        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        symbolManager = new SymbolManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(symbolLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(iconImage(get("icon-image")))));
 
         SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withIconImage("undefined");
@@ -319,7 +319,7 @@ public class SymbolManagerTest {
 
     @Test
     public void testIconRotateLayerProperty() {
-        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        symbolManager = new SymbolManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(symbolLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(iconRotate(get("icon-rotate")))));
 
         SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withIconRotate(2.0f);
@@ -333,7 +333,7 @@ public class SymbolManagerTest {
 
     @Test
     public void testIconOffsetLayerProperty() {
-        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        symbolManager = new SymbolManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(symbolLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(iconOffset(get("icon-offset")))));
 
         SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withIconOffset(new Float[]{0f, 0f});
@@ -347,7 +347,7 @@ public class SymbolManagerTest {
 
     @Test
     public void testIconAnchorLayerProperty() {
-        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        symbolManager = new SymbolManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(symbolLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(iconAnchor(get("icon-anchor")))));
 
         SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withIconAnchor(ICON_ANCHOR_CENTER);
@@ -361,7 +361,7 @@ public class SymbolManagerTest {
 
     @Test
     public void testTextFieldLayerProperty() {
-        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        symbolManager = new SymbolManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(symbolLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(textField(get("text-field")))));
 
         SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withTextField("");
@@ -375,7 +375,7 @@ public class SymbolManagerTest {
 
     @Test
     public void testTextFontLayerProperty() {
-        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        symbolManager = new SymbolManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(symbolLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(textFont(get("text-font")))));
 
         SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withTextFont(new String[]{"Open Sans Regular", "Arial Unicode MS Regular"});
@@ -389,7 +389,7 @@ public class SymbolManagerTest {
 
     @Test
     public void testTextSizeLayerProperty() {
-        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        symbolManager = new SymbolManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(symbolLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(textSize(get("text-size")))));
 
         SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withTextSize(2.0f);
@@ -403,7 +403,7 @@ public class SymbolManagerTest {
 
     @Test
     public void testTextMaxWidthLayerProperty() {
-        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        symbolManager = new SymbolManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(symbolLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(textMaxWidth(get("text-max-width")))));
 
         SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withTextMaxWidth(2.0f);
@@ -417,7 +417,7 @@ public class SymbolManagerTest {
 
     @Test
     public void testTextLetterSpacingLayerProperty() {
-        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        symbolManager = new SymbolManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(symbolLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(textLetterSpacing(get("text-letter-spacing")))));
 
         SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withTextLetterSpacing(2.0f);
@@ -431,7 +431,7 @@ public class SymbolManagerTest {
 
     @Test
     public void testTextJustifyLayerProperty() {
-        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        symbolManager = new SymbolManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(symbolLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(textJustify(get("text-justify")))));
 
         SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withTextJustify(TEXT_JUSTIFY_AUTO);
@@ -445,7 +445,7 @@ public class SymbolManagerTest {
 
     @Test
     public void testTextRadialOffsetLayerProperty() {
-        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        symbolManager = new SymbolManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(symbolLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(textRadialOffset(get("text-radial-offset")))));
 
         SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withTextRadialOffset(2.0f);
@@ -459,7 +459,7 @@ public class SymbolManagerTest {
 
     @Test
     public void testTextAnchorLayerProperty() {
-        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        symbolManager = new SymbolManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(symbolLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(textAnchor(get("text-anchor")))));
 
         SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withTextAnchor(TEXT_ANCHOR_CENTER);
@@ -473,7 +473,7 @@ public class SymbolManagerTest {
 
     @Test
     public void testTextRotateLayerProperty() {
-        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        symbolManager = new SymbolManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(symbolLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(textRotate(get("text-rotate")))));
 
         SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withTextRotate(2.0f);
@@ -487,7 +487,7 @@ public class SymbolManagerTest {
 
     @Test
     public void testTextTransformLayerProperty() {
-        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        symbolManager = new SymbolManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(symbolLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(textTransform(get("text-transform")))));
 
         SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withTextTransform(TEXT_TRANSFORM_NONE);
@@ -501,7 +501,7 @@ public class SymbolManagerTest {
 
     @Test
     public void testTextOffsetLayerProperty() {
-        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        symbolManager = new SymbolManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(symbolLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(textOffset(get("text-offset")))));
 
         SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withTextOffset(new Float[]{0f, 0f});
@@ -515,7 +515,7 @@ public class SymbolManagerTest {
 
     @Test
     public void testIconOpacityLayerProperty() {
-        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        symbolManager = new SymbolManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(symbolLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(iconOpacity(get("icon-opacity")))));
 
         SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withIconOpacity(2.0f);
@@ -529,7 +529,7 @@ public class SymbolManagerTest {
 
     @Test
     public void testIconColorLayerProperty() {
-        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        symbolManager = new SymbolManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(symbolLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(iconColor(get("icon-color")))));
 
         SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withIconColor("rgba(0, 0, 0, 1)");
@@ -543,7 +543,7 @@ public class SymbolManagerTest {
 
     @Test
     public void testIconHaloColorLayerProperty() {
-        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        symbolManager = new SymbolManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(symbolLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(iconHaloColor(get("icon-halo-color")))));
 
         SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withIconHaloColor("rgba(0, 0, 0, 1)");
@@ -557,7 +557,7 @@ public class SymbolManagerTest {
 
     @Test
     public void testIconHaloWidthLayerProperty() {
-        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        symbolManager = new SymbolManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(symbolLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(iconHaloWidth(get("icon-halo-width")))));
 
         SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withIconHaloWidth(2.0f);
@@ -571,7 +571,7 @@ public class SymbolManagerTest {
 
     @Test
     public void testIconHaloBlurLayerProperty() {
-        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        symbolManager = new SymbolManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(symbolLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(iconHaloBlur(get("icon-halo-blur")))));
 
         SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withIconHaloBlur(2.0f);
@@ -585,7 +585,7 @@ public class SymbolManagerTest {
 
     @Test
     public void testTextOpacityLayerProperty() {
-        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        symbolManager = new SymbolManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(symbolLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(textOpacity(get("text-opacity")))));
 
         SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withTextOpacity(2.0f);
@@ -599,7 +599,7 @@ public class SymbolManagerTest {
 
     @Test
     public void testTextColorLayerProperty() {
-        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        symbolManager = new SymbolManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(symbolLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(textColor(get("text-color")))));
 
         SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withTextColor("rgba(0, 0, 0, 1)");
@@ -613,7 +613,7 @@ public class SymbolManagerTest {
 
     @Test
     public void testTextHaloColorLayerProperty() {
-        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        symbolManager = new SymbolManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(symbolLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(textHaloColor(get("text-halo-color")))));
 
         SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withTextHaloColor("rgba(0, 0, 0, 1)");
@@ -627,7 +627,7 @@ public class SymbolManagerTest {
 
     @Test
     public void testTextHaloWidthLayerProperty() {
-        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        symbolManager = new SymbolManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(symbolLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(textHaloWidth(get("text-halo-width")))));
 
         SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withTextHaloWidth(2.0f);
@@ -641,7 +641,7 @@ public class SymbolManagerTest {
 
     @Test
     public void testTextHaloBlurLayerProperty() {
-        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        symbolManager = new SymbolManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(symbolLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(textHaloBlur(get("text-halo-blur")))));
 
         SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withTextHaloBlur(2.0f);
@@ -655,7 +655,7 @@ public class SymbolManagerTest {
 
     @Test
     public void testSymbolLayerFilter() {
-        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        symbolManager = new SymbolManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         Expression expression = Expression.eq(Expression.get("test"), "selected");
         verify(symbolLayer, times(0)).setFilter(expression);
 
@@ -670,7 +670,7 @@ public class SymbolManagerTest {
     @Test
     public void testClickListener() {
         OnSymbolClickListener listener = mock(OnSymbolClickListener.class);
-        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        symbolManager = new SymbolManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         assertTrue(symbolManager.getClickListeners().isEmpty());
         symbolManager.addClickListener(listener);
         assertTrue(symbolManager.getClickListeners().contains(listener));
@@ -681,7 +681,7 @@ public class SymbolManagerTest {
     @Test
     public void testLongClickListener() {
         OnSymbolLongClickListener listener = mock(OnSymbolLongClickListener.class);
-        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        symbolManager = new SymbolManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         assertTrue(symbolManager.getLongClickListeners().isEmpty());
         symbolManager.addLongClickListener(listener);
         assertTrue(symbolManager.getLongClickListeners().contains(listener));
@@ -692,7 +692,7 @@ public class SymbolManagerTest {
     @Test
     public void testDragListener() {
         OnSymbolDragListener listener = mock(OnSymbolDragListener.class);
-        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        symbolManager = new SymbolManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         assertTrue(symbolManager.getDragListeners().isEmpty());
         symbolManager.addDragListener(listener);
         assertTrue(symbolManager.getDragListeners().contains(listener));
@@ -702,7 +702,7 @@ public class SymbolManagerTest {
 
     @Test
     public void testCustomData() {
-        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        symbolManager = new SymbolManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         SymbolOptions options = new SymbolOptions().withLatLng(new LatLng());
         options.withData(new JsonPrimitive("hello"));
         Symbol symbol = symbolManager.create(options);
@@ -711,7 +711,7 @@ public class SymbolManagerTest {
 
     @Test
     public void testClearAll() {
-        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        symbolManager = new SymbolManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         SymbolOptions options = new SymbolOptions().withLatLng(new LatLng());
         symbolManager.create(options);
         assertEquals(1, symbolManager.getAnnotations().size());
@@ -721,7 +721,7 @@ public class SymbolManagerTest {
 
     @Test
     public void testIgnoreClearedAnnotations() {
-        symbolManager = new SymbolManager(mapView, mapboxMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        symbolManager = new SymbolManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         SymbolOptions options = new SymbolOptions().withLatLng(new LatLng());
         Symbol symbol = symbolManager.create(options);
         assertEquals(1, symbolManager.annotations.size());

--- a/plugin-building/src/main/java/com/mapbox/mapboxsdk/plugins/building/BuildingPlugin.java
+++ b/plugin-building/src/main/java/com/mapbox/mapboxsdk/plugins/building/BuildingPlugin.java
@@ -2,38 +2,38 @@ package com.mapbox.mapboxsdk.plugins.building;
 
 import android.graphics.Color;
 
-import com.mapbox.mapboxsdk.maps.MapView;
-import com.mapbox.mapboxsdk.maps.MapboxMap;
-import com.mapbox.mapboxsdk.maps.Style;
-import com.mapbox.mapboxsdk.style.layers.FillExtrusionLayer;
-import com.mapbox.mapboxsdk.style.light.Light;
+import org.maplibre.android.maps.MapView;
+import org.maplibre.android.maps.MapLibreMap;
+import org.maplibre.android.maps.Style;
+import org.maplibre.android.style.layers.FillExtrusionLayer;
+import org.maplibre.android.style.light.Light;
 
 import androidx.annotation.ColorInt;
 import androidx.annotation.FloatRange;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-import static com.mapbox.mapboxsdk.constants.MapboxConstants.MAXIMUM_ZOOM;
-import static com.mapbox.mapboxsdk.constants.MapboxConstants.MINIMUM_ZOOM;
-import static com.mapbox.mapboxsdk.style.expressions.Expression.exponential;
-import static com.mapbox.mapboxsdk.style.expressions.Expression.get;
-import static com.mapbox.mapboxsdk.style.expressions.Expression.interpolate;
-import static com.mapbox.mapboxsdk.style.expressions.Expression.literal;
-import static com.mapbox.mapboxsdk.style.expressions.Expression.stop;
-import static com.mapbox.mapboxsdk.style.expressions.Expression.zoom;
-import static com.mapbox.mapboxsdk.style.layers.Property.NONE;
-import static com.mapbox.mapboxsdk.style.layers.Property.VISIBLE;
-import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.fillExtrusionColor;
-import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.fillExtrusionHeight;
-import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.fillExtrusionOpacity;
-import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.visibility;
+import static org.maplibre.android.constants.MapLibreConstants.MAXIMUM_ZOOM;
+import static org.maplibre.android.constants.MapLibreConstants.MINIMUM_ZOOM;
+import static org.maplibre.android.style.expressions.Expression.exponential;
+import static org.maplibre.android.style.expressions.Expression.get;
+import static org.maplibre.android.style.expressions.Expression.interpolate;
+import static org.maplibre.android.style.expressions.Expression.literal;
+import static org.maplibre.android.style.expressions.Expression.stop;
+import static org.maplibre.android.style.expressions.Expression.zoom;
+import static org.maplibre.android.style.layers.Property.NONE;
+import static org.maplibre.android.style.layers.Property.VISIBLE;
+import static org.maplibre.android.style.layers.PropertyFactory.fillExtrusionColor;
+import static org.maplibre.android.style.layers.PropertyFactory.fillExtrusionHeight;
+import static org.maplibre.android.style.layers.PropertyFactory.fillExtrusionOpacity;
+import static org.maplibre.android.style.layers.PropertyFactory.visibility;
 
 /**
  * The building plugin allows you to add 3d buildings FillExtrusionLayer to the Mapbox Maps SDK for
  * Android v5.1.0.
  * <p>
- * Initialise this plugin in the {@link com.mapbox.mapboxsdk.maps.OnMapReadyCallback#onMapReady(MapboxMap)}
- * and provide a valid instance of {@link MapView} and {@link MapboxMap}.
+ * Initialise this plugin in the {@link org.maplibre.android.maps.OnMapReadyCallback#onMapReady(MapLibreMap)}
+ * and provide a valid instance of {@link MapView} and {@link MapLibreMap}.
  * </p>
  * <ul>
  * <li>Use {@link #setVisibility(boolean)}} to show buildings from this plugin.</li>
@@ -60,21 +60,21 @@ public final class BuildingPlugin {
      * Create a building plugin.
      *
      * @param mapView   the MapView to apply the building plugin to
-     * @param mapboxMap the MapboxMap to apply building plugin with
+     * @param MapLibreMap the MapLibreMap to apply building plugin with
      * @since 0.1.0
      */
-    public BuildingPlugin(@NonNull MapView mapView, @NonNull final MapboxMap mapboxMap, @NonNull Style style) {
-        this(mapView, mapboxMap, style, null);
+    public BuildingPlugin(@NonNull MapView mapView, @NonNull final MapLibreMap MapLibreMap, @NonNull Style style) {
+        this(mapView, MapLibreMap, style, null);
     }
 
     /**
      * Create a building plugin.
      *
      * @param mapView   the MapView to apply the building plugin to
-     * @param mapboxMap the MapboxMap to apply building plugin with
+     * @param MapLibreMap the MapLibreMap to apply building plugin with
      * @since 0.1.0
      */
-    public BuildingPlugin(@NonNull MapView mapView, @NonNull final MapboxMap mapboxMap, @NonNull Style style,
+    public BuildingPlugin(@NonNull MapView mapView, @NonNull final MapLibreMap MapLibreMap, @NonNull Style style,
                           @Nullable final String belowLayer) {
         this.style = style;
         if (!style.isFullyLoaded()) {
@@ -86,7 +86,7 @@ public final class BuildingPlugin {
         mapView.addOnDidFinishLoadingStyleListener(new MapView.OnDidFinishLoadingStyleListener() {
             @Override
             public void onDidFinishLoadingStyle() {
-                mapboxMap.getStyle(new Style.OnStyleLoaded() {
+                MapLibreMap.getStyle(new Style.OnStyleLoaded() {
                     @Override
                     public void onStyleLoaded(@NonNull Style style) {
                         BuildingPlugin.this.style = style;

--- a/plugin-localization/src/main/java/com/mapbox/mapboxsdk/plugins/localization/LocalizationPlugin.java
+++ b/plugin-localization/src/main/java/com/mapbox/mapboxsdk/plugins/localization/LocalizationPlugin.java
@@ -1,18 +1,10 @@
 package com.mapbox.mapboxsdk.plugins.localization;
 
 
-import com.mapbox.mapboxsdk.camera.CameraUpdateFactory;
-import com.mapbox.mapboxsdk.geometry.LatLngBounds;
-import com.mapbox.mapboxsdk.maps.MapView;
-import com.mapbox.mapboxsdk.maps.MapboxMap;
-import com.mapbox.mapboxsdk.maps.Style;
+import static org.maplibre.android.style.expressions.Expression.raw;
+import static org.maplibre.android.style.layers.PropertyFactory.textField;
+
 import com.mapbox.mapboxsdk.plugins.localization.MapLocale.Languages;
-import com.mapbox.mapboxsdk.style.expressions.Expression;
-import com.mapbox.mapboxsdk.style.layers.Layer;
-import com.mapbox.mapboxsdk.style.layers.PropertyValue;
-import com.mapbox.mapboxsdk.style.layers.SymbolLayer;
-import com.mapbox.mapboxsdk.style.sources.Source;
-import com.mapbox.mapboxsdk.style.sources.VectorSource;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -21,10 +13,19 @@ import java.util.Locale;
 import androidx.annotation.NonNull;
 import androidx.annotation.UiThread;
 
-import timber.log.Timber;
+import org.maplibre.android.camera.CameraUpdateFactory;
+import org.maplibre.android.geometry.LatLngBounds;
+import org.maplibre.android.maps.MapLibreMap;
+import org.maplibre.android.maps.MapView;
+import org.maplibre.android.maps.Style;
+import org.maplibre.android.style.expressions.Expression;
+import org.maplibre.android.style.layers.Layer;
+import org.maplibre.android.style.layers.PropertyValue;
+import org.maplibre.android.style.layers.SymbolLayer;
+import org.maplibre.android.style.sources.Source;
+import org.maplibre.android.style.sources.VectorSource;
 
-import static com.mapbox.mapboxsdk.style.expressions.Expression.raw;
-import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.textField;
+import timber.log.Timber;
 
 /**
  * Useful class for quickly adjusting the maps language and the maps camera starting position.
@@ -94,7 +95,7 @@ public final class LocalizationPlugin {
     private static final String STEP_TEMPLATE = "[\"zoom\"], \"\", ";
 
     // configuration
-    private final MapboxMap mapboxMap;
+    private final MapLibreMap maplibreMap;
     private MapLocale mapLocale;
     @NonNull
     private Style style;
@@ -106,8 +107,8 @@ public final class LocalizationPlugin {
      * @param mapboxMap the Mapbox map object which your current map view is using for control
      * @param style     the Style object that represents a fully loaded style
      */
-    public LocalizationPlugin(@NonNull MapView mapView, @NonNull final MapboxMap mapboxMap, @NonNull Style style) {
-        this.mapboxMap = mapboxMap;
+    public LocalizationPlugin(@NonNull MapView mapView, @NonNull final MapLibreMap mapboxMap, @NonNull Style style) {
+        this.maplibreMap = mapboxMap;
         this.style = style;
         if (!style.isFullyLoaded()) {
             throw new RuntimeException("The style has to be non-null and fully loaded.");
@@ -350,7 +351,7 @@ public final class LocalizationPlugin {
             throw new NullPointerException("Expected a LatLngBounds object but received null instead. Mak"
                 + "e sure your MapLocale instance also has a country bounding box defined.");
         }
-        mapboxMap.moveCamera(CameraUpdateFactory.newLatLngBounds(bounds, padding));
+        maplibreMap.moveCamera(CameraUpdateFactory.newLatLngBounds(bounds, padding));
     }
 
     /*

--- a/plugin-localization/src/main/java/com/mapbox/mapboxsdk/plugins/localization/LocalizationPlugin.java
+++ b/plugin-localization/src/main/java/com/mapbox/mapboxsdk/plugins/localization/LocalizationPlugin.java
@@ -104,11 +104,11 @@ public final class LocalizationPlugin {
      * Public constructor for passing in the required objects.
      *
      * @param mapView   the MapView object in which the map is displayed
-     * @param mapboxMap the Mapbox map object which your current map view is using for control
+     * @param maplibreMap the Mapbox map object which your current map view is using for control
      * @param style     the Style object that represents a fully loaded style
      */
-    public LocalizationPlugin(@NonNull MapView mapView, @NonNull final MapLibreMap mapboxMap, @NonNull Style style) {
-        this.maplibreMap = mapboxMap;
+    public LocalizationPlugin(@NonNull MapView mapView, @NonNull final MapLibreMap maplibreMap, @NonNull Style style) {
+        this.maplibreMap = maplibreMap;
         this.style = style;
         if (!style.isFullyLoaded()) {
             throw new RuntimeException("The style has to be non-null and fully loaded.");
@@ -117,7 +117,7 @@ public final class LocalizationPlugin {
         mapView.addOnDidFinishLoadingStyleListener(new MapView.OnDidFinishLoadingStyleListener() {
             @Override
             public void onDidFinishLoadingStyle() {
-                mapboxMap.getStyle(new Style.OnStyleLoaded() {
+                maplibreMap.getStyle(new Style.OnStyleLoaded() {
                     @Override
                     public void onStyleLoaded(@NonNull Style style) {
                         LocalizationPlugin.this.style = style;

--- a/plugin-localization/src/main/java/com/mapbox/mapboxsdk/plugins/localization/MapLocale.java
+++ b/plugin-localization/src/main/java/com/mapbox/mapboxsdk/plugins/localization/MapLocale.java
@@ -1,9 +1,6 @@
 package com.mapbox.mapboxsdk.plugins.localization;
 
 
-import com.mapbox.mapboxsdk.geometry.LatLng;
-import com.mapbox.mapboxsdk.geometry.LatLngBounds;
-
 import java.lang.annotation.Retention;
 import java.util.HashMap;
 import java.util.Locale;
@@ -14,6 +11,9 @@ import androidx.annotation.Nullable;
 import androidx.annotation.StringDef;
 
 import static java.lang.annotation.RetentionPolicy.SOURCE;
+
+import org.maplibre.android.geometry.LatLng;
+import org.maplibre.android.geometry.LatLngBounds;
 
 /**
  * A {@link MapLocale} object builds off of the {@link Locale} object and provides additional

--- a/plugin-localization/src/test/java/com/mapbox/mapboxsdk/plugins/localization/LocalizationPluginTest.java
+++ b/plugin-localization/src/test/java/com/mapbox/mapboxsdk/plugins/localization/LocalizationPluginTest.java
@@ -1,8 +1,8 @@
 package com.mapbox.mapboxsdk.plugins.localization;
 
-import com.mapbox.mapboxsdk.maps.MapView;
-import com.mapbox.mapboxsdk.maps.MapboxMap;
-import com.mapbox.mapboxsdk.maps.Style;
+import org.maplibre.android.maps.MapView;
+import org.maplibre.android.maps.MapLibreMap;
+import org.maplibre.android.maps.Style;
 
 import org.junit.Ignore;
 import org.junit.Rule;
@@ -34,7 +34,7 @@ public class LocalizationPluginTest {
     public void sanity() throws Exception {
         when(style.isFullyLoaded()).thenReturn(true);
         LocalizationPlugin localizationPlugin
-            = new LocalizationPlugin(mock(MapView.class), mock(MapboxMap.class), style);
+            = new LocalizationPlugin(mock(MapView.class), mock(MapLibreMap.class), style);
         assertNotNull(localizationPlugin);
     }
 
@@ -45,7 +45,7 @@ public class LocalizationPluginTest {
         thrown.expect(NullPointerException.class);
         thrown.expectMessage(containsString("has no matching MapLocale object. You need to create"));
         LocalizationPlugin localizationPlugin
-            = new LocalizationPlugin(mock(MapView.class), mock(MapboxMap.class), style);
+            = new LocalizationPlugin(mock(MapView.class), mock(MapLibreMap.class), style);
         localizationPlugin.setMapLanguage(new Locale("foo", "bar"), false);
     }
 }

--- a/plugin-markerview/src/main/java/com/mapbox/mapboxsdk/plugins/markerview/MarkerView.java
+++ b/plugin-markerview/src/main/java/com/mapbox/mapboxsdk/plugins/markerview/MarkerView.java
@@ -3,10 +3,10 @@ package com.mapbox.mapboxsdk.plugins.markerview;
 import android.graphics.PointF;
 import android.view.View;
 
-import com.mapbox.mapboxsdk.geometry.LatLng;
-import com.mapbox.mapboxsdk.maps.Projection;
-
 import androidx.annotation.NonNull;
+
+import org.maplibre.android.geometry.LatLng;
+import org.maplibre.android.maps.Projection;
 
 /**
  * MarkerView class wraps a latitude-longitude pair with a Android SDK View.

--- a/plugin-markerview/src/main/java/com/mapbox/mapboxsdk/plugins/markerview/MarkerViewManager.java
+++ b/plugin-markerview/src/main/java/com/mapbox/mapboxsdk/plugins/markerview/MarkerViewManager.java
@@ -1,8 +1,7 @@
 package com.mapbox.mapboxsdk.plugins.markerview;
 
-
-import com.mapbox.mapboxsdk.maps.MapView;
-import com.mapbox.mapboxsdk.maps.MapboxMap;
+import org.maplibre.android.maps.MapLibreMap;
+import org.maplibre.android.maps.MapView;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -16,7 +15,7 @@ import androidx.annotation.UiThread;
 public class MarkerViewManager implements MapView.OnCameraDidChangeListener, MapView.OnCameraIsChangingListener {
 
     private final MapView mapView;
-    private final MapboxMap mapboxMap;
+    private final MapLibreMap maplibreMap;
     private final List<MarkerView> markers = new ArrayList<>();
     private boolean initialised;
 
@@ -26,9 +25,9 @@ public class MarkerViewManager implements MapView.OnCameraDidChangeListener, Map
      * @param mapView   the MapView used to synchronise views on
      * @param mapboxMap the MapboxMap to synchronise views with
      */
-    public MarkerViewManager(MapView mapView, MapboxMap mapboxMap) {
+    public MarkerViewManager(MapView mapView, MapLibreMap mapboxMap) {
         this.mapView = mapView;
-        this.mapboxMap = mapboxMap;
+        this.maplibreMap = mapboxMap;
     }
 
     /**
@@ -61,7 +60,7 @@ public class MarkerViewManager implements MapView.OnCameraDidChangeListener, Map
             mapView.addOnCameraDidChangeListener(this);
             mapView.addOnCameraIsChangingListener(this);
         }
-        markerView.setProjection(mapboxMap.getProjection());
+        markerView.setProjection(maplibreMap.getProjection());
         mapView.addView(markerView.getView());
         markers.add(markerView);
         markerView.update();

--- a/plugin-markerview/src/main/java/com/mapbox/mapboxsdk/plugins/markerview/MarkerViewManager.java
+++ b/plugin-markerview/src/main/java/com/mapbox/mapboxsdk/plugins/markerview/MarkerViewManager.java
@@ -23,11 +23,11 @@ public class MarkerViewManager implements MapView.OnCameraDidChangeListener, Map
      * Create a MarkerViewManager.
      *
      * @param mapView   the MapView used to synchronise views on
-     * @param mapboxMap the MapboxMap to synchronise views with
+     * @param maplibreMap the MapboxMap to synchronise views with
      */
-    public MarkerViewManager(MapView mapView, MapLibreMap mapboxMap) {
+    public MarkerViewManager(MapView mapView, MapLibreMap maplibreMap) {
         this.mapView = mapView;
-        this.maplibreMap = mapboxMap;
+        this.maplibreMap = maplibreMap;
     }
 
     /**

--- a/plugin-offline/src/main/java/com/mapbox/mapboxsdk/plugins/offline/OfflineRegionSelector.java
+++ b/plugin-offline/src/main/java/com/mapbox/mapboxsdk/plugins/offline/OfflineRegionSelector.java
@@ -4,7 +4,6 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 
-import com.mapbox.mapboxsdk.offline.OfflineRegionDefinition;
 import com.mapbox.mapboxsdk.plugins.offline.model.NotificationOptions;
 import com.mapbox.mapboxsdk.plugins.offline.model.OfflineDownloadOptions;
 import com.mapbox.mapboxsdk.plugins.offline.model.RegionSelectionOptions;
@@ -14,6 +13,8 @@ import androidx.annotation.NonNull;
 
 import static com.mapbox.mapboxsdk.plugins.offline.offline.OfflineConstants.RETURNING_DEFINITION;
 import static com.mapbox.mapboxsdk.plugins.offline.offline.OfflineConstants.RETURNING_REGION_NAME;
+
+import org.maplibre.android.offline.OfflineRegionDefinition;
 
 /**
  * While the offline plugin includes a service for optimally launching an offline download session,

--- a/plugin-offline/src/main/java/com/mapbox/mapboxsdk/plugins/offline/model/OfflineDownloadOptions.java
+++ b/plugin-offline/src/main/java/com/mapbox/mapboxsdk/plugins/offline/model/OfflineDownloadOptions.java
@@ -3,8 +3,6 @@ package com.mapbox.mapboxsdk.plugins.offline.model;
 import android.os.Parcelable;
 
 import com.google.auto.value.AutoValue;
-import com.mapbox.mapboxsdk.offline.OfflineRegion;
-import com.mapbox.mapboxsdk.offline.OfflineRegionDefinition;
 import com.mapbox.mapboxsdk.plugins.offline.offline.OfflineDownloadService;
 import com.mapbox.mapboxsdk.plugins.offline.offline.OfflinePlugin;
 
@@ -12,6 +10,8 @@ import java.util.UUID;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+
+import org.maplibre.android.offline.OfflineRegionDefinition;
 
 /**
  * This model class wraps the offline region definition with notifications options and the offline

--- a/plugin-offline/src/main/java/com/mapbox/mapboxsdk/plugins/offline/model/RegionSelectionOptions.java
+++ b/plugin-offline/src/main/java/com/mapbox/mapboxsdk/plugins/offline/model/RegionSelectionOptions.java
@@ -3,12 +3,13 @@ package com.mapbox.mapboxsdk.plugins.offline.model;
 import android.os.Parcelable;
 
 import com.google.auto.value.AutoValue;
-import com.mapbox.mapboxsdk.camera.CameraPosition;
-import com.mapbox.mapboxsdk.geometry.LatLngBounds;
 import com.mapbox.mapboxsdk.plugins.offline.ui.OfflineActivity;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+
+import org.maplibre.android.camera.CameraPosition;
+import org.maplibre.android.geometry.LatLngBounds;
 
 /**
  * Options specific to the Region Selection UI component.

--- a/plugin-offline/src/main/java/com/mapbox/mapboxsdk/plugins/offline/offline/OfflineDownloadService.java
+++ b/plugin-offline/src/main/java/com/mapbox/mapboxsdk/plugins/offline/offline/OfflineDownloadService.java
@@ -12,20 +12,21 @@ import androidx.collection.LongSparseArray;
 import androidx.core.app.NotificationCompat;
 import androidx.core.app.NotificationManagerCompat;
 
-import com.mapbox.mapboxsdk.offline.OfflineManager;
-import com.mapbox.mapboxsdk.offline.OfflineRegion;
-import com.mapbox.mapboxsdk.offline.OfflineRegionDefinition;
-import com.mapbox.mapboxsdk.offline.OfflineRegionError;
-import com.mapbox.mapboxsdk.offline.OfflineRegionStatus;
 import com.mapbox.mapboxsdk.plugins.offline.model.OfflineDownloadOptions;
 import com.mapbox.mapboxsdk.plugins.offline.utils.NotificationUtils;
-import com.mapbox.mapboxsdk.snapshotter.MapSnapshot;
-import com.mapbox.mapboxsdk.snapshotter.MapSnapshotter;
 
 import timber.log.Timber;
 
 import static com.mapbox.mapboxsdk.plugins.offline.offline.OfflineConstants.KEY_BUNDLE;
 import static com.mapbox.mapboxsdk.plugins.offline.utils.NotificationUtils.setupNotificationChannel;
+
+import org.maplibre.android.offline.OfflineManager;
+import org.maplibre.android.offline.OfflineRegion;
+import org.maplibre.android.offline.OfflineRegionDefinition;
+import org.maplibre.android.offline.OfflineRegionError;
+import org.maplibre.android.offline.OfflineRegionStatus;
+import org.maplibre.android.snapshotter.MapSnapshot;
+import org.maplibre.android.snapshotter.MapSnapshotter;
 
 /**
  * Internal usage only, use this service indirectly by using methods found in

--- a/plugin-offline/src/main/java/com/mapbox/mapboxsdk/plugins/offline/offline/OfflinePlugin.java
+++ b/plugin-offline/src/main/java/com/mapbox/mapboxsdk/plugins/offline/offline/OfflinePlugin.java
@@ -5,7 +5,6 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 
-import com.mapbox.mapboxsdk.offline.OfflineRegion;
 import com.mapbox.mapboxsdk.plugins.offline.model.OfflineDownloadOptions;
 
 import java.util.ArrayList;
@@ -15,6 +14,8 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import static com.mapbox.mapboxsdk.plugins.offline.offline.OfflineConstants.KEY_BUNDLE;
+
+import org.maplibre.android.offline.OfflineRegion;
 
 /**
  * OfflinePlugin is the main entry point for integrating the offline plugin into your app.

--- a/plugin-offline/src/main/java/com/mapbox/mapboxsdk/plugins/offline/ui/OfflineActivity.java
+++ b/plugin-offline/src/main/java/com/mapbox/mapboxsdk/plugins/offline/ui/OfflineActivity.java
@@ -4,7 +4,6 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.view.Window;
 
-import com.mapbox.mapboxsdk.offline.OfflineRegionDefinition;
 import com.mapbox.mapboxsdk.plugins.offline.OfflinePluginConstants;
 import com.mapbox.mapboxsdk.plugins.offline.R;
 import com.mapbox.mapboxsdk.plugins.offline.model.RegionSelectionOptions;
@@ -16,6 +15,8 @@ import androidx.constraintlayout.widget.ConstraintLayout;
 
 import static com.mapbox.mapboxsdk.plugins.offline.offline.OfflineConstants.RETURNING_DEFINITION;
 import static com.mapbox.mapboxsdk.plugins.offline.offline.OfflineConstants.RETURNING_REGION_NAME;
+
+import org.maplibre.android.offline.OfflineRegionDefinition;
 
 public class OfflineActivity extends AppCompatActivity implements RegionSelectedCallback {
 

--- a/plugin-offline/src/main/java/com/mapbox/mapboxsdk/plugins/offline/ui/RegionSelectedCallback.java
+++ b/plugin-offline/src/main/java/com/mapbox/mapboxsdk/plugins/offline/ui/RegionSelectedCallback.java
@@ -1,6 +1,6 @@
 package com.mapbox.mapboxsdk.plugins.offline.ui;
 
-import com.mapbox.mapboxsdk.offline.OfflineRegionDefinition;
+import org.maplibre.android.offline.OfflineRegionDefinition;
 
 public interface RegionSelectedCallback {
 

--- a/plugin-offline/src/main/java/com/mapbox/mapboxsdk/plugins/offline/ui/RegionSelectionFragment.java
+++ b/plugin-offline/src/main/java/com/mapbox/mapboxsdk/plugins/offline/ui/RegionSelectionFragment.java
@@ -98,18 +98,18 @@ public class RegionSelectionFragment extends Fragment implements OnMapReadyCallb
     }
 
     @Override
-    public void onMapReady(final MapLibreMap mapboxMap) {
-        this.mapLibreMap = mapboxMap;
-        mapboxMap.setStyle(Style.getPredefinedStyle("Streets"), new Style.OnStyleLoaded() {
+    public void onMapReady(final MapLibreMap maplibreMap) {
+        this.mapLibreMap = maplibreMap;
+        maplibreMap.setStyle(Style.getPredefinedStyle("Streets"), new Style.OnStyleLoaded() {
             @Override
             public void onStyleLoaded(@NonNull Style style) {
                 RegionSelectionFragment.this.style = style;
-                mapboxMap.addOnCameraIdleListener(RegionSelectionFragment.this);
+                maplibreMap.addOnCameraIdleListener(RegionSelectionFragment.this);
                 if (options != null) {
                     if (options.startingBounds() != null) {
-                        mapboxMap.moveCamera(CameraUpdateFactory.newLatLngBounds(options.startingBounds(), 0));
+                        maplibreMap.moveCamera(CameraUpdateFactory.newLatLngBounds(options.startingBounds(), 0));
                     } else if (options.statingCameraPosition() != null) {
-                        mapboxMap.moveCamera(CameraUpdateFactory.newCameraPosition(options.statingCameraPosition()));
+                        maplibreMap.moveCamera(CameraUpdateFactory.newCameraPosition(options.statingCameraPosition()));
                     }
                 }
             }

--- a/plugin-offline/src/main/java/com/mapbox/mapboxsdk/plugins/offline/utils/NotificationUtils.java
+++ b/plugin-offline/src/main/java/com/mapbox/mapboxsdk/plugins/offline/utils/NotificationUtils.java
@@ -1,5 +1,7 @@
 package com.mapbox.mapboxsdk.plugins.offline.utils;
 
+import static org.maplibre.android.MapLibre.getApplicationContext;
+
 import android.app.Notification;
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
@@ -16,8 +18,6 @@ import com.mapbox.mapboxsdk.plugins.offline.R;
 import com.mapbox.mapboxsdk.plugins.offline.model.NotificationOptions;
 import com.mapbox.mapboxsdk.plugins.offline.model.OfflineDownloadOptions;
 import com.mapbox.mapboxsdk.plugins.offline.offline.OfflineConstants;
-
-import static com.mapbox.mapboxsdk.Mapbox.getApplicationContext;
 
 public class NotificationUtils {
 

--- a/plugin-offline/src/main/java/com/mapbox/mapboxsdk/plugins/offline/utils/OfflineUtils.java
+++ b/plugin-offline/src/main/java/com/mapbox/mapboxsdk/plugins/offline/utils/OfflineUtils.java
@@ -2,10 +2,9 @@ package com.mapbox.mapboxsdk.plugins.offline.utils;
 
 import android.util.Log;
 
-import com.mapbox.mapboxsdk.camera.CameraPosition;
-import com.mapbox.mapboxsdk.offline.OfflineRegionDefinition;
-
 import org.json.JSONObject;
+import org.maplibre.android.camera.CameraPosition;
+import org.maplibre.android.offline.OfflineRegionDefinition;
 
 import androidx.annotation.NonNull;
 

--- a/plugin-offline/src/main/res/layout/mapbox_offline_region_selection_fragment.xml
+++ b/plugin-offline/src/main/res/layout/mapbox_offline_region_selection_fragment.xml
@@ -5,7 +5,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <com.mapbox.mapboxsdk.maps.MapView
+    <org.maplibre.android.maps.MapView
         android:id="@+id/mapbox_offline_region_selection_map_view"
         android:layout_width="0dp"
         android:layout_height="0dp"

--- a/plugin-scalebar/src/main/java/com/mapbox/pluginscalebar/ScaleBarPlugin.java
+++ b/plugin-scalebar/src/main/java/com/mapbox/pluginscalebar/ScaleBarPlugin.java
@@ -2,15 +2,15 @@ package com.mapbox.pluginscalebar;
 
 import android.view.View;
 
-import com.mapbox.mapboxsdk.camera.CameraPosition;
-import com.mapbox.mapboxsdk.log.Logger;
-import com.mapbox.mapboxsdk.maps.MapView;
-import com.mapbox.mapboxsdk.maps.MapboxMap;
-import com.mapbox.mapboxsdk.maps.Projection;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.UiThread;
 import androidx.annotation.VisibleForTesting;
+
+import org.maplibre.android.camera.CameraPosition;
+import org.maplibre.android.log.Logger;
+import org.maplibre.android.maps.MapLibreMap;
+import org.maplibre.android.maps.MapView;
+import org.maplibre.android.maps.Projection;
 
 /**
  * Plugin class that shows a scale bar on MapView and changes the scale corresponding to the MapView's scale.
@@ -19,13 +19,13 @@ public class ScaleBarPlugin {
     private static final String TAG = "Mbgl-ScaleBarPlugin";
 
     private final MapView mapView;
-    private final MapboxMap mapboxMap;
+    private final MapLibreMap mapLibreMap;
     private final Projection projection;
     private boolean enabled = true;
     private ScaleBarWidget scaleBarWidget;
 
     @VisibleForTesting
-    final MapboxMap.OnCameraMoveListener cameraMoveListener = new MapboxMap.OnCameraMoveListener() {
+    final MapLibreMap.OnCameraMoveListener cameraMoveListener = new MapLibreMap.OnCameraMoveListener() {
         @Override
         public void onCameraMove() {
             invalidateScaleBar();
@@ -33,16 +33,16 @@ public class ScaleBarPlugin {
     };
 
     @VisibleForTesting
-    final MapboxMap.OnCameraIdleListener cameraIdleListener = new MapboxMap.OnCameraIdleListener() {
+    final MapLibreMap.OnCameraIdleListener cameraIdleListener = new MapLibreMap.OnCameraIdleListener() {
         @Override
         public void onCameraIdle() {
             invalidateScaleBar();
         }
     };
 
-    public ScaleBarPlugin(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap) {
+    public ScaleBarPlugin(@NonNull MapView mapView, @NonNull MapLibreMap mapboxMap) {
         this.mapView = mapView;
-        this.mapboxMap = mapboxMap;
+        this.mapLibreMap = mapboxMap;
         this.projection = mapboxMap.getProjection();
     }
 
@@ -80,9 +80,9 @@ public class ScaleBarPlugin {
     /**
      * Toggles the scale plugin state.
      * <p>
-     * If the scale plugin wasn enabled, a {@link com.mapbox.mapboxsdk.maps.MapboxMap.OnCameraMoveListener}
+     * If the scale plugin wasn enabled, a {@link org.maplibre.android.maps.MapLibreMap.OnCameraMoveListener}
      * will be added to the {@link MapView} to listen to scale change events to update the state of this plugin. If the
-     * plugin was disabled the {@link com.mapbox.mapboxsdk.maps.MapboxMap.OnCameraMoveListener}
+     * plugin was disabled the {@link org.maplibre.android.maps.MapLibreMap.OnCameraMoveListener}
      * will be removed from the map.
      * </p>
      */
@@ -107,18 +107,18 @@ public class ScaleBarPlugin {
     }
 
     private void invalidateScaleBar() {
-        CameraPosition cameraPosition = mapboxMap.getCameraPosition();
+        CameraPosition cameraPosition = mapLibreMap.getCameraPosition();
         scaleBarWidget.setDistancePerPixel((projection.getMetersPerPixelAtLatitude(cameraPosition.target.getLatitude()))
             / mapView.getPixelRatio());
     }
 
     private void addCameraListeners() {
-        mapboxMap.addOnCameraMoveListener(cameraMoveListener);
-        mapboxMap.addOnCameraIdleListener(cameraIdleListener);
+        mapLibreMap.addOnCameraMoveListener(cameraMoveListener);
+        mapLibreMap.addOnCameraIdleListener(cameraIdleListener);
     }
 
     private void removeCameraListeners() {
-        mapboxMap.removeOnCameraMoveListener(cameraMoveListener);
-        mapboxMap.removeOnCameraIdleListener(cameraIdleListener);
+        mapLibreMap.removeOnCameraMoveListener(cameraMoveListener);
+        mapLibreMap.removeOnCameraIdleListener(cameraIdleListener);
     }
 }

--- a/plugin-scalebar/src/main/java/com/mapbox/pluginscalebar/ScaleBarPlugin.java
+++ b/plugin-scalebar/src/main/java/com/mapbox/pluginscalebar/ScaleBarPlugin.java
@@ -40,10 +40,10 @@ public class ScaleBarPlugin {
         }
     };
 
-    public ScaleBarPlugin(@NonNull MapView mapView, @NonNull MapLibreMap mapboxMap) {
+    public ScaleBarPlugin(@NonNull MapView mapView, @NonNull MapLibreMap maplibreMap) {
         this.mapView = mapView;
-        this.mapLibreMap = mapboxMap;
-        this.projection = mapboxMap.getProjection();
+        this.mapLibreMap = maplibreMap;
+        this.projection = maplibreMap.getProjection();
     }
 
     /**

--- a/plugin-scalebar/src/test/java/com/mapbox/pluginscalebar/ScaleBarPluginTest.kt
+++ b/plugin-scalebar/src/test/java/com/mapbox/pluginscalebar/ScaleBarPluginTest.kt
@@ -24,7 +24,7 @@ class ScaleBarPluginTest {
     lateinit var projection: Projection
 
     @MockK
-    lateinit var mapboxMap: MapLibreMap
+    lateinit var maplibreMap: MapLibreMap
 
     @MockK
     lateinit var scaleBarOptions: ScaleBarOptions
@@ -47,8 +47,8 @@ class ScaleBarPluginTest {
         displayMetrics.density = 2f
         every { mapView.width } returns 1000
         every { CameraPosition.DEFAULT.target?.let { projection.getMetersPerPixelAtLatitude(it.latitude) } } returns 100_000.0
-        every { mapboxMap.projection } returns projection
-        every { mapboxMap.cameraPosition } returns CameraPosition.DEFAULT
+        every { maplibreMap.projection } returns projection
+        every { maplibreMap.cameraPosition } returns CameraPosition.DEFAULT
         every { scaleBarOptions.build() } returns scaleBarWidget
         every { mapView.context } returns context
         every { mapView.pixelRatio } returns 2f
@@ -59,82 +59,82 @@ class ScaleBarPluginTest {
     @Test
     fun sanity() {
         assertNotNull(mapView)
-        assertNotNull(mapboxMap)
+        assertNotNull(maplibreMap)
         assertNotNull(scaleBarOptions)
         assertNotNull(scaleBarWidget)
     }
 
     @Test
     fun create_isEnabled() {
-        val scaleBarPlugin = ScaleBarPlugin(mapView, mapboxMap)
+        val scaleBarPlugin = ScaleBarPlugin(mapView, maplibreMap)
         scaleBarPlugin.create(scaleBarOptions)
 
         assertTrue(scaleBarPlugin.isEnabled)
         verify { scaleBarWidget.visibility = View.VISIBLE }
-        verify(exactly = 1) { mapboxMap.addOnCameraMoveListener(scaleBarPlugin.cameraMoveListener) }
-        verify(exactly = 1) { mapboxMap.addOnCameraIdleListener(scaleBarPlugin.cameraIdleListener) }
+        verify(exactly = 1) { maplibreMap.addOnCameraMoveListener(scaleBarPlugin.cameraMoveListener) }
+        verify(exactly = 1) { maplibreMap.addOnCameraIdleListener(scaleBarPlugin.cameraIdleListener) }
     }
 
     @Test
     fun disable() {
-        val scaleBarPlugin = ScaleBarPlugin(mapView, mapboxMap)
+        val scaleBarPlugin = ScaleBarPlugin(mapView, maplibreMap)
         scaleBarPlugin.create(scaleBarOptions)
         scaleBarPlugin.isEnabled = false
 
         assertFalse(scaleBarPlugin.isEnabled)
         verify { scaleBarWidget.visibility = View.GONE }
-        verify { mapboxMap.removeOnCameraMoveListener(scaleBarPlugin.cameraMoveListener) }
-        verify { mapboxMap.removeOnCameraIdleListener(scaleBarPlugin.cameraIdleListener) }
+        verify { maplibreMap.removeOnCameraMoveListener(scaleBarPlugin.cameraMoveListener) }
+        verify { maplibreMap.removeOnCameraIdleListener(scaleBarPlugin.cameraIdleListener) }
     }
 
     @Test
     fun enable() {
-        val scaleBarPlugin = ScaleBarPlugin(mapView, mapboxMap)
+        val scaleBarPlugin = ScaleBarPlugin(mapView, maplibreMap)
         scaleBarPlugin.create(scaleBarOptions)
-        verify(exactly = 1) { mapboxMap.addOnCameraMoveListener(scaleBarPlugin.cameraMoveListener) }
-        verify(exactly = 1) { mapboxMap.addOnCameraIdleListener(scaleBarPlugin.cameraIdleListener) }
+        verify(exactly = 1) { maplibreMap.addOnCameraMoveListener(scaleBarPlugin.cameraMoveListener) }
+        verify(exactly = 1) { maplibreMap.addOnCameraIdleListener(scaleBarPlugin.cameraIdleListener) }
         verify(exactly = 1) { scaleBarWidget.visibility = View.VISIBLE }
         scaleBarPlugin.isEnabled = false
         scaleBarPlugin.isEnabled = true
 
         assertTrue(scaleBarPlugin.isEnabled)
         verify(exactly = 2) { scaleBarWidget.visibility = View.VISIBLE }
-        verify(exactly = 2) { mapboxMap.addOnCameraMoveListener(scaleBarPlugin.cameraMoveListener) }
-        verify(exactly = 2) { mapboxMap.addOnCameraIdleListener(scaleBarPlugin.cameraIdleListener) }
+        verify(exactly = 2) { maplibreMap.addOnCameraMoveListener(scaleBarPlugin.cameraMoveListener) }
+        verify(exactly = 2) { maplibreMap.addOnCameraIdleListener(scaleBarPlugin.cameraIdleListener) }
     }
 
     @Test
     fun disable_enable_widgetIsNull() {
-        val scaleBarPlugin = ScaleBarPlugin(mapView, mapboxMap)
+        val scaleBarPlugin = ScaleBarPlugin(mapView, maplibreMap)
         scaleBarPlugin.isEnabled = false
         scaleBarPlugin.isEnabled = true
 
-        verify(exactly = 0) { mapboxMap.addOnCameraMoveListener(scaleBarPlugin.cameraMoveListener) }
-        verify(exactly = 0) { mapboxMap.addOnCameraIdleListener(scaleBarPlugin.cameraIdleListener) }
+        verify(exactly = 0) { maplibreMap.addOnCameraMoveListener(scaleBarPlugin.cameraMoveListener) }
+        verify(exactly = 0) { maplibreMap.addOnCameraIdleListener(scaleBarPlugin.cameraIdleListener) }
     }
 
     @Test
     fun disableBeforeCreate_ignoreResults() {
-        val scaleBarPlugin = ScaleBarPlugin(mapView, mapboxMap)
+        val scaleBarPlugin = ScaleBarPlugin(mapView, maplibreMap)
         scaleBarPlugin.isEnabled = false
         scaleBarPlugin.create(scaleBarOptions)
 
         assertTrue(scaleBarPlugin.isEnabled)
         verify { scaleBarWidget.visibility = View.VISIBLE }
-        verify(exactly = 1) { mapboxMap.addOnCameraMoveListener(scaleBarPlugin.cameraMoveListener) }
-        verify(exactly = 1) { mapboxMap.addOnCameraIdleListener(scaleBarPlugin.cameraIdleListener) }
+        verify(exactly = 1) { maplibreMap.addOnCameraMoveListener(scaleBarPlugin.cameraMoveListener) }
+        verify(exactly = 1) { maplibreMap.addOnCameraIdleListener(scaleBarPlugin.cameraIdleListener) }
     }
 
     @Test
     fun toggled_invalidateWidget() {
-        val scaleBarPlugin = ScaleBarPlugin(mapView, mapboxMap)
+        val scaleBarPlugin = ScaleBarPlugin(mapView, maplibreMap)
         scaleBarPlugin.create(scaleBarOptions)
-        verify(exactly = 1) { mapboxMap.cameraPosition }
+        verify(exactly = 1) { maplibreMap.cameraPosition }
         verify(exactly = 1) { scaleBarWidget.setDistancePerPixel(50_000.0) }
         scaleBarPlugin.isEnabled = false
         scaleBarPlugin.isEnabled = true
 
-        verify(exactly = 2) { mapboxMap.cameraPosition }
+        verify(exactly = 2) { maplibreMap.cameraPosition }
         verify(exactly = 2) { scaleBarWidget.setDistancePerPixel(50_000.0) }
     }
 }

--- a/plugin-scalebar/src/test/java/com/mapbox/pluginscalebar/ScaleBarPluginTest.kt
+++ b/plugin-scalebar/src/test/java/com/mapbox/pluginscalebar/ScaleBarPluginTest.kt
@@ -4,10 +4,6 @@ import android.content.Context
 import android.content.res.Resources
 import android.util.DisplayMetrics
 import android.view.View
-import com.mapbox.mapboxsdk.camera.CameraPosition
-import com.mapbox.mapboxsdk.maps.MapView
-import com.mapbox.mapboxsdk.maps.MapboxMap
-import com.mapbox.mapboxsdk.maps.Projection
 import io.mockk.MockKAnnotations
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
@@ -15,6 +11,10 @@ import io.mockk.verify
 import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Test
+import org.maplibre.android.camera.CameraPosition
+import org.maplibre.android.maps.MapLibreMap
+import org.maplibre.android.maps.MapView
+import org.maplibre.android.maps.Projection
 
 class ScaleBarPluginTest {
     @MockK
@@ -24,7 +24,7 @@ class ScaleBarPluginTest {
     lateinit var projection: Projection
 
     @MockK
-    lateinit var mapboxMap: MapboxMap
+    lateinit var mapboxMap: MapLibreMap
 
     @MockK
     lateinit var scaleBarOptions: ScaleBarOptions


### PR DESCRIPTION
I updated the package names imports for `plugin-annotation` to use the new ones, as it was changed in MapLibre Native for version 11.
From now, dependency is set on the 11.0.0-pre3 release.

**Warning :** This PR doesn't modify others plugins to use the new package names.

### Side note
Additionally, to align with the changes in MapLibre Native, should we also update the package names in plugins? Currently, plugin package names follow the format `com.mapbox.mapboxsdk.plugins.annotation`. Why not adopt a naming convention like `org.maplibre.android.plugins.annotation`?
I'm aware this will trigger a breaking change in the plugins, but wouldn't it be better to consolidate all the breaking changes at once?



