### PR TITLE
Use Java 17 for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,11 +20,10 @@ jobs:
           submodules: recursive
           fetch-depth: 0
 
-      - name: Set up JDK 11
-        uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
-          java-version: '11'
-          distribution: 'temurin'
+          distribution: "temurin"
+          java-version: "17"  
 
       - name: Build Plugins SDK
         run: make build-release


### PR DESCRIPTION
We need to use Java 17 for release, even though we target Java 11.

This is so because Android Gradle Plugin was updated.