### PR TITLE
Update io.github.gradle-nexus:publish-plugin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ javadoc:
 	./gradlew javadocrelease
 
 publish:
-	./gradlew publishReleasePublicationToSonatypeRepository closeAndReleaseSonatypeStagingRepository
+	./gradlew publishReleasePublicationToSonatypeRepository closeAndReleaseSonatypeStagingRepositories
 
 generate-sanity-test:
 	npm install && node scripts/generate-activity-test.js
@@ -48,9 +48,6 @@ javadoc-$1:
 	# Android modules
 	# Output is ./mapbox/*/build/docs/javadoc/release
 	./gradlew :$2:javadocrelease
-
-publish-$1:
-	./gradlew :$2:mapboxSDKRegistryUpload
 
 endef
 

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ buildscript {
     classpath 'com.android.tools.build:gradle:8.6.0'
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:2.0.0"
     classpath "org.jlleitschuh.gradle:ktlint-gradle:8.1.0"
-    classpath "io.github.gradle-nexus:publish-plugin:1.1.0"
+    classpath "io.github.gradle-nexus:publish-plugin:2.0.0"
   }
 }
 


### PR DESCRIPTION
The [release workflow failed](https://github.com/maplibre/maplibre-plugins-android/actions/runs/10758657276/job/29834326478) with some cryptic error. This version should have better support for Gradle 8.x.x so I hope it fixes it.