### PR TITLE
#83 Disable draggabledAnnotationController

### DIFF
--- a/plugin-annotation/src/main/java/org/maplibre/android/plugins/annotation/AnnotationManager.java
+++ b/plugin-annotation/src/main/java/org/maplibre/android/plugins/annotation/AnnotationManager.java
@@ -244,6 +244,8 @@ public abstract class AnnotationManager<
             mapView.post(() -> {
                 isSourceUpToDate.set(true);
 
+                enableDragIfNeeded();
+
                 if (!style.isFullyLoaded()) {
                     // We are in progress of loading a new style
                     return;
@@ -396,6 +398,19 @@ public abstract class AnnotationManager<
         }
 
         updateSource();
+    }
+
+    private void enableDragIfNeeded(){
+        boolean hasDraggableAnnotation = false;
+        for (int i = 0, size = annotations.size(); i < size; i++) {
+            Annotation annotation = annotations.valueAt(i);
+
+            if (annotation.isDraggable()) {
+                hasDraggableAnnotation=true;
+                break;
+            }
+        }
+        draggableAnnotationController.setEnable(hasDraggableAnnotation);
     }
 
     /**

--- a/plugin-annotation/src/main/java/org/maplibre/android/plugins/annotation/DraggableAnnotationController.java
+++ b/plugin-annotation/src/main/java/org/maplibre/android/plugins/annotation/DraggableAnnotationController.java
@@ -2,12 +2,12 @@ package org.maplibre.android.plugins.annotation;
 
 import android.annotation.SuppressLint;
 import android.graphics.PointF;
-import android.view.MotionEvent;
-import android.view.View;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.UiThread;
 import androidx.annotation.VisibleForTesting;
+
 import org.maplibre.android.gestures.AndroidGesturesManager;
 import org.maplibre.android.gestures.MoveDistancesObject;
 import org.maplibre.android.gestures.MoveGestureDetector;
@@ -54,6 +54,8 @@ final class DraggableAnnotationController {
     @Nullable
     private AnnotationManager draggedAnnotationManager;
 
+    private AndroidGesturesManager androidGesturesManager;
+
     @SuppressLint("ClickableViewAccessibility")
     DraggableAnnotationController(MapView mapView, MapLibreMap maplibreMap) {
         this(mapView, maplibreMap, new AndroidGesturesManager(mapView.getContext(), false),
@@ -72,18 +74,25 @@ final class DraggableAnnotationController {
         this.touchAreaMaxX = touchAreaMaxX;
         this.touchAreaMaxY = touchAreaMaxY;
 
-        androidGesturesManager.setMoveGestureListener(new AnnotationMoveGestureListener());
+        this.androidGesturesManager = androidGesturesManager;
+    }
 
-        mapView.setOnTouchListener(new View.OnTouchListener() {
-            @Override
-            public boolean onTouch(View v, MotionEvent event) {
+    void setEnable(boolean enable) {
+        if (enable) {
+            androidGesturesManager.setMoveGestureListener(new AnnotationMoveGestureListener());
+
+            mapView.setOnTouchListener((v, event) -> {
                 // Using active gesture manager
                 Annotation oldAnnotation = draggedAnnotation;
                 androidGesturesManager.onTouchEvent(event);
                 // if drag is started or drag is finished, don't pass motion events further
-                return draggedAnnotation != null || oldAnnotation != null;
-            }
-        });
+                boolean t = draggedAnnotation != null || oldAnnotation != null;
+                return t;
+            });
+        } else {
+            androidGesturesManager.removeMoveGestureListener();
+            mapView.setOnTouchListener(null);
+        }
     }
 
     void addAnnotationManager(AnnotationManager annotationManager) {


### PR DESCRIPTION

As mentioned in issue #83, even annotations that don't use drag are passed through functions, and this has an impact on performance.

- [x] At each source update, check that there is at least one draggable annotation to activate


We could give the developer the option to skip this loop altogether, but that would create a breaking change.
Does the developer need to remember to activate a + symbol in the manager for this to work? Wouldn't that be too confusing ?