### PR TITLE
docs: fix links in documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@ build/
 
 ### Code gen activity sanity tests ###
 /node_modules
-app/src/androidTest/java/com/mapbox/mapboxsdk/plugins/gen
+app/src/androidTest/java/org/maplibre/android/plugins/gen
 
 ### Code gen annotation plugin ###
 plugin-annotation/scripts/code-gen.list

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,12 @@
 
 Each maplibre plugin for Android has a separate changelog that highlights changes relevant to the plugin:
 
-* [Location layer plugin](https://github.com/maplibre/maplibre-plugins-android/tree/master/plugin-locationlayer/CHANGELOG.md)
-* [Building plugin](https://github.com/maplibre/maplibre-plugins-android/tree/master/plugin-building/CHANGELOG.md)
-* [Traffic plugin](https://github.com/maplibre/maplibre-plugins-android/tree/master/plugin-traffic/CHANGELOG.md)
-* [Places plugin](https://github.com/maplibre/maplibre-plugins-android/tree/master/plugin-places/CHANGELOG.md)
-* [Offline plugin](https://github.com/maplibre/maplibre-plugins-android/tree/master/plugin-offline/CHANGELOG.md)
-* [Localization plugin](https://github.com/maplibre/maplibre-plugins-android/tree/master/plugin-localization/CHANGELOG.md)
-* [Annotation plugin](https://github.com/maplibre/maplibre-plugins-android/tree/master/plugin-annotation/CHANGELOG.md)
-* [MarkerView plugin](https://github.com/maplibre/maplibre-plugins-android/blob/master/plugin-markerview/CHANGELOG.md)
-* [Scalebar plugin](https://github.com/maplibre/maplibre-plugins-android/blob/master/plugin-scalebar/CHANGELOG.md)
+* [Location layer plugin](https://github.com/maplibre/maplibre-plugins-android/tree/main/plugin-locationlayer/CHANGELOG.md)
+* [Building plugin](https://github.com/maplibre/maplibre-plugins-android/tree/main/plugin-building/CHANGELOG.md)
+* [Traffic plugin](https://github.com/maplibre/maplibre-plugins-android/tree/main/plugin-traffic/CHANGELOG.md)
+* [Places plugin](https://github.com/maplibre/maplibre-plugins-android/tree/main/plugin-places/CHANGELOG.md)
+* [Offline plugin](https://github.com/maplibre/maplibre-plugins-android/tree/main/plugin-offline/CHANGELOG.md)
+* [Localization plugin](https://github.com/maplibre/maplibre-plugins-android/tree/main/plugin-localization/CHANGELOG.md)
+* [Annotation plugin](https://github.com/maplibre/maplibre-plugins-android/tree/main/plugin-annotation/CHANGELOG.md)
+* [MarkerView plugin](https://github.com/maplibre/maplibre-plugins-android/blob/main/plugin-markerview/CHANGELOG.md)
+* [Scalebar plugin](https://github.com/maplibre/maplibre-plugins-android/blob/main/plugin-scalebar/CHANGELOG.md)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <h1 align="center">
   <br>
-  <img src="https://github.com/maplibre/maplibre-plugins-android/blob/master/.github/mlb-plugins-logo.png" alt="MapLibre Plugins" width="500">
+  <img src="https://github.com/maplibre/maplibre-plugins-android/blob/main/.github/mlb-plugins-logo.png" alt="MapLibre Plugins" width="500">
 </h1>
 
 <h4 align="center">Plugins are single-purpose libraries built on top of the <a href="https://maplibre.org/maplibre-gl-native/android/api/">MapLibre Maps SDK for Android</a> that you can include in your apps like any other Android dependency</h4>
@@ -14,27 +14,27 @@
 
 Plugins are single-purpose libraries built on top of the [MapLibre GL Native for Android](https://maplibre.org/maplibre-gl-native/android/api/) that you can include in your apps like any other Android dependency. A full list of the current plugins is available below.
 
-We are looking for maintainers for these plugins! Please reach out to the Maplibre team and take a look at [the contribution guide](https://github.com/maplibre/maplibre-plugins-android/blob/master/CONTRIBUTING.md).
+We are looking for maintainers for these plugins! Please reach out to the Maplibre team and take a look at [the contribution guide](https://github.com/maplibre/maplibre-plugins-android/blob/main/CONTRIBUTING.md).
 
 ## Available Plugins
 
-* [**Annotation:** Simplify the way to set and adjust the visual properties of annotations on a map.](https://github.com/maplibre/maplibre-plugins-android/tree/master/plugin-annotation)
+* [**Annotation:** Simplify the way to set and adjust the visual properties of annotations on a map.](https://github.com/maplibre/maplibre-plugins-android/tree/main/plugin-annotation)
 
-* [**MarkerView:** Add map markers that are Android views.](https://github.com/maplibre/maplibre-plugins-android/tree/master/plugin-markerview)
+* [**MarkerView:** Add map markers that are Android views.](https://github.com/maplibre/maplibre-plugins-android/tree/main/plugin-markerview)
 
-* [**Traffic:** Adds a real-time traffic layer to any MapLibre base map.](https://github.com/maplibre/maplibre-plugins-android/tree/master/plugin-traffic)
+* [**Traffic:** Adds a real-time traffic layer to any MapLibre base map.](https://github.com/maplibre/maplibre-plugins-android/tree/main/plugin-traffic)
 
-* [**Location layer:** [Deprecated] Add a location marker on your map indicating the user's location.](https://github.com/maplibre/maplibre-plugins-android/tree/master/plugin-locationlayer)
+* [**Location layer:** [Deprecated] Add a location marker on your map indicating the user's location.](https://github.com/maplibre/maplibre-plugins-android/tree/main/plugin-locationlayer)
 
-* [**Building:** Add extruded "3D" buildings in your map style.](https://github.com/maplibre/maplibre-plugins-android/tree/master/plugin-building)
+* [**Building:** Add extruded "3D" buildings in your map style.](https://github.com/maplibre/maplibre-plugins-android/tree/main/plugin-building)
 
-* [**Offline:** Download maps tiles and manage downloaded regions for situations when a user's device doesn't have an internet connection.](https://github.com/maplibre/maplibre-plugins-android/tree/master/plugin-offline)
+* [**Offline:** Download maps tiles and manage downloaded regions for situations when a user's device doesn't have an internet connection.](https://github.com/maplibre/maplibre-plugins-android/tree/main/plugin-offline)
 
-* [**Places:** Add location search to your app with beautiful UI.](https://github.com/maplibre/maplibre-plugins-android/tree/master/plugin-places)
+* [**Places:** Add location search to your app with beautiful UI.](https://github.com/maplibre/maplibre-plugins-android/tree/main/plugin-places)
 
-* [**Localization:** Have your map's text automatically match the device's default language setting.](https://github.com/maplibre/maplibre-plugins-android/tree/master/plugin-localization)
+* [**Localization:** Have your map's text automatically match the device's default language setting.](https://github.com/maplibre/maplibre-plugins-android/tree/main/plugin-localization)
 
-* [**Scale bar:** Provide a visual map scale bar for your users to determine distance.](https://github.com/maplibre/maplibre-plugins-android/tree/master/plugin-scalebar)
+* [**Scale bar:** Provide a visual map scale bar for your users to determine distance.](https://github.com/maplibre/maplibre-plugins-android/tree/main/plugin-scalebar)
 
 ## Installing a plugin
 
@@ -72,7 +72,7 @@ A plugin is simply a library module built on top of the MapLibre Maps SDK for An
 
 This repository includes an app with examples showing how you can use each plugin.
 
-- To access ready-to-use snippets, [see its code here](https://github.com/mapbox/mapbox-plugins-android/tree/master/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp).
+- To access ready-to-use snippets, [see its code here](https://github.com/mapbox/mapbox-plugins-android/tree/main/app/src/main/java/org/maplibre/android/plugins/testapp).
 - To run the application locally, you need to provide your own [maptiler API key](https://cloud.maptiler.com/account/keys/) at compile time. Therefore, add the property `maptilerApiKey="…"` to your `local.properties` file in the repository's root.
 
 This might change in the future as we build more plugins and learn how you use them. We'd love to [hear your feedback](https://github.com/maplibre/maplibre-plugins-android/issues).
@@ -88,4 +88,4 @@ Plugins' lightweight nature makes them much easier for you and anyone else to co
 
 We welcome contributions to this plugin repository!
 
-If you're interested in building and sharing your own plugin, please read [the contribution guide](https://github.com/maplibre/maplibre-plugins-android/blob/master/CONTRIBUTING.md) to learn how to get started.
+If you're interested in building and sharing your own plugin, please read [the contribution guide](https://github.com/maplibre/maplibre-plugins-android/blob/main/CONTRIBUTING.md) to learn how to get started.

--- a/plugin-annotation/README.md
+++ b/plugin-annotation/README.md
@@ -54,11 +54,11 @@ dependencies {
 
 ## Annotation plugin examples
 
-- [In this repo's test app](https://github.com/maplibre/maplibre-plugins-android/tree/master/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation)
+- [In this repo's test app](https://github.com/maplibre/maplibre-plugins-android/tree/main/app/src/main/java/org/maplibre/android/plugins/testapp/activity/annotation)
 
 ## Help and Usage
 
-This repository includes an app that shows how to use each plugin in this repository. [Check out its code](https://github.com/maplibre/maplibre-plugins-android/tree/master/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity) for ready-to-use snippets.
+This repository includes an app that shows how to use each plugin in this repository. [Check out its code](https://github.com/maplibre/maplibre-plugins-android/tree/main/app/src/main/java/org/maplibre/android/plugins/testapp/activity) for ready-to-use snippets.
 
 We'd love to [hear your feedback](https://github.com/maplibre/maplibre-plugins-android/issues) as we build more plugins and learn how you use them.
 
@@ -73,4 +73,4 @@ Plugins' lightweight nature makes them much easier for you and anyone else to co
 
 We welcome contributions to this plugin repository!
 
-If you're interested in building and sharing your own plugin, please read [the contribution guide](https://github.com/maplibre/maplibre-plugins-android/blob/master/CONTRIBUTING.md) to learn how to get started.
+If you're interested in building and sharing your own plugin, please read [the contribution guide](https://github.com/maplibre/maplibre-plugins-android/blob/main/CONTRIBUTING.md) to learn how to get started.

--- a/plugin-building/README.md
+++ b/plugin-building/README.md
@@ -47,7 +47,7 @@ dependencies {
 
 ## Help and Usage
 
-This repository includes an app that shows how to use each plugins in this repository. [Check out its code](https://github.com/maplibre/maplibre-plugins-android/tree/master/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity) for ready-to-use snippets.
+This repository includes an app that shows how to use each plugins in this repository. [Check out its code](https://github.com/maplibre/maplibre-plugins-android/tree/main/app/src/main/java/org/maplibre/android/plugins/testapp/activity) for ready-to-use snippets.
 
 We'd love to [hear your feedback](https://github.com/maplibre/maplibre-plugins-android/issues) as we build more plugins and learn how you use them.
 
@@ -62,4 +62,4 @@ Plugins' lightweight nature makes them much easier for you and anyone else to co
 
 We welcome contributions to this plugin repository!
 
-If you're interested in building and sharing your own plugin, please read [the contribution guide](https://github.com/maplibre/maplibre-plugins-android/blob/master/CONTRIBUTING.md) to learn how to get started.
+If you're interested in building and sharing your own plugin, please read [the contribution guide](https://github.com/maplibre/maplibre-plugins-android/blob/main/CONTRIBUTING.md) to learn how to get started.

--- a/plugin-localization/README.md
+++ b/plugin-localization/README.md
@@ -45,11 +45,11 @@ dependencies {
 
 ## Localization examples
 
-- [In this repo's test app](https://github.com/maplibre/maplibre-plugins-android/blob/master/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/localization/LocalizationActivity.kt)
+- [In this repo's test app](https://github.com/maplibre/maplibre-plugins-android/blob/main/app/src/main/java/org/maplibre/android/plugins/testapp/activity/localization/LocalizationActivity.kt)
 
 ## Help and Usage
 
-This repository includes an app that shows how to use each plugins in this repository. [Check out its code](https://github.com/maplibre/maplibre-plugins-android/tree/master/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity) for ready-to-use snippets.
+This repository includes an app that shows how to use each plugins in this repository. [Check out its code](https://github.com/maplibre/maplibre-plugins-android/tree/main/app/src/main/java/org/maplibre/android/plugins/testapp/activity) for ready-to-use snippets.
 
 We'd love to [hear your feedback](https://github.com/maplibre/maplibre-plugins-android/issues) as we build more plugins and learn how you use them.
 
@@ -64,4 +64,4 @@ Plugins' lightweight nature makes them much easier for you and anyone else to co
 
 We welcome contributions to this plugin repository!
 
-If you're interested in building and sharing your own plugin, please read [the contribution guide](https://github.com/maplibre/maplibre-plugins-android/blob/master/CONTRIBUTING.md) to learn how to get started.
+If you're interested in building and sharing your own plugin, please read [the contribution guide](https://github.com/maplibre/maplibre-plugins-android/blob/main/CONTRIBUTING.md) to learn how to get started.

--- a/plugin-markerview/README.md
+++ b/plugin-markerview/README.md
@@ -45,11 +45,11 @@ dependencies {
 
 ## MarkerView plugin examples
 
-- [In this repo's test app](https://github.com/maplibre/maplibre-plugins-android/blob/master/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/markerview/MarkerViewActivity.kt)
+- [In this repo's test app](https://github.com/maplibre/maplibre-plugins-android/blob/main/app/src/main/java/org/maplibre/android/plugins/testapp/activity/markerview/MarkerViewActivity.kt)
 
 ## Help and Usage
 
-This repository includes an app that shows how to use each plugin in this repository. [Check out its code](https://github.com/maplibre/maplibre-plugins-android/tree/master/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity) for ready-to-use snippets.
+This repository includes an app that shows how to use each plugin in this repository. [Check out its code](https://github.com/maplibre/maplibre-plugins-android/tree/main/app/src/main/java/org/maplibre/android/plugins/testapp/activity) for ready-to-use snippets.
 
 We'd love to [hear your feedback](https://github.com/maplibre/maplibre-plugins-android/issues) as we build more plugins and learn how you use them.
 
@@ -64,4 +64,4 @@ Plugins' lightweight nature makes them much easier for you and anyone else to co
 
 We welcome contributions to this plugin repository!
 
-If you're interested in building and sharing your own plugin, please read [the contribution guide](https://github.com/maplibre/maplibre-plugins-android/blob/master/CONTRIBUTING.md) to learn how to get started.
+If you're interested in building and sharing your own plugin, please read [the contribution guide](https://github.com/maplibre/maplibre-plugins-android/blob/main/CONTRIBUTING.md) to learn how to get started.

--- a/plugin-offline/README.md
+++ b/plugin-offline/README.md
@@ -43,11 +43,11 @@ dependencies {
 
 ## Offline plugin examples
 
-- [In this repo's test app](https://github.com/maplibre/maplibre-plugins-android/tree/master/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/offline)
+- [In this repo's test app](https://github.com/maplibre/maplibre-plugins-android/tree/main/app/src/main/java/org/maplibre/android/plugins/testapp/activity/offline)
 
 ## Help and Usage
 
-This repository includes an app that shows how to use each plugins in this repository. [Check out its code](https://github.com/maplibre/maplibre-plugins-android/tree/master/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity) for ready-to-use snippets.
+This repository includes an app that shows how to use each plugins in this repository. [Check out its code](https://github.com/maplibre/maplibre-plugins-android/tree/main/app/src/main/java/org/maplibre/android/plugins/testapp/activity) for ready-to-use snippets.
 
 We'd love to [hear your feedback](https://github.com/maplibre/maplibre-plugins-android/issues) as we build more plugins and learn how you use them.
 
@@ -62,4 +62,4 @@ Plugins' lightweight nature makes them much easier for you and anyone else to co
 
 We welcome contributions to this plugin repository!
 
-If you're interested in geojson and sharing your own plugin, please read [the contribution guide](https://github.com/maplibre/maplibre-plugins-android/blob/master/CONTRIBUTING.md) to learn how to get started.
+If you're interested in geojson and sharing your own plugin, please read [the contribution guide](https://github.com/maplibre/maplibre-plugins-android/blob/main/CONTRIBUTING.md) to learn how to get started.

--- a/plugin-scalebar/README.md
+++ b/plugin-scalebar/README.md
@@ -43,11 +43,11 @@ dependencies {
 
 ## Scale bar plugin examples
 
-- [In this repo's test app](https://github.com/maplibre/maplibre-plugins-android/blob/master/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/scalebar/ScalebarActivity.kt)
+- [In this repo's test app](https://github.com/maplibre/maplibre-plugins-android/blob/main/app/src/main/java/org/maplibre/android/plugins/testapp/activity/scalebar/ScalebarActivity.kt)
 
 ## Help and Usage
 
-This repository includes an app that shows how to use each plugins in this repository. [Check out its code](https://github.com/maplibre/maplibre-plugins-android/tree/master/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity) for ready-to-use snippets.
+This repository includes an app that shows how to use each plugins in this repository. [Check out its code](https://github.com/maplibre/maplibre-plugins-android/tree/main/app/src/main/java/org/maplibre/android/plugins/testapp/activity) for ready-to-use snippets.
 
 Plugins are easy to use. A plugin is simply a library module built on top of the MapLibre Maps SDK for Android. Currently, we are not requiring plugins to register themselves or to implement any specific interfaces so that they're simple to consume.
 
@@ -64,4 +64,4 @@ Plugins' lightweight nature makes them much easier for you and anyone else to co
 
 We welcome contributions to this plugin repository!
 
-If you're interested in building and sharing your own plugin, please read [the contribution guide](https://github.com/maplibre/maplibre-plugins-android/blob/master/CONTRIBUTING.md) to learn how to get started.
+If you're interested in building and sharing your own plugin, please read [the contribution guide](https://github.com/maplibre/maplibre-plugins-android/blob/main/CONTRIBUTING.md) to learn how to get started.


### PR DESCRIPTION
- update links to use the new default branch (main instead of master)
- update links to the testapp to use the new default branch and package path.
- update package path in gitignore