### PR TITLE
Modernize publishing Gradle config

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,17 @@ allprojects {
 subprojects {
   apply plugin: 'idea'
   apply from: "${rootDir}/gradle/dependencies.gradle"
+
+  plugins.withId('com.android.library') {
+    android {
+        publishing {
+            singleVariant("release") {
+                withJavadocJar()
+                withSourcesJar()
+            }
+        }
+    }
+  }
 }
 
 task clean(type: Delete) {

--- a/gradle/publish-root.gradle
+++ b/gradle/publish-root.gradle
@@ -1,21 +1,7 @@
-ext["signing.keyId"] = ''
-ext["signing.password"] = ''
 ext["signing.secretKeyRingFile"] = "${projectDir}/../signing-key.gpg"
-ext["ossrhUsername"] = ''
-ext["ossrhPassword"] = ''
-ext["sonatypeStagingProfileId"] = ''
 
-File secretPropsFile = project.rootProject.file('local.properties')
-if (secretPropsFile.exists()) {
-    // Read local.properties file first if it exists
-    Properties p = new Properties()
-    new FileInputStream(secretPropsFile).withCloseable { is -> p.load(is) }
-    p.each { name, value -> ext[name] = value }
-} else {
-    // Use system environment variables
-    ext["ossrhUsername"] = System.getenv('OSSRH_USERNAME')
-    ext["ossrhPassword"] = System.getenv('OSSRH_PASSWORD')
-    ext["sonatypeStagingProfileId"] = System.getenv('SONATYPE_STAGING_PROFILE_ID')
-    ext["signing.keyId"] = System.getenv('SIGNING_KEY_ID')
-    ext["signing.password"] = System.getenv('SIGNING_PASSWORD')
-}
+ext["ossrhUsername"] = System.getenv('OSSRH_USERNAME')
+ext["ossrhPassword"] = System.getenv('OSSRH_PASSWORD')
+ext["sonatypeStagingProfileId"] = System.getenv('SONATYPE_STAGING_PROFILE_ID')
+ext["signing.keyId"] = System.getenv('SIGNING_KEY_ID')
+ext["signing.password"] = System.getenv('SIGNING_PASSWORD')

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -6,27 +6,6 @@ apply from: '../gradle/publish-root.gradle'
 version = project.ext.versionName
 group = project.ext.mapLibreArtifactGroupId
 
-task androidJavadocs(type: Javadoc) {
-  source = android.sourceSets.main.java.sourceFiles
-  classpath = files(android.bootClasspath)
-  failOnError = false
-}
-
-task androidJavadocsJar(type: Jar, dependsOn: androidJavadocs) {
-    archiveClassifier = 'dokka'
-    from androidJavadocs.destinationDir
-}
-
-task androidSourcesJar(type: Jar) {
-    archiveClassifier = 'sources'
-    from android.sourceSets.main.java.sourceFiles
-}
-
-artifacts {
-    archives androidSourcesJar
-    archives androidJavadocsJar
-}
-
 afterEvaluate {
     publishing {
         publications {
@@ -34,11 +13,8 @@ afterEvaluate {
                             
                 groupId this.group
                 artifactId project.ext.mapLibreArtifactId
-                
-                from components.findByName('release')
 
-                artifact androidSourcesJar
-                artifact androidJavadocsJar  
+                from components.findByName('release')
 
                 version this.version
 
@@ -66,17 +42,6 @@ afterEvaluate {
                     }
                 }            
             }
-        }
-    }
-}
-
-
-// See: https://github.com/chrisbanes/gradle-mvn-push/issues/43#issuecomment-84140513
-afterEvaluate { project ->
-    android.libraryVariants.all { variant ->
-        tasks.androidJavadocs.doFirst {
-            classpath += files(variant.javaCompile.classpath.files)
-            classpath += configurations.javadocDeps
         }
     }
 }


### PR DESCRIPTION
We had some issues with publication.

```
> Task :ktx-mapbox-maps:generateMetadataFileForReleasePublication FAILED
FAILURE: Build failed with an exception.
* What went wrong: A problem was found with the configuration of task ':ktx-mapbox-maps:generateMetadataFileForReleasePublication'  (type 'GenerateModuleMetadata' ) .    - Gradle detected a problem with the following location: '/Users/bart/src/maplibre- plugins- android/ ktx- mapbox- maps/ build/ libs/ ktx- mapbox- maps- 3. 0. 1- pre0- sources. jar' . 
    Reason: Task ':ktx-mapbox-maps:generateMetadataFileForReleasePublication'  uses this output of task ':ktx-mapbox-maps:androidSourcesJar'  without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed.
    Possible solutions:       1. Declare task ':ktx-mapbox-maps:androidSourcesJar'  as an input of ':ktx-mapbox-maps:generateMetadataFileForReleasePublication' .        2. Declare an explicit dependency on ':ktx-mapbox-maps:androidSourcesJar'  from ':ktx-mapbox-maps:generateMetadataFileForReleasePublication'  using Task#dependsOn.       3. Declare an explicit dependency on ':ktx-mapbox-maps:androidSourcesJar'  from ':ktx-mapbox-maps:generateMetadataFileForReleasePublication'  using Task#mustRunAfter.
    For more information, please refer to https://docs.gradle. org/ 8. 7/ userguide/ validation_ problems. html# implicit_ dependency in the Gradle documentation.
```

This seems to fix it.