### PR TITLE
Bump maplibre from 11.3.0 to 11.13.0 and turf from 5.9.0 to 6.0.1

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -51,7 +51,6 @@ dependencies {
     exclude group: 'com.google.android.gms'
   })
   implementation dependenciesList.maplibreTurf
-  implementation dependenciesList.maplibreCore
 
   // Architecture
   implementation dependenciesList.lifecycleExtensions

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -7,9 +7,8 @@
   ]
 
   version = [
-      mapLibreAndroidSdk : '11.3.0',
-      mapLibreJava       : '5.9.0',
-      mapLibreTurf       : '5.9.0',
+      mapLibreAndroidSdk : '11.13.0',
+      mapLibreTurf       : '6.0.1',
       playLocation       : '16.0.0',
       autoValue          : '1.5.4',
       autoValueParcel    : '0.2.6',
@@ -32,10 +31,7 @@
   dependenciesList = [
           // MapLibre
           mapLibreAndroidSdk     : "org.maplibre.gl:android-sdk:${version.mapLibreAndroidSdk}",
-          maplibreGeoJson        : "org.maplibre.gl:android-sdk-geojson:${version.maplibreJava}",
-          maplibreGeocoding      : "org.maplibre.gl:android-sdk-services:${version.maplibreJava}",
           maplibreTurf           : "org.maplibre.gl:android-sdk-turf:${version.mapLibreTurf}",
-          maplibreCore           : "org.maplibre.gl:android-sdk-core:${version.mapLibreJava}",
 
           // Google Play Location
           playLocation           : "com.google.android.gms:play-services-location:${version.playLocation}",

--- a/plugin-annotation/scripts/code-gen.js
+++ b/plugin-annotation/scripts/code-gen.js
@@ -112,6 +112,8 @@ global.propertyType = function propertyType(property) {
         return 'String';
       case 'color':
         return 'String';
+      case 'number[]':
+              return 'Float[]';
       case 'array':
         return `${propertyType({type:property.value})}[]`;
       default:
@@ -132,6 +134,8 @@ global.propertyJavaType = function propertyType(property) {
          return 'String';
        case 'color':
          return 'String';
+       case 'number[]':
+             return 'Float[]';
        case 'array':
          return `${propertyJavaType({type:property.value})}[]`;
        default:


### PR DESCRIPTION
Updated maplibre to fix the sample app crashing on certain examples.

Updated turf to use the latest distributed version.