### PR TITLE
Upgrade MapLibre Android SDK from v11.3.0 to v13.1.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
-[submodule "plugin-annotation/gl-js"]
-	path = plugin-annotation/gl-js
-	url = https://github.com/maplibre/maplibre-gl-js
+[submodule "plugin-annotation/maplibre-style-spec"]
+	path = plugin-annotation/maplibre-style-spec
+	url = https://github.com/maplibre/maplibre-style-spec.git

--- a/app/src/androidTest/java/org/maplibre/android/plugins/annotation/CircleTest.java
+++ b/app/src/androidTest/java/org/maplibre/android/plugins/annotation/CircleTest.java
@@ -48,6 +48,19 @@ public class CircleTest extends BaseActivityTest {
     }
 
     @Test
+    public void testCircleSortKey() {
+        validateTestSetup();
+        setupAnnotation();
+        Timber.i("circle-sort-key");
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
+            assertNotNull(circle);
+
+            circle.setCircleSortKey(2.0f);
+            assertEquals((Float) circle.getCircleSortKey(), (Float) 2.0f);
+        });
+    }
+
+    @Test
     public void testCircleRadius() {
         validateTestSetup();
         setupAnnotation();

--- a/app/src/androidTest/java/org/maplibre/android/plugins/annotation/FillTest.java
+++ b/app/src/androidTest/java/org/maplibre/android/plugins/annotation/FillTest.java
@@ -54,6 +54,19 @@ public class FillTest extends BaseActivityTest {
     }
 
     @Test
+    public void testFillSortKey() {
+        validateTestSetup();
+        setupAnnotation();
+        Timber.i("fill-sort-key");
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
+            assertNotNull(fill);
+
+            fill.setFillSortKey(2.0f);
+            assertEquals((Float) fill.getFillSortKey(), (Float) 2.0f);
+        });
+    }
+
+    @Test
     public void testFillOpacity() {
         validateTestSetup();
         setupAnnotation();

--- a/app/src/androidTest/java/org/maplibre/android/plugins/annotation/LineManagerTest.java
+++ b/app/src/androidTest/java/org/maplibre/android/plugins/annotation/LineManagerTest.java
@@ -103,17 +103,4 @@ public class LineManagerTest extends BaseActivityTest {
             assertEquals((String) lineManager.getLineTranslateAnchor(), (String) LINE_TRANSLATE_ANCHOR_MAP);
         });
     }
-
-    @Test
-    public void testLineDasharrayAsConstant() {
-        validateTestSetup();
-        setupLineManager();
-        Timber.i("line-dasharray");
-        invoke(maplibreMap, (uiController, maplibreMap) -> {
-            assertNotNull(lineManager);
-
-            lineManager.setLineDasharray(new Float[]{});
-            assertEquals((Float[]) lineManager.getLineDasharray(), (Float[]) new Float[]{});
-        });
-    }
 }

--- a/app/src/androidTest/java/org/maplibre/android/plugins/annotation/LineTest.java
+++ b/app/src/androidTest/java/org/maplibre/android/plugins/annotation/LineTest.java
@@ -64,6 +64,19 @@ public class LineTest extends BaseActivityTest {
     }
 
     @Test
+    public void testLineSortKey() {
+        validateTestSetup();
+        setupAnnotation();
+        Timber.i("line-sort-key");
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
+            assertNotNull(line);
+
+            line.setLineSortKey(2.0f);
+            assertEquals((Float) line.getLineSortKey(), (Float) 2.0f);
+        });
+    }
+
+    @Test
     public void testLineOpacity() {
         validateTestSetup();
         setupAnnotation();
@@ -151,6 +164,19 @@ public class LineTest extends BaseActivityTest {
 
             line.setLineBlur(2.0f);
             assertEquals((Float) line.getLineBlur(), (Float) 2.0f);
+        });
+    }
+
+    @Test
+    public void testLineDasharray() {
+        validateTestSetup();
+        setupAnnotation();
+        Timber.i("line-dasharray");
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
+            assertNotNull(line);
+
+            line.setLineDasharray(new Float[]{});
+            assertEquals((Float[]) line.getLineDasharray(), (Float[]) new Float[]{});
         });
     }
 

--- a/app/src/androidTest/java/org/maplibre/android/plugins/annotation/SymbolManagerTest.java
+++ b/app/src/androidTest/java/org/maplibre/android/plugins/annotation/SymbolManagerTest.java
@@ -157,19 +157,6 @@ public class SymbolManagerTest extends BaseActivityTest {
     }
 
     @Test
-    public void testIconPaddingAsConstant() {
-        validateTestSetup();
-        setupSymbolManager();
-        Timber.i("icon-padding");
-        invoke(maplibreMap, (uiController, maplibreMap) -> {
-            assertNotNull(symbolManager);
-
-            symbolManager.setIconPadding(2.0f);
-            assertEquals((Float) symbolManager.getIconPadding(), (Float) 2.0f);
-        });
-    }
-
-    @Test
     public void testIconKeepUprightAsConstant() {
         validateTestSetup();
         setupSymbolManager();
@@ -257,6 +244,19 @@ public class SymbolManagerTest extends BaseActivityTest {
 
             symbolManager.setTextMaxAngle(2.0f);
             assertEquals((Float) symbolManager.getTextMaxAngle(), (Float) 2.0f);
+        });
+    }
+
+    @Test
+    public void testTextWritingModeAsConstant() {
+        validateTestSetup();
+        setupSymbolManager();
+        Timber.i("text-writing-mode");
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
+            assertNotNull(symbolManager);
+
+            symbolManager.setTextWritingMode(new String[]{TEXT_WRITING_MODE_HORIZONTAL});
+            assertEquals((String[]) symbolManager.getTextWritingMode(), (String[]) new String[]{TEXT_WRITING_MODE_HORIZONTAL});
         });
     }
 

--- a/app/src/androidTest/java/org/maplibre/android/plugins/annotation/SymbolTest.java
+++ b/app/src/androidTest/java/org/maplibre/android/plugins/annotation/SymbolTest.java
@@ -100,6 +100,19 @@ public class SymbolTest extends BaseActivityTest {
     }
 
     @Test
+    public void testIconPadding() {
+        validateTestSetup();
+        setupAnnotation();
+        Timber.i("icon-padding");
+        invoke(maplibreMap, (uiController, maplibreMap) -> {
+            assertNotNull(symbol);
+
+            symbol.setIconPadding(2.0f);
+            assertEquals((Float) symbol.getIconPadding(), (Float) 2.0f);
+        });
+    }
+
+    @Test
     public void testIconOffset() {
         validateTestSetup();
         setupAnnotation();

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ buildscript {
 
   dependencies {
     classpath 'com.android.tools.build:gradle:8.6.0'
-    classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:2.0.0"
+    classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:2.2.0"
     classpath "org.jlleitschuh.gradle:ktlint-gradle:8.1.0"
     classpath "io.github.gradle-nexus:publish-plugin:2.0.0"
   }

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -1,15 +1,17 @@
  ext {
 
   androidVersions = [
-      minSdkVersion    : 21,
+      minSdkVersion    : 23,
       targetSdkVersion : 30,
       compileSdkVersion: 34,
   ]
 
   version = [
-      mapLibreAndroidSdk : '11.3.0',
-      mapLibreJava       : '5.9.0',
-      mapLibreTurf       : '5.9.0',
+      mapLibreAndroidSdk : '13.1.0',
+      mapLibreGeoJson    : '6.0.1',
+      mapLibreGeocoding  : '5.9.0',
+      mapLibreTurf       : '6.0.1',
+      mapLibreCore       : '5.9.0',
       playLocation       : '16.0.0',
       autoValue          : '1.5.4',
       autoValueParcel    : '0.2.6',
@@ -32,10 +34,10 @@
   dependenciesList = [
           // MapLibre
           mapLibreAndroidSdk     : "org.maplibre.gl:android-sdk:${version.mapLibreAndroidSdk}",
-          maplibreGeoJson        : "org.maplibre.gl:android-sdk-geojson:${version.maplibreJava}",
-          maplibreGeocoding      : "org.maplibre.gl:android-sdk-services:${version.maplibreJava}",
+          maplibreGeoJson        : "org.maplibre.gl:android-sdk-geojson:${version.mapLibreGeoJson}",
+          maplibreGeocoding      : "org.maplibre.gl:android-sdk-services:${version.mapLibreGeocoding}",
           maplibreTurf           : "org.maplibre.gl:android-sdk-turf:${version.mapLibreTurf}",
-          maplibreCore           : "org.maplibre.gl:android-sdk-core:${version.mapLibreJava}",
+          maplibreCore           : "org.maplibre.gl:android-sdk-core:${version.mapLibreCore}",
 
           // Google Play Location
           playLocation           : "com.google.android.gms:play-services-location:${version.playLocation}",

--- a/plugin-annotation/scripts/annotation.java.ejs
+++ b/plugin-annotation/scripts/annotation.java.ejs
@@ -162,7 +162,7 @@ public class <%- camelize(type) %> extends Annotation<<%- geometryType(type) %>>
 <% for (const property of properties) { -%>
 <% if (supportsPropertyFunction(property)) { -%>
 <% if (propertyType(property).endsWith("[]")) { -%>
-<% if (propertyType(property).endsWith("Float[]")) { -%>
+<% if (isPointFProperty(property)) { -%>
 
     /**
      * Get the <%- camelize(property.name) %> property

--- a/plugin-annotation/scripts/annotation_instrumentation_test.junit.ejs
+++ b/plugin-annotation/scripts/annotation_instrumentation_test.junit.ejs
@@ -67,7 +67,7 @@ public class <%- camelize(type) %>Test extends BaseActivityTest {
     }
 <% for (const property of properties) { -%>
 <% if (supportsPropertyFunction(property)) { -%>
-<% if (propertyType(property).endsWith("Float[]")) { -%>
+<% if (isPointFProperty(property)) { -%>
 
     @Test
     public void test<%- camelize(property.name) %>() {

--- a/plugin-annotation/scripts/annotation_manager_unit_test.junit.ejs
+++ b/plugin-annotation/scripts/annotation_manager_unit_test.junit.ejs
@@ -208,7 +208,7 @@ public class <%- camelize(type) %>ManagerTest {
 <% for (const property of properties) { -%>
 <% if (supportsPropertyFunction(property)) { -%>
 <% if (propertyType(property).endsWith("[]")) { -%>
-<% if (propertyType(property).endsWith("Float[]")) { -%>
+<% if (isPointFProperty(property)) { -%>
         PointF <%- camelizeWithLeadingLowercase(property.name) %>Expected = new PointF(<%- defaultValueJava(property) %>[0], <%- defaultValueJava(property) %>[1]);
         assertEquals(<%- camelizeWithLeadingLowercase(property.name) %>Expected.x, <%- type %>.get<%- camelize(property.name) %>().x);
         assertEquals(<%- camelizeWithLeadingLowercase(property.name) %>Expected.y, <%- type %>.get<%- camelize(property.name) %>().y);

--- a/plugin-annotation/scripts/code-gen.js
+++ b/plugin-annotation/scripts/code-gen.js
@@ -3,7 +3,7 @@
 
 const fs = require('fs');
 const ejs = require('ejs');
-const spec = require('./../gl-js/src/style-spec/reference/v8');
+const spec = require('./../maplibre-style-spec/src/reference/v8');
 const _ = require('lodash');
 const path = require('path');
 
@@ -68,10 +68,35 @@ const lightProperties = Object.keys(spec[`light`]).reduce((memo, name) => {
   return memo;
 }, []);
 
+// Properties that cannot be represented by the annotation plugin's per-feature
+// model (a GeoJSON JsonObject + simple expressions) and are therefore skipped
+// during generation, analogous to the `visibility` layout property. The
+// text-variable-anchor-offset property uses the variableAnchorOffsetCollection
+// type (an alternating list of anchors and offsets) which has no meaningful
+// scalar/array representation in a feature's JsonObject.
+const skippedProperties = ['visibility', 'text-variable-anchor-offset'];
+
+// A property is only generated when it is actually implemented in the MapLibre
+// Android SDK. The style spec records this under sdk-support: an implemented
+// property has a semver string (e.g. "2.0.1") for android, while an unimplemented
+// one has either no entry or a GitHub issue URL (e.g. icon-overlap, text-overlap).
+// Generating an unsupported property would reference SDK methods that do not
+// exist, so mirror the maplibre-native code generator and skip them.
+global.isSupportedOnAndroid = function (property) {
+  const support = property['sdk-support']
+    && property['sdk-support']['basic functionality']
+    && property['sdk-support']['basic functionality'].android;
+  return typeof support === 'string' && /^[0-9]/.test(support);
+};
+
+const includeProperty = function (property, name) {
+  return skippedProperties.indexOf(name) === -1 && global.isSupportedOnAndroid(property);
+};
+
 // Collect layer types from spec
 var layers = Object.keys(spec.layer.type.values).map((type) => {
   const layoutProperties = Object.keys(spec[`layout_${type}`]).reduce((memo, name) => {
-    if (name !== 'visibility') {
+    if (includeProperty(spec[`layout_${type}`][name], name)) {
       spec[`layout_${type}`][name].name = name;
       memo.push(spec[`layout_${type}`][name]);
     }
@@ -79,8 +104,10 @@ var layers = Object.keys(spec.layer.type.values).map((type) => {
   }, []);
 
   const paintProperties = Object.keys(spec[`paint_${type}`]).reduce((memo, name) => {
-    spec[`paint_${type}`][name].name = name;
-    memo.push(spec[`paint_${type}`][name]);
+    if (includeProperty(spec[`paint_${type}`][name], name)) {
+      spec[`paint_${type}`][name].name = name;
+      memo.push(spec[`paint_${type}`][name]);
+    }
     return memo;
   }, []);
 
@@ -99,14 +126,28 @@ const paintProperties = _(layers).map('paintProperties').flatten().value();
 const allProperties = _(layoutProperties).union(paintProperties).union(lightProperties).value();
 const enumProperties = _(allProperties).filter({'type': 'enum'}).value();
 
+// Two-element numeric arrays (icon-offset, text-offset) are surfaced through the
+// per-feature API as a PointF. Variable-length numeric arrays such as
+// line-dasharray have no fixed (x, y) shape and must use the generic Float[]
+// array accessors instead, otherwise the generated code would index a possibly
+// empty array.
+global.isPointFProperty = function (property) {
+  return property.type === 'array' && property.value === 'number' && property.length === 2;
+};
+
 global.propertyType = function propertyType(property) {
   switch (property.type) {
       case 'boolean':
         return 'Boolean';
       case 'number':
+      // A padding is exposed by the SDK as a single Float per feature
+      // (PropertyFactory#iconPadding accepts an expression resolving to a number).
+      case 'padding':
         return 'Float';
       case 'formatted':
       case 'string':
+      // A resolvedImage resolves to an image name string (icon-image, *-pattern).
+      case 'resolvedImage':
         return 'String';
       case 'enum':
         return 'String';
@@ -235,9 +276,11 @@ global.defaultValueJava = function(property) {
       case 'boolean':
         return 'true';
       case 'number':
+      case 'padding':
         return '2.0f';
       case 'formatted':
       case 'string':
+      case 'resolvedImage':
         return '"' + property['default'] + '"';
       case 'enum':
         return snakeCaseUpper(property.name) + "_" + snakeCaseUpper(Object.keys(property.values)[0]);
@@ -248,6 +291,8 @@ global.defaultValueJava = function(property) {
               case 'formatted':
               case 'string':
                 return '[' + property['default'] + "]";
+              case 'enum':
+                return `new String[]{${snakeCaseUpper(property.name)}_${snakeCaseUpper(Object.keys(property.values)[0])}}`;
               case 'number':
                 var result ='new Float[]{';
                 for (var i = 0; i < property.length; i++) {

--- a/plugin-annotation/src/main/java/org/maplibre/android/plugins/annotation/Circle.java
+++ b/plugin-annotation/src/main/java/org/maplibre/android/plugins/annotation/Circle.java
@@ -45,6 +45,9 @@ public class Circle extends Annotation<Point> {
 
     @Override
     void setUsedDataDrivenProperties() {
+        if (!(jsonObject.get(CircleOptions.PROPERTY_CIRCLE_SORT_KEY) instanceof JsonNull)) {
+            annotationManager.enableDataDrivenProperty(CircleOptions.PROPERTY_CIRCLE_SORT_KEY);
+        }
         if (!(jsonObject.get(CircleOptions.PROPERTY_CIRCLE_RADIUS) instanceof JsonNull)) {
             annotationManager.enableDataDrivenProperty(CircleOptions.PROPERTY_CIRCLE_RADIUS);
         }
@@ -91,6 +94,33 @@ public class Circle extends Annotation<Point> {
     }
 
     // Property accessors
+
+    /**
+     * Get the CircleSortKey property
+     * <p>
+     * Sorts features in ascending order based on this value. Features with a higher sort key will appear above features with a lower sort key.
+     * </p>
+     *
+     * @return property wrapper value around Float
+     */
+    public Float getCircleSortKey() {
+        return jsonObject.get(CircleOptions.PROPERTY_CIRCLE_SORT_KEY).getAsFloat();
+    }
+
+    /**
+     * Set the CircleSortKey property
+     * <p>
+     * Sorts features in ascending order based on this value. Features with a higher sort key will appear above features with a lower sort key.
+     * </p>
+     * <p>
+     * To update the circle on the map use {@link CircleManager#update(Annotation)}.
+     * <p>
+     *
+     * @param value constant property value for Float
+     */
+    public void setCircleSortKey(Float value) {
+        jsonObject.addProperty(CircleOptions.PROPERTY_CIRCLE_SORT_KEY, value);
+    }
 
     /**
      * Get the CircleRadius property

--- a/plugin-annotation/src/main/java/org/maplibre/android/plugins/annotation/CircleManager.java
+++ b/plugin-annotation/src/main/java/org/maplibre/android/plugins/annotation/CircleManager.java
@@ -80,6 +80,7 @@ public class CircleManager extends AnnotationManager<CircleLayer, Circle, Circle
 
     @Override
     void initializeDataDrivenPropertyMap() {
+        dataDrivenPropertyUsageMap.put(CircleOptions.PROPERTY_CIRCLE_SORT_KEY, false);
         dataDrivenPropertyUsageMap.put(CircleOptions.PROPERTY_CIRCLE_RADIUS, false);
         dataDrivenPropertyUsageMap.put(CircleOptions.PROPERTY_CIRCLE_COLOR, false);
         dataDrivenPropertyUsageMap.put(CircleOptions.PROPERTY_CIRCLE_BLUR, false);
@@ -92,6 +93,9 @@ public class CircleManager extends AnnotationManager<CircleLayer, Circle, Circle
     @Override
     protected void setDataDrivenPropertyIsUsed(@NonNull String property) {
         switch (property) {
+            case CircleOptions.PROPERTY_CIRCLE_SORT_KEY:
+                layer.setProperties(circleSortKey(get(CircleOptions.PROPERTY_CIRCLE_SORT_KEY)));
+                break;
             case CircleOptions.PROPERTY_CIRCLE_RADIUS:
                 layer.setProperties(circleRadius(get(CircleOptions.PROPERTY_CIRCLE_RADIUS)));
                 break;
@@ -122,6 +126,7 @@ public class CircleManager extends AnnotationManager<CircleLayer, Circle, Circle
      * Circles are going to be created only for features with a matching geometry.
      * <p>
      * All supported properties are:<br>
+     * CircleOptions.PROPERTY_CIRCLE_SORT_KEY - Float<br>
      * CircleOptions.PROPERTY_CIRCLE_RADIUS - Float<br>
      * CircleOptions.PROPERTY_CIRCLE_COLOR - String<br>
      * CircleOptions.PROPERTY_CIRCLE_BLUR - Float<br>
@@ -148,6 +153,7 @@ public class CircleManager extends AnnotationManager<CircleLayer, Circle, Circle
      * Circles are going to be created only for features with a matching geometry.
      * <p>
      * All supported properties are:<br>
+     * CircleOptions.PROPERTY_CIRCLE_SORT_KEY - Float<br>
      * CircleOptions.PROPERTY_CIRCLE_RADIUS - Float<br>
      * CircleOptions.PROPERTY_CIRCLE_COLOR - String<br>
      * CircleOptions.PROPERTY_CIRCLE_BLUR - Float<br>

--- a/plugin-annotation/src/main/java/org/maplibre/android/plugins/annotation/CircleOptions.java
+++ b/plugin-annotation/src/main/java/org/maplibre/android/plugins/annotation/CircleOptions.java
@@ -28,6 +28,7 @@ public class CircleOptions extends Options<Circle> {
     private boolean isDraggable;
     private JsonElement data;
     private Point geometry;
+    private Float circleSortKey;
     private Float circleRadius;
     private String circleColor;
     private Float circleBlur;
@@ -36,6 +37,7 @@ public class CircleOptions extends Options<Circle> {
     private String circleStrokeColor;
     private Float circleStrokeOpacity;
 
+    static final String PROPERTY_CIRCLE_SORT_KEY = "circle-sort-key";
     static final String PROPERTY_CIRCLE_RADIUS = "circle-radius";
     static final String PROPERTY_CIRCLE_COLOR = "circle-color";
     static final String PROPERTY_CIRCLE_BLUR = "circle-blur";
@@ -44,6 +46,32 @@ public class CircleOptions extends Options<Circle> {
     static final String PROPERTY_CIRCLE_STROKE_COLOR = "circle-stroke-color";
     static final String PROPERTY_CIRCLE_STROKE_OPACITY = "circle-stroke-opacity";
     private static final String PROPERTY_IS_DRAGGABLE = "is-draggable";
+
+    /**
+     * Set circle-sort-key to initialise the circle with.
+     * <p>
+     * Sorts features in ascending order based on this value. Features with a higher sort key will appear above features with a lower sort key.
+     * </p>
+     *
+     * @param circleSortKey the circle-sort-key value
+     * @return this
+     */
+    public CircleOptions withCircleSortKey(Float circleSortKey) {
+        this.circleSortKey = circleSortKey;
+        return this;
+    }
+
+    /**
+     * Get the current configured  circle-sort-key for the circle
+     * <p>
+     * Sorts features in ascending order based on this value. Features with a higher sort key will appear above features with a lower sort key.
+     * </p>
+     *
+     * @return circleSortKey value
+     */
+    public Float getCircleSortKey() {
+        return circleSortKey;
+    }
 
     /**
      * Set circle-radius to initialise the circle with.
@@ -316,6 +344,7 @@ public class CircleOptions extends Options<Circle> {
             throw new RuntimeException("geometry field is required");
         }
         JsonObject jsonObject = new JsonObject();
+        jsonObject.addProperty(PROPERTY_CIRCLE_SORT_KEY, circleSortKey);
         jsonObject.addProperty(PROPERTY_CIRCLE_RADIUS, circleRadius);
         jsonObject.addProperty(PROPERTY_CIRCLE_COLOR, circleColor);
         jsonObject.addProperty(PROPERTY_CIRCLE_BLUR, circleBlur);
@@ -345,6 +374,9 @@ public class CircleOptions extends Options<Circle> {
 
         CircleOptions options = new CircleOptions();
         options.geometry = (Point) feature.geometry();
+        if (feature.hasProperty(PROPERTY_CIRCLE_SORT_KEY)) {
+            options.circleSortKey = feature.getProperty(PROPERTY_CIRCLE_SORT_KEY).getAsFloat();
+        }
         if (feature.hasProperty(PROPERTY_CIRCLE_RADIUS)) {
             options.circleRadius = feature.getProperty(PROPERTY_CIRCLE_RADIUS).getAsFloat();
         }

--- a/plugin-annotation/src/main/java/org/maplibre/android/plugins/annotation/Fill.java
+++ b/plugin-annotation/src/main/java/org/maplibre/android/plugins/annotation/Fill.java
@@ -45,6 +45,9 @@ public class Fill extends Annotation<Polygon> {
 
     @Override
     void setUsedDataDrivenProperties() {
+        if (!(jsonObject.get(FillOptions.PROPERTY_FILL_SORT_KEY) instanceof JsonNull)) {
+            annotationManager.enableDataDrivenProperty(FillOptions.PROPERTY_FILL_SORT_KEY);
+        }
         if (!(jsonObject.get(FillOptions.PROPERTY_FILL_OPACITY) instanceof JsonNull)) {
             annotationManager.enableDataDrivenProperty(FillOptions.PROPERTY_FILL_OPACITY);
         }
@@ -102,6 +105,33 @@ public class Fill extends Annotation<Polygon> {
     }
 
     // Property accessors
+
+    /**
+     * Get the FillSortKey property
+     * <p>
+     * Sorts features in ascending order based on this value. Features with a higher sort key will appear above features with a lower sort key.
+     * </p>
+     *
+     * @return property wrapper value around Float
+     */
+    public Float getFillSortKey() {
+        return jsonObject.get(FillOptions.PROPERTY_FILL_SORT_KEY).getAsFloat();
+    }
+
+    /**
+     * Set the FillSortKey property
+     * <p>
+     * Sorts features in ascending order based on this value. Features with a higher sort key will appear above features with a lower sort key.
+     * </p>
+     * <p>
+     * To update the fill on the map use {@link FillManager#update(Annotation)}.
+     * <p>
+     *
+     * @param value constant property value for Float
+     */
+    public void setFillSortKey(Float value) {
+        jsonObject.addProperty(FillOptions.PROPERTY_FILL_SORT_KEY, value);
+    }
 
     /**
      * Get the FillOpacity property

--- a/plugin-annotation/src/main/java/org/maplibre/android/plugins/annotation/FillManager.java
+++ b/plugin-annotation/src/main/java/org/maplibre/android/plugins/annotation/FillManager.java
@@ -79,6 +79,7 @@ public class FillManager extends AnnotationManager<FillLayer, Fill, FillOptions,
 
     @Override
     void initializeDataDrivenPropertyMap() {
+        dataDrivenPropertyUsageMap.put(FillOptions.PROPERTY_FILL_SORT_KEY, false);
         dataDrivenPropertyUsageMap.put(FillOptions.PROPERTY_FILL_OPACITY, false);
         dataDrivenPropertyUsageMap.put(FillOptions.PROPERTY_FILL_COLOR, false);
         dataDrivenPropertyUsageMap.put(FillOptions.PROPERTY_FILL_OUTLINE_COLOR, false);
@@ -88,6 +89,9 @@ public class FillManager extends AnnotationManager<FillLayer, Fill, FillOptions,
     @Override
     protected void setDataDrivenPropertyIsUsed(@NonNull String property) {
         switch (property) {
+            case FillOptions.PROPERTY_FILL_SORT_KEY:
+                layer.setProperties(fillSortKey(get(FillOptions.PROPERTY_FILL_SORT_KEY)));
+                break;
             case FillOptions.PROPERTY_FILL_OPACITY:
                 layer.setProperties(fillOpacity(get(FillOptions.PROPERTY_FILL_OPACITY)));
                 break;
@@ -109,6 +113,7 @@ public class FillManager extends AnnotationManager<FillLayer, Fill, FillOptions,
      * Fills are going to be created only for features with a matching geometry.
      * <p>
      * All supported properties are:<br>
+     * FillOptions.PROPERTY_FILL_SORT_KEY - Float<br>
      * FillOptions.PROPERTY_FILL_OPACITY - Float<br>
      * FillOptions.PROPERTY_FILL_COLOR - String<br>
      * FillOptions.PROPERTY_FILL_OUTLINE_COLOR - String<br>
@@ -132,6 +137,7 @@ public class FillManager extends AnnotationManager<FillLayer, Fill, FillOptions,
      * Fills are going to be created only for features with a matching geometry.
      * <p>
      * All supported properties are:<br>
+     * FillOptions.PROPERTY_FILL_SORT_KEY - Float<br>
      * FillOptions.PROPERTY_FILL_OPACITY - Float<br>
      * FillOptions.PROPERTY_FILL_COLOR - String<br>
      * FillOptions.PROPERTY_FILL_OUTLINE_COLOR - String<br>

--- a/plugin-annotation/src/main/java/org/maplibre/android/plugins/annotation/FillOptions.java
+++ b/plugin-annotation/src/main/java/org/maplibre/android/plugins/annotation/FillOptions.java
@@ -28,16 +28,44 @@ public class FillOptions extends Options<Fill> {
     private boolean isDraggable;
     private JsonElement data;
     private Polygon geometry;
+    private Float fillSortKey;
     private Float fillOpacity;
     private String fillColor;
     private String fillOutlineColor;
     private String fillPattern;
 
+    static final String PROPERTY_FILL_SORT_KEY = "fill-sort-key";
     static final String PROPERTY_FILL_OPACITY = "fill-opacity";
     static final String PROPERTY_FILL_COLOR = "fill-color";
     static final String PROPERTY_FILL_OUTLINE_COLOR = "fill-outline-color";
     static final String PROPERTY_FILL_PATTERN = "fill-pattern";
     private static final String PROPERTY_IS_DRAGGABLE = "is-draggable";
+
+    /**
+     * Set fill-sort-key to initialise the fill with.
+     * <p>
+     * Sorts features in ascending order based on this value. Features with a higher sort key will appear above features with a lower sort key.
+     * </p>
+     *
+     * @param fillSortKey the fill-sort-key value
+     * @return this
+     */
+    public FillOptions withFillSortKey(Float fillSortKey) {
+        this.fillSortKey = fillSortKey;
+        return this;
+    }
+
+    /**
+     * Get the current configured  fill-sort-key for the fill
+     * <p>
+     * Sorts features in ascending order based on this value. Features with a higher sort key will appear above features with a lower sort key.
+     * </p>
+     *
+     * @return fillSortKey value
+     */
+    public Float getFillSortKey() {
+        return fillSortKey;
+    }
 
     /**
      * Set fill-opacity to initialise the fill with.
@@ -247,6 +275,7 @@ public class FillOptions extends Options<Fill> {
             throw new RuntimeException("geometry field is required");
         }
         JsonObject jsonObject = new JsonObject();
+        jsonObject.addProperty(PROPERTY_FILL_SORT_KEY, fillSortKey);
         jsonObject.addProperty(PROPERTY_FILL_OPACITY, fillOpacity);
         jsonObject.addProperty(PROPERTY_FILL_COLOR, fillColor);
         jsonObject.addProperty(PROPERTY_FILL_OUTLINE_COLOR, fillOutlineColor);
@@ -273,6 +302,9 @@ public class FillOptions extends Options<Fill> {
 
         FillOptions options = new FillOptions();
         options.geometry = (Polygon) feature.geometry();
+        if (feature.hasProperty(PROPERTY_FILL_SORT_KEY)) {
+            options.fillSortKey = feature.getProperty(PROPERTY_FILL_SORT_KEY).getAsFloat();
+        }
         if (feature.hasProperty(PROPERTY_FILL_OPACITY)) {
             options.fillOpacity = feature.getProperty(PROPERTY_FILL_OPACITY).getAsFloat();
         }

--- a/plugin-annotation/src/main/java/org/maplibre/android/plugins/annotation/Line.java
+++ b/plugin-annotation/src/main/java/org/maplibre/android/plugins/annotation/Line.java
@@ -48,6 +48,9 @@ public class Line extends Annotation<LineString> {
         if (!(jsonObject.get(LineOptions.PROPERTY_LINE_JOIN) instanceof JsonNull)) {
             annotationManager.enableDataDrivenProperty(LineOptions.PROPERTY_LINE_JOIN);
         }
+        if (!(jsonObject.get(LineOptions.PROPERTY_LINE_SORT_KEY) instanceof JsonNull)) {
+            annotationManager.enableDataDrivenProperty(LineOptions.PROPERTY_LINE_SORT_KEY);
+        }
         if (!(jsonObject.get(LineOptions.PROPERTY_LINE_OPACITY) instanceof JsonNull)) {
             annotationManager.enableDataDrivenProperty(LineOptions.PROPERTY_LINE_OPACITY);
         }
@@ -65,6 +68,9 @@ public class Line extends Annotation<LineString> {
         }
         if (!(jsonObject.get(LineOptions.PROPERTY_LINE_BLUR) instanceof JsonNull)) {
             annotationManager.enableDataDrivenProperty(LineOptions.PROPERTY_LINE_BLUR);
+        }
+        if (!(jsonObject.get(LineOptions.PROPERTY_LINE_DASHARRAY) instanceof JsonNull)) {
+            annotationManager.enableDataDrivenProperty(LineOptions.PROPERTY_LINE_DASHARRAY);
         }
         if (!(jsonObject.get(LineOptions.PROPERTY_LINE_PATTERN) instanceof JsonNull)) {
             annotationManager.enableDataDrivenProperty(LineOptions.PROPERTY_LINE_PATTERN);
@@ -129,6 +135,33 @@ public class Line extends Annotation<LineString> {
      */
     public void setLineJoin(@Property.LINE_JOIN String value) {
         jsonObject.addProperty(LineOptions.PROPERTY_LINE_JOIN, value);
+    }
+
+    /**
+     * Get the LineSortKey property
+     * <p>
+     * Sorts features in ascending order based on this value. Features with a higher sort key will appear above features with a lower sort key.
+     * </p>
+     *
+     * @return property wrapper value around Float
+     */
+    public Float getLineSortKey() {
+        return jsonObject.get(LineOptions.PROPERTY_LINE_SORT_KEY).getAsFloat();
+    }
+
+    /**
+     * Set the LineSortKey property
+     * <p>
+     * Sorts features in ascending order based on this value. Features with a higher sort key will appear above features with a lower sort key.
+     * </p>
+     * <p>
+     * To update the line on the map use {@link LineManager#update(Annotation)}.
+     * <p>
+     *
+     * @param value constant property value for Float
+     */
+    public void setLineSortKey(Float value) {
+        jsonObject.addProperty(LineOptions.PROPERTY_LINE_SORT_KEY, value);
     }
 
     /**
@@ -319,6 +352,42 @@ public class Line extends Annotation<LineString> {
      */
     public void setLineBlur(Float value) {
         jsonObject.addProperty(LineOptions.PROPERTY_LINE_BLUR, value);
+    }
+
+    /**
+     * Get the LineDasharray property
+     * <p>
+     * Specifies the lengths of the alternating dashes and gaps that form the dash pattern. The lengths are later scaled by the line width. To convert a dash length to density-independent pixels, multiply the length by the current line width. GeoJSON sources with `lineMetrics: true` specified won't render dashed lines to the expected scale. Zoom-dependent expressions will be evaluated only at integer zoom levels. The only way to create an array value is using `["literal", [...]]`; arrays cannot be read from or derived from feature properties.
+     * </p>
+     *
+     * @return property wrapper value around Float[]
+     */
+    public Float[] getLineDasharray() {
+        JsonArray jsonArray = jsonObject.getAsJsonArray(LineOptions.PROPERTY_LINE_DASHARRAY);
+        Float[] value = new Float[jsonArray.size()];
+        for (int i = 0; i < jsonArray.size(); i++) {
+            value[i] = jsonArray.get(i).getAsFloat();
+        }
+        return value;
+    }
+
+    /**
+     * Set the LineDasharray property.
+     * <p>
+     * Specifies the lengths of the alternating dashes and gaps that form the dash pattern. The lengths are later scaled by the line width. To convert a dash length to density-independent pixels, multiply the length by the current line width. GeoJSON sources with `lineMetrics: true` specified won't render dashed lines to the expected scale. Zoom-dependent expressions will be evaluated only at integer zoom levels. The only way to create an array value is using `["literal", [...]]`; arrays cannot be read from or derived from feature properties.
+     * </p>
+     * <p>
+     * To update the line on the map use {@link LineManager#update(Annotation)}.
+     * <p>
+     *
+     * @param value constant property value for Float[]
+     */
+    public void setLineDasharray(Float[] value) {
+        JsonArray jsonArray = new JsonArray();
+        for (Float element : value) {
+            jsonArray.add(element);
+        }
+        jsonObject.add(LineOptions.PROPERTY_LINE_DASHARRAY, jsonArray);
     }
 
     /**

--- a/plugin-annotation/src/main/java/org/maplibre/android/plugins/annotation/LineManager.java
+++ b/plugin-annotation/src/main/java/org/maplibre/android/plugins/annotation/LineManager.java
@@ -35,7 +35,6 @@ public class LineManager extends AnnotationManager<LineLayer, Line, LineOptions,
     private static final String PROPERTY_LINE_ROUND_LIMIT = "line-round-limit";
     private static final String PROPERTY_LINE_TRANSLATE = "line-translate";
     private static final String PROPERTY_LINE_TRANSLATE_ANCHOR = "line-translate-anchor";
-    private static final String PROPERTY_LINE_DASHARRAY = "line-dasharray";
 
     /**
      * Create a line manager, used to manage lines.
@@ -83,12 +82,14 @@ public class LineManager extends AnnotationManager<LineLayer, Line, LineOptions,
     @Override
     void initializeDataDrivenPropertyMap() {
         dataDrivenPropertyUsageMap.put(LineOptions.PROPERTY_LINE_JOIN, false);
+        dataDrivenPropertyUsageMap.put(LineOptions.PROPERTY_LINE_SORT_KEY, false);
         dataDrivenPropertyUsageMap.put(LineOptions.PROPERTY_LINE_OPACITY, false);
         dataDrivenPropertyUsageMap.put(LineOptions.PROPERTY_LINE_COLOR, false);
         dataDrivenPropertyUsageMap.put(LineOptions.PROPERTY_LINE_WIDTH, false);
         dataDrivenPropertyUsageMap.put(LineOptions.PROPERTY_LINE_GAP_WIDTH, false);
         dataDrivenPropertyUsageMap.put(LineOptions.PROPERTY_LINE_OFFSET, false);
         dataDrivenPropertyUsageMap.put(LineOptions.PROPERTY_LINE_BLUR, false);
+        dataDrivenPropertyUsageMap.put(LineOptions.PROPERTY_LINE_DASHARRAY, false);
         dataDrivenPropertyUsageMap.put(LineOptions.PROPERTY_LINE_PATTERN, false);
     }
 
@@ -97,6 +98,9 @@ public class LineManager extends AnnotationManager<LineLayer, Line, LineOptions,
         switch (property) {
             case LineOptions.PROPERTY_LINE_JOIN:
                 layer.setProperties(lineJoin(get(LineOptions.PROPERTY_LINE_JOIN)));
+                break;
+            case LineOptions.PROPERTY_LINE_SORT_KEY:
+                layer.setProperties(lineSortKey(get(LineOptions.PROPERTY_LINE_SORT_KEY)));
                 break;
             case LineOptions.PROPERTY_LINE_OPACITY:
                 layer.setProperties(lineOpacity(get(LineOptions.PROPERTY_LINE_OPACITY)));
@@ -116,6 +120,9 @@ public class LineManager extends AnnotationManager<LineLayer, Line, LineOptions,
             case LineOptions.PROPERTY_LINE_BLUR:
                 layer.setProperties(lineBlur(get(LineOptions.PROPERTY_LINE_BLUR)));
                 break;
+            case LineOptions.PROPERTY_LINE_DASHARRAY:
+                layer.setProperties(lineDasharray(get(LineOptions.PROPERTY_LINE_DASHARRAY)));
+                break;
             case LineOptions.PROPERTY_LINE_PATTERN:
                 layer.setProperties(linePattern(get(LineOptions.PROPERTY_LINE_PATTERN)));
                 break;
@@ -129,12 +136,14 @@ public class LineManager extends AnnotationManager<LineLayer, Line, LineOptions,
      * <p>
      * All supported properties are:<br>
      * LineOptions.PROPERTY_LINE_JOIN - String<br>
+     * LineOptions.PROPERTY_LINE_SORT_KEY - Float<br>
      * LineOptions.PROPERTY_LINE_OPACITY - Float<br>
      * LineOptions.PROPERTY_LINE_COLOR - String<br>
      * LineOptions.PROPERTY_LINE_WIDTH - Float<br>
      * LineOptions.PROPERTY_LINE_GAP_WIDTH - Float<br>
      * LineOptions.PROPERTY_LINE_OFFSET - Float<br>
      * LineOptions.PROPERTY_LINE_BLUR - Float<br>
+     * LineOptions.PROPERTY_LINE_DASHARRAY - Float[]<br>
      * LineOptions.PROPERTY_LINE_PATTERN - String<br>
      * Learn more about above properties in the <a href="https://www.mapbox.com/mapbox-gl-js/style-spec/">Style specification</a>.
      * <p>
@@ -156,12 +165,14 @@ public class LineManager extends AnnotationManager<LineLayer, Line, LineOptions,
      * <p>
      * All supported properties are:<br>
      * LineOptions.PROPERTY_LINE_JOIN - String<br>
+     * LineOptions.PROPERTY_LINE_SORT_KEY - Float<br>
      * LineOptions.PROPERTY_LINE_OPACITY - Float<br>
      * LineOptions.PROPERTY_LINE_COLOR - String<br>
      * LineOptions.PROPERTY_LINE_WIDTH - Float<br>
      * LineOptions.PROPERTY_LINE_GAP_WIDTH - Float<br>
      * LineOptions.PROPERTY_LINE_OFFSET - Float<br>
      * LineOptions.PROPERTY_LINE_BLUR - Float<br>
+     * LineOptions.PROPERTY_LINE_DASHARRAY - Float[]<br>
      * LineOptions.PROPERTY_LINE_PATTERN - String<br>
      * Learn more about above properties in the <a href="https://www.mapbox.com/mapbox-gl-js/style-spec/">Style specification</a>.
      * <p>
@@ -325,32 +336,6 @@ public class LineManager extends AnnotationManager<LineLayer, Line, LineOptions,
     public void setLineTranslateAnchor(@Property.LINE_TRANSLATE_ANCHOR String value) {
         PropertyValue propertyValue = lineTranslateAnchor(value);
         constantPropertyUsageMap.put(PROPERTY_LINE_TRANSLATE_ANCHOR, propertyValue);
-        layer.setProperties(propertyValue);
-    }
-
-    /**
-     * Get the LineDasharray property
-     * <p>
-     * Specifies the lengths of the alternating dashes and gaps that form the dash pattern. The lengths are later scaled by the line width. To convert a dash length to density-independent pixels, multiply the length by the current line width. Note that GeoJSON sources with `lineMetrics: true` specified won't render dashed lines to the expected scale. Also note that zoom-dependent expressions will be evaluated only at integer zoom levels.
-     * </p>
-     *
-     * @return property wrapper value around Float[]
-     */
-    public Float[] getLineDasharray() {
-        return layer.getLineDasharray().value;
-    }
-
-    /**
-     * Set the LineDasharray property
-     * <p>
-     * Specifies the lengths of the alternating dashes and gaps that form the dash pattern. The lengths are later scaled by the line width. To convert a dash length to density-independent pixels, multiply the length by the current line width. Note that GeoJSON sources with `lineMetrics: true` specified won't render dashed lines to the expected scale. Also note that zoom-dependent expressions will be evaluated only at integer zoom levels.
-     * </p>
-     *
-     * @param value property wrapper value around Float[]
-     */
-    public void setLineDasharray(Float[] value) {
-        PropertyValue propertyValue = lineDasharray(value);
-        constantPropertyUsageMap.put(PROPERTY_LINE_DASHARRAY, propertyValue);
         layer.setProperties(propertyValue);
     }
 

--- a/plugin-annotation/src/main/java/org/maplibre/android/plugins/annotation/LineOptions.java
+++ b/plugin-annotation/src/main/java/org/maplibre/android/plugins/annotation/LineOptions.java
@@ -29,21 +29,25 @@ public class LineOptions extends Options<Line> {
     private JsonElement data;
     private LineString geometry;
     private String lineJoin;
+    private Float lineSortKey;
     private Float lineOpacity;
     private String lineColor;
     private Float lineWidth;
     private Float lineGapWidth;
     private Float lineOffset;
     private Float lineBlur;
+    private Float[] lineDasharray;
     private String linePattern;
 
     static final String PROPERTY_LINE_JOIN = "line-join";
+    static final String PROPERTY_LINE_SORT_KEY = "line-sort-key";
     static final String PROPERTY_LINE_OPACITY = "line-opacity";
     static final String PROPERTY_LINE_COLOR = "line-color";
     static final String PROPERTY_LINE_WIDTH = "line-width";
     static final String PROPERTY_LINE_GAP_WIDTH = "line-gap-width";
     static final String PROPERTY_LINE_OFFSET = "line-offset";
     static final String PROPERTY_LINE_BLUR = "line-blur";
+    static final String PROPERTY_LINE_DASHARRAY = "line-dasharray";
     static final String PROPERTY_LINE_PATTERN = "line-pattern";
     private static final String PROPERTY_IS_DRAGGABLE = "is-draggable";
 
@@ -71,6 +75,32 @@ public class LineOptions extends Options<Line> {
      */
     public String getLineJoin() {
         return lineJoin;
+    }
+
+    /**
+     * Set line-sort-key to initialise the line with.
+     * <p>
+     * Sorts features in ascending order based on this value. Features with a higher sort key will appear above features with a lower sort key.
+     * </p>
+     *
+     * @param lineSortKey the line-sort-key value
+     * @return this
+     */
+    public LineOptions withLineSortKey(Float lineSortKey) {
+        this.lineSortKey = lineSortKey;
+        return this;
+    }
+
+    /**
+     * Get the current configured  line-sort-key for the line
+     * <p>
+     * Sorts features in ascending order based on this value. Features with a higher sort key will appear above features with a lower sort key.
+     * </p>
+     *
+     * @return lineSortKey value
+     */
+    public Float getLineSortKey() {
+        return lineSortKey;
     }
 
     /**
@@ -230,6 +260,32 @@ public class LineOptions extends Options<Line> {
     }
 
     /**
+     * Set line-dasharray to initialise the line with.
+     * <p>
+     * Specifies the lengths of the alternating dashes and gaps that form the dash pattern. The lengths are later scaled by the line width. To convert a dash length to density-independent pixels, multiply the length by the current line width. GeoJSON sources with `lineMetrics: true` specified won't render dashed lines to the expected scale. Zoom-dependent expressions will be evaluated only at integer zoom levels. The only way to create an array value is using `["literal", [...]]`; arrays cannot be read from or derived from feature properties.
+     * </p>
+     *
+     * @param lineDasharray the line-dasharray value
+     * @return this
+     */
+    public LineOptions withLineDasharray(Float[] lineDasharray) {
+        this.lineDasharray = lineDasharray;
+        return this;
+    }
+
+    /**
+     * Get the current configured  line-dasharray for the line
+     * <p>
+     * Specifies the lengths of the alternating dashes and gaps that form the dash pattern. The lengths are later scaled by the line width. To convert a dash length to density-independent pixels, multiply the length by the current line width. GeoJSON sources with `lineMetrics: true` specified won't render dashed lines to the expected scale. Zoom-dependent expressions will be evaluated only at integer zoom levels. The only way to create an array value is using `["literal", [...]]`; arrays cannot be read from or derived from feature properties.
+     * </p>
+     *
+     * @return lineDasharray value
+     */
+    public Float[] getLineDasharray() {
+        return lineDasharray;
+    }
+
+    /**
      * Set line-pattern to initialise the line with.
      * <p>
      * Name of image in sprite to use for drawing image lines. For seamless patterns, image width must be a factor of two (2, 4, 8, ..., 512). Note that zoom-dependent expressions will be evaluated only at integer zoom levels.
@@ -352,12 +408,14 @@ public class LineOptions extends Options<Line> {
         }
         JsonObject jsonObject = new JsonObject();
         jsonObject.addProperty(PROPERTY_LINE_JOIN, lineJoin);
+        jsonObject.addProperty(PROPERTY_LINE_SORT_KEY, lineSortKey);
         jsonObject.addProperty(PROPERTY_LINE_OPACITY, lineOpacity);
         jsonObject.addProperty(PROPERTY_LINE_COLOR, lineColor);
         jsonObject.addProperty(PROPERTY_LINE_WIDTH, lineWidth);
         jsonObject.addProperty(PROPERTY_LINE_GAP_WIDTH, lineGapWidth);
         jsonObject.addProperty(PROPERTY_LINE_OFFSET, lineOffset);
         jsonObject.addProperty(PROPERTY_LINE_BLUR, lineBlur);
+        jsonObject.add(PROPERTY_LINE_DASHARRAY, convertArray(lineDasharray));
         jsonObject.addProperty(PROPERTY_LINE_PATTERN, linePattern);
         Line line = new Line(id, annotationManager, jsonObject, geometry);
         line.setDraggable(isDraggable);
@@ -384,6 +442,9 @@ public class LineOptions extends Options<Line> {
         if (feature.hasProperty(PROPERTY_LINE_JOIN)) {
             options.lineJoin = feature.getProperty(PROPERTY_LINE_JOIN).getAsString();
         }
+        if (feature.hasProperty(PROPERTY_LINE_SORT_KEY)) {
+            options.lineSortKey = feature.getProperty(PROPERTY_LINE_SORT_KEY).getAsFloat();
+        }
         if (feature.hasProperty(PROPERTY_LINE_OPACITY)) {
             options.lineOpacity = feature.getProperty(PROPERTY_LINE_OPACITY).getAsFloat();
         }
@@ -401,6 +462,9 @@ public class LineOptions extends Options<Line> {
         }
         if (feature.hasProperty(PROPERTY_LINE_BLUR)) {
             options.lineBlur = feature.getProperty(PROPERTY_LINE_BLUR).getAsFloat();
+        }
+        if (feature.hasProperty(PROPERTY_LINE_DASHARRAY)) {
+            options.lineDasharray = toFloatArray(feature.getProperty(PROPERTY_LINE_DASHARRAY).getAsJsonArray());
         }
         if (feature.hasProperty(PROPERTY_LINE_PATTERN)) {
             options.linePattern = feature.getProperty(PROPERTY_LINE_PATTERN).getAsString();

--- a/plugin-annotation/src/main/java/org/maplibre/android/plugins/annotation/Symbol.java
+++ b/plugin-annotation/src/main/java/org/maplibre/android/plugins/annotation/Symbol.java
@@ -57,6 +57,9 @@ public class Symbol extends Annotation<Point> {
         if (!(jsonObject.get(SymbolOptions.PROPERTY_ICON_ROTATE) instanceof JsonNull)) {
             annotationManager.enableDataDrivenProperty(SymbolOptions.PROPERTY_ICON_ROTATE);
         }
+        if (!(jsonObject.get(SymbolOptions.PROPERTY_ICON_PADDING) instanceof JsonNull)) {
+            annotationManager.enableDataDrivenProperty(SymbolOptions.PROPERTY_ICON_PADDING);
+        }
         if (!(jsonObject.get(SymbolOptions.PROPERTY_ICON_OFFSET) instanceof JsonNull)) {
             annotationManager.enableDataDrivenProperty(SymbolOptions.PROPERTY_ICON_OFFSET);
         }
@@ -155,7 +158,7 @@ public class Symbol extends Annotation<Point> {
     /**
      * Get the SymbolSortKey property
      * <p>
-     * Sorts features in ascending order based on this value. Features with a higher sort key will appear above features with a lower sort key when they overlap. Features with a lower sort key will have priority over other features when doing placement.
+     * Sorts features in ascending order based on this value. Features with lower sort keys are drawn and placed first.  When {@link PropertyFactory#iconAllowOverlap} or {@link PropertyFactory#textAllowOverlap} is `false`, features with a lower sort key will have priority during placement. When {@link PropertyFactory#iconAllowOverlap} or {@link PropertyFactory#textAllowOverlap} is set to `true`, features with a higher sort key will overlap over features with a lower sort key.
      * </p>
      *
      * @return property wrapper value around Float
@@ -167,7 +170,7 @@ public class Symbol extends Annotation<Point> {
     /**
      * Set the SymbolSortKey property
      * <p>
-     * Sorts features in ascending order based on this value. Features with a higher sort key will appear above features with a lower sort key when they overlap. Features with a lower sort key will have priority over other features when doing placement.
+     * Sorts features in ascending order based on this value. Features with lower sort keys are drawn and placed first.  When {@link PropertyFactory#iconAllowOverlap} or {@link PropertyFactory#textAllowOverlap} is `false`, features with a lower sort key will have priority during placement. When {@link PropertyFactory#iconAllowOverlap} or {@link PropertyFactory#textAllowOverlap} is set to `true`, features with a higher sort key will overlap over features with a lower sort key.
      * </p>
      * <p>
      * To update the symbol on the map use {@link SymbolManager#update(Annotation)}.
@@ -261,6 +264,33 @@ public class Symbol extends Annotation<Point> {
     }
 
     /**
+     * Get the IconPadding property
+     * <p>
+     * Size of additional area round the icon bounding box used for detecting symbol collisions.
+     * </p>
+     *
+     * @return property wrapper value around Float
+     */
+    public Float getIconPadding() {
+        return jsonObject.get(SymbolOptions.PROPERTY_ICON_PADDING).getAsFloat();
+    }
+
+    /**
+     * Set the IconPadding property
+     * <p>
+     * Size of additional area round the icon bounding box used for detecting symbol collisions.
+     * </p>
+     * <p>
+     * To update the symbol on the map use {@link SymbolManager#update(Annotation)}.
+     * <p>
+     *
+     * @param value constant property value for Float
+     */
+    public void setIconPadding(Float value) {
+        jsonObject.addProperty(SymbolOptions.PROPERTY_ICON_PADDING, value);
+    }
+
+    /**
      * Get the IconOffset property
      * <p>
      * Offset distance of icon from its anchor. Positive values indicate right and down, while negative values indicate left and up. Each component is multiplied by the value of {@link PropertyFactory#iconSize} to obtain the final offset in density-independent pixels. When combined with {@link PropertyFactory#iconRotate} the offset will be as if the rotated direction was up.
@@ -348,7 +378,7 @@ public class Symbol extends Annotation<Point> {
     /**
      * Get the TextFont property
      * <p>
-     * Font stack to use for displaying text.
+     * Fonts to use for displaying text. If the `glyphs` root property is specified, this array is joined together and interpreted as a font stack name. Otherwise, it is interpreted as a cascading fallback list of local font names.
      * </p>
      *
      * @return property wrapper value around String[]
@@ -365,7 +395,7 @@ public class Symbol extends Annotation<Point> {
     /**
      * Set the TextFont property.
      * <p>
-     * Font stack to use for displaying text.
+     * Fonts to use for displaying text. If the `glyphs` root property is specified, this array is joined together and interpreted as a font stack name. Otherwise, it is interpreted as a cascading fallback list of local font names.
      * </p>
      * <p>
      * To update the symbol on the map use {@link SymbolManager#update(Annotation)}.
@@ -492,7 +522,7 @@ public class Symbol extends Annotation<Point> {
     /**
      * Get the TextRadialOffset property
      * <p>
-     * Radial offset of text, in the direction of the symbol's anchor. Useful in combination with {@link PropertyFactory#textVariableAnchor}, which doesn't support the two-dimensional {@link PropertyFactory#textOffset}.
+     * Radial offset of text, in the direction of the symbol's anchor. Useful in combination with {@link PropertyFactory#textVariableAnchor}, which defaults to using the two-dimensional {@link PropertyFactory#textOffset} if present.
      * </p>
      *
      * @return property wrapper value around Float
@@ -504,7 +534,7 @@ public class Symbol extends Annotation<Point> {
     /**
      * Set the TextRadialOffset property
      * <p>
-     * Radial offset of text, in the direction of the symbol's anchor. Useful in combination with {@link PropertyFactory#textVariableAnchor}, which doesn't support the two-dimensional {@link PropertyFactory#textOffset}.
+     * Radial offset of text, in the direction of the symbol's anchor. Useful in combination with {@link PropertyFactory#textVariableAnchor}, which defaults to using the two-dimensional {@link PropertyFactory#textOffset} if present.
      * </p>
      * <p>
      * To update the symbol on the map use {@link SymbolManager#update(Annotation)}.
@@ -600,7 +630,7 @@ public class Symbol extends Annotation<Point> {
     /**
      * Get the TextOffset property
      * <p>
-     * Offset distance of text from its anchor. Positive values indicate right and down, while negative values indicate left and up.
+     * Offset distance of text from its anchor. Positive values indicate right and down, while negative values indicate left and up. If used with text-variable-anchor, input values will be taken as absolute values. Offsets along the x- and y-axis will be applied automatically based on the anchor position.
      * </p>
      *
      * @return PointF value for Float[]
@@ -613,7 +643,7 @@ public class Symbol extends Annotation<Point> {
     /**
      * Set the TextOffset property.
      * <p>
-     * Offset distance of text from its anchor. Positive values indicate right and down, while negative values indicate left and up.
+     * Offset distance of text from its anchor. Positive values indicate right and down, while negative values indicate left and up. If used with text-variable-anchor, input values will be taken as absolute values. Offsets along the x- and y-axis will be applied automatically based on the anchor position.
      * </p>
      * <p>
      * To update the symbol on the map use {@link SymbolManager#update(Annotation)}.
@@ -658,7 +688,7 @@ public class Symbol extends Annotation<Point> {
     /**
      * Get the IconColor property
      * <p>
-     * The color of the icon. This can only be used with sdf icons.
+     * The color of the icon. This can only be used with SDF icons.
      * </p>
      *
      * @return color value for String
@@ -671,7 +701,7 @@ public class Symbol extends Annotation<Point> {
     /**
      * Get the IconColor property
      * <p>
-     * The color of the icon. This can only be used with sdf icons.
+     * The color of the icon. This can only be used with SDF icons.
      * </p>
      *
      * @return color value for String
@@ -683,7 +713,7 @@ public class Symbol extends Annotation<Point> {
     /**
      * Set the IconColor property
      * <p>
-     * The color of the icon. This can only be used with sdf icons.
+     * The color of the icon. This can only be used with SDF icons.
      * </p>
      * <p>
      * To update the symbol on the map use {@link SymbolManager#update(Annotation)}.
@@ -698,7 +728,7 @@ public class Symbol extends Annotation<Point> {
     /**
      * Set the IconColor property
      * <p>
-     * The color of the icon. This can only be used with sdf icons.
+     * The color of the icon. This can only be used with SDF icons.
      * </p>
      * <p>
      * To update the symbol on the map use {@link SymbolManager#update(Annotation)}.
@@ -768,7 +798,9 @@ public class Symbol extends Annotation<Point> {
     /**
      * Get the IconHaloWidth property
      * <p>
-     * Distance of halo to the icon outline.
+     * Distance of halo to the icon outline. 
+
+The unit is in density-independent pixels only for SDF sprites that were created with a blur radius of 8, multiplied by the display density. I.e., the radius needs to be 16 for `@2x` sprites, etc.
      * </p>
      *
      * @return property wrapper value around Float
@@ -780,7 +812,9 @@ public class Symbol extends Annotation<Point> {
     /**
      * Set the IconHaloWidth property
      * <p>
-     * Distance of halo to the icon outline.
+     * Distance of halo to the icon outline. 
+
+The unit is in density-independent pixels only for SDF sprites that were created with a blur radius of 8, multiplied by the display density. I.e., the radius needs to be 16 for `@2x` sprites, etc.
      * </p>
      * <p>
      * To update the symbol on the map use {@link SymbolManager#update(Annotation)}.

--- a/plugin-annotation/src/main/java/org/maplibre/android/plugins/annotation/SymbolManager.java
+++ b/plugin-annotation/src/main/java/org/maplibre/android/plugins/annotation/SymbolManager.java
@@ -39,7 +39,6 @@ public class SymbolManager extends AnnotationManager<SymbolLayer, Symbol, Symbol
     private static final String PROPERTY_ICON_ROTATION_ALIGNMENT = "icon-rotation-alignment";
     private static final String PROPERTY_ICON_TEXT_FIT = "icon-text-fit";
     private static final String PROPERTY_ICON_TEXT_FIT_PADDING = "icon-text-fit-padding";
-    private static final String PROPERTY_ICON_PADDING = "icon-padding";
     private static final String PROPERTY_ICON_KEEP_UPRIGHT = "icon-keep-upright";
     private static final String PROPERTY_ICON_PITCH_ALIGNMENT = "icon-pitch-alignment";
     private static final String PROPERTY_TEXT_PITCH_ALIGNMENT = "text-pitch-alignment";
@@ -47,6 +46,7 @@ public class SymbolManager extends AnnotationManager<SymbolLayer, Symbol, Symbol
     private static final String PROPERTY_TEXT_LINE_HEIGHT = "text-line-height";
     private static final String PROPERTY_TEXT_VARIABLE_ANCHOR = "text-variable-anchor";
     private static final String PROPERTY_TEXT_MAX_ANGLE = "text-max-angle";
+    private static final String PROPERTY_TEXT_WRITING_MODE = "text-writing-mode";
     private static final String PROPERTY_TEXT_PADDING = "text-padding";
     private static final String PROPERTY_TEXT_KEEP_UPRIGHT = "text-keep-upright";
     private static final String PROPERTY_TEXT_ALLOW_OVERLAP = "text-allow-overlap";
@@ -121,6 +121,7 @@ public class SymbolManager extends AnnotationManager<SymbolLayer, Symbol, Symbol
         dataDrivenPropertyUsageMap.put(SymbolOptions.PROPERTY_ICON_SIZE, false);
         dataDrivenPropertyUsageMap.put(SymbolOptions.PROPERTY_ICON_IMAGE, false);
         dataDrivenPropertyUsageMap.put(SymbolOptions.PROPERTY_ICON_ROTATE, false);
+        dataDrivenPropertyUsageMap.put(SymbolOptions.PROPERTY_ICON_PADDING, false);
         dataDrivenPropertyUsageMap.put(SymbolOptions.PROPERTY_ICON_OFFSET, false);
         dataDrivenPropertyUsageMap.put(SymbolOptions.PROPERTY_ICON_ANCHOR, false);
         dataDrivenPropertyUsageMap.put(SymbolOptions.PROPERTY_TEXT_FIELD, false);
@@ -160,6 +161,9 @@ public class SymbolManager extends AnnotationManager<SymbolLayer, Symbol, Symbol
                 break;
             case SymbolOptions.PROPERTY_ICON_ROTATE:
                 layer.setProperties(iconRotate(get(SymbolOptions.PROPERTY_ICON_ROTATE)));
+                break;
+            case SymbolOptions.PROPERTY_ICON_PADDING:
+                layer.setProperties(iconPadding(get(SymbolOptions.PROPERTY_ICON_PADDING)));
                 break;
             case SymbolOptions.PROPERTY_ICON_OFFSET:
                 layer.setProperties(iconOffset(get(SymbolOptions.PROPERTY_ICON_OFFSET)));
@@ -243,6 +247,7 @@ public class SymbolManager extends AnnotationManager<SymbolLayer, Symbol, Symbol
      * SymbolOptions.PROPERTY_ICON_SIZE - Float<br>
      * SymbolOptions.PROPERTY_ICON_IMAGE - String<br>
      * SymbolOptions.PROPERTY_ICON_ROTATE - Float<br>
+     * SymbolOptions.PROPERTY_ICON_PADDING - Float<br>
      * SymbolOptions.PROPERTY_ICON_OFFSET - Float[]<br>
      * SymbolOptions.PROPERTY_ICON_ANCHOR - String<br>
      * SymbolOptions.PROPERTY_TEXT_FIELD - String<br>
@@ -289,6 +294,7 @@ public class SymbolManager extends AnnotationManager<SymbolLayer, Symbol, Symbol
      * SymbolOptions.PROPERTY_ICON_SIZE - Float<br>
      * SymbolOptions.PROPERTY_ICON_IMAGE - String<br>
      * SymbolOptions.PROPERTY_ICON_ROTATE - Float<br>
+     * SymbolOptions.PROPERTY_ICON_PADDING - Float<br>
      * SymbolOptions.PROPERTY_ICON_OFFSET - Float[]<br>
      * SymbolOptions.PROPERTY_ICON_ANCHOR - String<br>
      * SymbolOptions.PROPERTY_TEXT_FIELD - String<br>
@@ -402,7 +408,7 @@ public class SymbolManager extends AnnotationManager<SymbolLayer, Symbol, Symbol
     /**
      * Get the SymbolAvoidEdges property
      * <p>
-     * If true, the symbols will not cross tile edges to avoid mutual collisions. Recommended in layers that don't have enough padding in the vector tile to prevent collisions, or if it is a point symbol layer placed after a line symbol layer.
+     * If true, the symbols will not cross tile edges to avoid mutual collisions. Recommended in layers that don't have enough padding in the vector tile to prevent collisions, or if it is a point symbol layer placed after a line symbol layer. When using a client that supports global collision detection, like MapLibre GL JS version 0.42.0 or greater, enabling this property is not needed to prevent clipped labels at tile boundaries.
      * </p>
      *
      * @return property wrapper value around Boolean
@@ -414,7 +420,7 @@ public class SymbolManager extends AnnotationManager<SymbolLayer, Symbol, Symbol
     /**
      * Set the SymbolAvoidEdges property
      * <p>
-     * If true, the symbols will not cross tile edges to avoid mutual collisions. Recommended in layers that don't have enough padding in the vector tile to prevent collisions, or if it is a point symbol layer placed after a line symbol layer.
+     * If true, the symbols will not cross tile edges to avoid mutual collisions. Recommended in layers that don't have enough padding in the vector tile to prevent collisions, or if it is a point symbol layer placed after a line symbol layer. When using a client that supports global collision detection, like MapLibre GL JS version 0.42.0 or greater, enabling this property is not needed to prevent clipped labels at tile boundaries.
      * </p>
      *
      * @param value property wrapper value around Boolean
@@ -582,33 +588,6 @@ public class SymbolManager extends AnnotationManager<SymbolLayer, Symbol, Symbol
     }
 
     /**
-     * Get the IconPadding property
-     * <p>
-     * Size of the additional area around the icon bounding box used for detecting symbol collisions.
-     * </p>
-     *
-     * @return property wrapper value around Float
-     */
-    public Float getIconPadding() {
-        Float[] values = layer.getIconPadding().value;
-        return (values != null && values.length > 0) ? values[0] : null;
-    }
-
-    /**
-     * Set the IconPadding property
-     * <p>
-     * Size of the additional area around the icon bounding box used for detecting symbol collisions.
-     * </p>
-     *
-     * @param value property wrapper value around Float
-     */
-    public void setIconPadding(Float value) {
-        PropertyValue propertyValue = iconPadding(value);
-        constantPropertyUsageMap.put(PROPERTY_ICON_PADDING, propertyValue);
-        layer.setProperties(propertyValue);
-    }
-
-    /**
      * Get the IconKeepUpright property
      * <p>
      * If true, the icon may be flipped to prevent it from being rendered upside-down.
@@ -741,7 +720,7 @@ public class SymbolManager extends AnnotationManager<SymbolLayer, Symbol, Symbol
     /**
      * Get the TextVariableAnchor property
      * <p>
-     * To increase the chance of placing high-priority labels on the map, you can provide an array of {@link Property.TEXT_ANCHOR} locations: the render will attempt to place the label at each location, in order, before moving onto the next label. Use `text-justify: auto` to choose justification based on anchor position. To apply an offset, use the {@link PropertyFactory#textRadialOffset} instead of the two-dimensional {@link PropertyFactory#textOffset}.
+     * To increase the chance of placing high-priority labels on the map, you can provide an array of {@link Property.TEXT_ANCHOR} locations: the renderer will attempt to place the label at each location, in order, before moving onto the next label. Use `text-justify: auto` to choose justification based on anchor position. To apply an offset, use the {@link PropertyFactory#textRadialOffset} or the two-dimensional {@link PropertyFactory#textOffset}.
      * </p>
      *
      * @return property wrapper value around String[]
@@ -753,7 +732,7 @@ public class SymbolManager extends AnnotationManager<SymbolLayer, Symbol, Symbol
     /**
      * Set the TextVariableAnchor property
      * <p>
-     * To increase the chance of placing high-priority labels on the map, you can provide an array of {@link Property.TEXT_ANCHOR} locations: the render will attempt to place the label at each location, in order, before moving onto the next label. Use `text-justify: auto` to choose justification based on anchor position. To apply an offset, use the {@link PropertyFactory#textRadialOffset} instead of the two-dimensional {@link PropertyFactory#textOffset}.
+     * To increase the chance of placing high-priority labels on the map, you can provide an array of {@link Property.TEXT_ANCHOR} locations: the renderer will attempt to place the label at each location, in order, before moving onto the next label. Use `text-justify: auto` to choose justification based on anchor position. To apply an offset, use the {@link PropertyFactory#textRadialOffset} or the two-dimensional {@link PropertyFactory#textOffset}.
      * </p>
      *
      * @param value property wrapper value around String[]
@@ -787,6 +766,32 @@ public class SymbolManager extends AnnotationManager<SymbolLayer, Symbol, Symbol
     public void setTextMaxAngle(Float value) {
         PropertyValue propertyValue = textMaxAngle(value);
         constantPropertyUsageMap.put(PROPERTY_TEXT_MAX_ANGLE, propertyValue);
+        layer.setProperties(propertyValue);
+    }
+
+    /**
+     * Get the TextWritingMode property
+     * <p>
+     * The property allows control over a symbol's orientation. Note that the property values act as a hint, so that a symbol whose language doesn’t support the provided orientation will be laid out in its natural orientation. Example: English point symbol will be rendered horizontally even if array value contains single 'vertical' enum value. The order of elements in an array define priority order for the placement of an orientation variant.
+     * </p>
+     *
+     * @return property wrapper value around String[]
+     */
+    public String[] getTextWritingMode() {
+        return layer.getTextWritingMode().value;
+    }
+
+    /**
+     * Set the TextWritingMode property
+     * <p>
+     * The property allows control over a symbol's orientation. Note that the property values act as a hint, so that a symbol whose language doesn’t support the provided orientation will be laid out in its natural orientation. Example: English point symbol will be rendered horizontally even if array value contains single 'vertical' enum value. The order of elements in an array define priority order for the placement of an orientation variant.
+     * </p>
+     *
+     * @param value property wrapper value around String[]
+     */
+    public void setTextWritingMode(String[] value) {
+        PropertyValue propertyValue = textWritingMode(value);
+        constantPropertyUsageMap.put(PROPERTY_TEXT_WRITING_MODE, propertyValue);
         layer.setProperties(propertyValue);
     }
 

--- a/plugin-annotation/src/main/java/org/maplibre/android/plugins/annotation/SymbolManager.java
+++ b/plugin-annotation/src/main/java/org/maplibre/android/plugins/annotation/SymbolManager.java
@@ -590,7 +590,8 @@ public class SymbolManager extends AnnotationManager<SymbolLayer, Symbol, Symbol
      * @return property wrapper value around Float
      */
     public Float getIconPadding() {
-        return layer.getIconPadding().value;
+        Float[] values = layer.getIconPadding().value;
+        return (values != null && values.length > 0) ? values[0] : null;
     }
 
     /**

--- a/plugin-annotation/src/main/java/org/maplibre/android/plugins/annotation/SymbolOptions.java
+++ b/plugin-annotation/src/main/java/org/maplibre/android/plugins/annotation/SymbolOptions.java
@@ -32,6 +32,7 @@ public class SymbolOptions extends Options<Symbol> {
     private Float iconSize;
     private String iconImage;
     private Float iconRotate;
+    private Float iconPadding;
     private Float[] iconOffset;
     private String iconAnchor;
     private String textField;
@@ -60,6 +61,7 @@ public class SymbolOptions extends Options<Symbol> {
     static final String PROPERTY_ICON_SIZE = "icon-size";
     static final String PROPERTY_ICON_IMAGE = "icon-image";
     static final String PROPERTY_ICON_ROTATE = "icon-rotate";
+    static final String PROPERTY_ICON_PADDING = "icon-padding";
     static final String PROPERTY_ICON_OFFSET = "icon-offset";
     static final String PROPERTY_ICON_ANCHOR = "icon-anchor";
     static final String PROPERTY_TEXT_FIELD = "text-field";
@@ -88,7 +90,7 @@ public class SymbolOptions extends Options<Symbol> {
     /**
      * Set symbol-sort-key to initialise the symbol with.
      * <p>
-     * Sorts features in ascending order based on this value. Features with a higher sort key will appear above features with a lower sort key when they overlap. Features with a lower sort key will have priority over other features when doing placement.
+     * Sorts features in ascending order based on this value. Features with lower sort keys are drawn and placed first.  When {@link PropertyFactory#iconAllowOverlap} or {@link PropertyFactory#textAllowOverlap} is `false`, features with a lower sort key will have priority during placement. When {@link PropertyFactory#iconAllowOverlap} or {@link PropertyFactory#textAllowOverlap} is set to `true`, features with a higher sort key will overlap over features with a lower sort key.
      * </p>
      *
      * @param symbolSortKey the symbol-sort-key value
@@ -102,7 +104,7 @@ public class SymbolOptions extends Options<Symbol> {
     /**
      * Get the current configured  symbol-sort-key for the symbol
      * <p>
-     * Sorts features in ascending order based on this value. Features with a higher sort key will appear above features with a lower sort key when they overlap. Features with a lower sort key will have priority over other features when doing placement.
+     * Sorts features in ascending order based on this value. Features with lower sort keys are drawn and placed first.  When {@link PropertyFactory#iconAllowOverlap} or {@link PropertyFactory#textAllowOverlap} is `false`, features with a lower sort key will have priority during placement. When {@link PropertyFactory#iconAllowOverlap} or {@link PropertyFactory#textAllowOverlap} is set to `true`, features with a higher sort key will overlap over features with a lower sort key.
      * </p>
      *
      * @return symbolSortKey value
@@ -190,6 +192,32 @@ public class SymbolOptions extends Options<Symbol> {
     }
 
     /**
+     * Set icon-padding to initialise the symbol with.
+     * <p>
+     * Size of additional area round the icon bounding box used for detecting symbol collisions.
+     * </p>
+     *
+     * @param iconPadding the icon-padding value
+     * @return this
+     */
+    public SymbolOptions withIconPadding(Float iconPadding) {
+        this.iconPadding = iconPadding;
+        return this;
+    }
+
+    /**
+     * Get the current configured  icon-padding for the symbol
+     * <p>
+     * Size of additional area round the icon bounding box used for detecting symbol collisions.
+     * </p>
+     *
+     * @return iconPadding value
+     */
+    public Float getIconPadding() {
+        return iconPadding;
+    }
+
+    /**
      * Set icon-offset to initialise the symbol with.
      * <p>
      * Offset distance of icon from its anchor. Positive values indicate right and down, while negative values indicate left and up. Each component is multiplied by the value of {@link PropertyFactory#iconSize} to obtain the final offset in density-independent pixels. When combined with {@link PropertyFactory#iconRotate} the offset will be as if the rotated direction was up.
@@ -270,7 +298,7 @@ public class SymbolOptions extends Options<Symbol> {
     /**
      * Set text-font to initialise the symbol with.
      * <p>
-     * Font stack to use for displaying text.
+     * Fonts to use for displaying text. If the `glyphs` root property is specified, this array is joined together and interpreted as a font stack name. Otherwise, it is interpreted as a cascading fallback list of local font names.
      * </p>
      *
      * @param textFont the text-font value
@@ -284,7 +312,7 @@ public class SymbolOptions extends Options<Symbol> {
     /**
      * Get the current configured  text-font for the symbol
      * <p>
-     * Font stack to use for displaying text.
+     * Fonts to use for displaying text. If the `glyphs` root property is specified, this array is joined together and interpreted as a font stack name. Otherwise, it is interpreted as a cascading fallback list of local font names.
      * </p>
      *
      * @return textFont value
@@ -400,7 +428,7 @@ public class SymbolOptions extends Options<Symbol> {
     /**
      * Set text-radial-offset to initialise the symbol with.
      * <p>
-     * Radial offset of text, in the direction of the symbol's anchor. Useful in combination with {@link PropertyFactory#textVariableAnchor}, which doesn't support the two-dimensional {@link PropertyFactory#textOffset}.
+     * Radial offset of text, in the direction of the symbol's anchor. Useful in combination with {@link PropertyFactory#textVariableAnchor}, which defaults to using the two-dimensional {@link PropertyFactory#textOffset} if present.
      * </p>
      *
      * @param textRadialOffset the text-radial-offset value
@@ -414,7 +442,7 @@ public class SymbolOptions extends Options<Symbol> {
     /**
      * Get the current configured  text-radial-offset for the symbol
      * <p>
-     * Radial offset of text, in the direction of the symbol's anchor. Useful in combination with {@link PropertyFactory#textVariableAnchor}, which doesn't support the two-dimensional {@link PropertyFactory#textOffset}.
+     * Radial offset of text, in the direction of the symbol's anchor. Useful in combination with {@link PropertyFactory#textVariableAnchor}, which defaults to using the two-dimensional {@link PropertyFactory#textOffset} if present.
      * </p>
      *
      * @return textRadialOffset value
@@ -504,7 +532,7 @@ public class SymbolOptions extends Options<Symbol> {
     /**
      * Set text-offset to initialise the symbol with.
      * <p>
-     * Offset distance of text from its anchor. Positive values indicate right and down, while negative values indicate left and up.
+     * Offset distance of text from its anchor. Positive values indicate right and down, while negative values indicate left and up. If used with text-variable-anchor, input values will be taken as absolute values. Offsets along the x- and y-axis will be applied automatically based on the anchor position.
      * </p>
      *
      * @param textOffset the text-offset value
@@ -518,7 +546,7 @@ public class SymbolOptions extends Options<Symbol> {
     /**
      * Get the current configured  text-offset for the symbol
      * <p>
-     * Offset distance of text from its anchor. Positive values indicate right and down, while negative values indicate left and up.
+     * Offset distance of text from its anchor. Positive values indicate right and down, while negative values indicate left and up. If used with text-variable-anchor, input values will be taken as absolute values. Offsets along the x- and y-axis will be applied automatically based on the anchor position.
      * </p>
      *
      * @return textOffset value
@@ -556,7 +584,7 @@ public class SymbolOptions extends Options<Symbol> {
     /**
      * Set icon-color to initialise the symbol with.
      * <p>
-     * The color of the icon. This can only be used with sdf icons.
+     * The color of the icon. This can only be used with SDF icons.
      * </p>
      *
      * @param iconColor the icon-color value
@@ -570,7 +598,7 @@ public class SymbolOptions extends Options<Symbol> {
     /**
      * Get the current configured  icon-color for the symbol
      * <p>
-     * The color of the icon. This can only be used with sdf icons.
+     * The color of the icon. This can only be used with SDF icons.
      * </p>
      *
      * @return iconColor value
@@ -608,7 +636,9 @@ public class SymbolOptions extends Options<Symbol> {
     /**
      * Set icon-halo-width to initialise the symbol with.
      * <p>
-     * Distance of halo to the icon outline.
+     * Distance of halo to the icon outline. 
+
+The unit is in density-independent pixels only for SDF sprites that were created with a blur radius of 8, multiplied by the display density. I.e., the radius needs to be 16 for `@2x` sprites, etc.
      * </p>
      *
      * @param iconHaloWidth the icon-halo-width value
@@ -622,7 +652,9 @@ public class SymbolOptions extends Options<Symbol> {
     /**
      * Get the current configured  icon-halo-width for the symbol
      * <p>
-     * Distance of halo to the icon outline.
+     * Distance of halo to the icon outline. 
+
+The unit is in density-independent pixels only for SDF sprites that were created with a blur radius of 8, multiplied by the display density. I.e., the radius needs to be 16 for `@2x` sprites, etc.
      * </p>
      *
      * @return iconHaloWidth value
@@ -880,6 +912,7 @@ public class SymbolOptions extends Options<Symbol> {
         jsonObject.addProperty(PROPERTY_ICON_SIZE, iconSize);
         jsonObject.addProperty(PROPERTY_ICON_IMAGE, iconImage);
         jsonObject.addProperty(PROPERTY_ICON_ROTATE, iconRotate);
+        jsonObject.addProperty(PROPERTY_ICON_PADDING, iconPadding);
         jsonObject.add(PROPERTY_ICON_OFFSET, convertArray(iconOffset));
         jsonObject.addProperty(PROPERTY_ICON_ANCHOR, iconAnchor);
         jsonObject.addProperty(PROPERTY_TEXT_FIELD, textField);
@@ -936,6 +969,9 @@ public class SymbolOptions extends Options<Symbol> {
         }
         if (feature.hasProperty(PROPERTY_ICON_ROTATE)) {
             options.iconRotate = feature.getProperty(PROPERTY_ICON_ROTATE).getAsFloat();
+        }
+        if (feature.hasProperty(PROPERTY_ICON_PADDING)) {
+            options.iconPadding = feature.getProperty(PROPERTY_ICON_PADDING).getAsFloat();
         }
         if (feature.hasProperty(PROPERTY_ICON_OFFSET)) {
             options.iconOffset = toFloatArray(feature.getProperty(PROPERTY_ICON_OFFSET).getAsJsonArray());

--- a/plugin-annotation/src/test/java/org/maplibre/android/plugins/annotation/CircleManagerTest.java
+++ b/plugin-annotation/src/test/java/org/maplibre/android/plugins/annotation/CircleManagerTest.java
@@ -151,6 +151,7 @@ public class CircleManagerTest {
         Geometry geometry = Point.fromLngLat(10, 10);
 
         Feature feature = Feature.fromGeometry(geometry);
+        feature.addNumberProperty("circle-sort-key", 2.0f);
         feature.addNumberProperty("circle-radius", 2.0f);
         feature.addStringProperty("circle-color", "rgba(0, 0, 0, 1)");
         feature.addNumberProperty("circle-blur", 2.0f);
@@ -164,6 +165,7 @@ public class CircleManagerTest {
         Circle circle = circles.get(0);
 
         assertEquals(circle.geometry, geometry);
+        assertEquals(circle.getCircleSortKey(), 2.0f);
         assertEquals(circle.getCircleRadius(), 2.0f);
         assertEquals(circle.getCircleColor(), "rgba(0, 0, 0, 1)");
         assertEquals(circle.getCircleBlur(), 2.0f);
@@ -230,6 +232,20 @@ public class CircleManagerTest {
         assertFalse(circleZero.isDraggable());
     }
 
+
+    @Test
+    public void testCircleSortKeyLayerProperty() {
+        circleManager = new CircleManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        verify(circleLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(circleSortKey(get("circle-sort-key")))));
+
+        CircleOptions options = new CircleOptions().withLatLng(new LatLng()).withCircleSortKey(2.0f);
+        circleManager.create(options);
+        circleManager.updateSourceNow();
+        verify(circleLayer, times(1)).setProperties(argThat(new PropertyValueMatcher(circleSortKey(get("circle-sort-key")))));
+
+        circleManager.create(options);
+        verify(circleLayer, times(1)).setProperties(argThat(new PropertyValueMatcher(circleSortKey(get("circle-sort-key")))));
+    }
 
     @Test
     public void testCircleRadiusLayerProperty() {

--- a/plugin-annotation/src/test/java/org/maplibre/android/plugins/annotation/FillManagerTest.java
+++ b/plugin-annotation/src/test/java/org/maplibre/android/plugins/annotation/FillManagerTest.java
@@ -165,6 +165,7 @@ public class FillManagerTest {
         Geometry geometry = Polygon.fromLngLats(points);
 
         Feature feature = Feature.fromGeometry(geometry);
+        feature.addNumberProperty("fill-sort-key", 2.0f);
         feature.addNumberProperty("fill-opacity", 2.0f);
         feature.addStringProperty("fill-color", "rgba(0, 0, 0, 1)");
         feature.addStringProperty("fill-outline-color", "rgba(0, 0, 0, 1)");
@@ -175,6 +176,7 @@ public class FillManagerTest {
         Fill fill = fills.get(0);
 
         assertEquals(fill.geometry, geometry);
+        assertEquals(fill.getFillSortKey(), 2.0f);
         assertEquals(fill.getFillOpacity(), 2.0f);
         assertEquals(fill.getFillColor(), "rgba(0, 0, 0, 1)");
         assertEquals(fill.getFillOutlineColor(), "rgba(0, 0, 0, 1)");
@@ -294,6 +296,26 @@ public class FillManagerTest {
         assertFalse(fillZero.isDraggable());
     }
 
+
+    @Test
+    public void testFillSortKeyLayerProperty() {
+        fillManager = new FillManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        verify(fillLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(fillSortKey(get("fill-sort-key")))));
+
+        List<LatLng> innerLatLngs = new ArrayList<>();
+        innerLatLngs.add(new LatLng());
+        innerLatLngs.add(new LatLng(1, 1));
+        innerLatLngs.add(new LatLng(-1, -1));
+        List<List<LatLng>> latLngs = new ArrayList<>();
+        latLngs.add(innerLatLngs);
+        FillOptions options = new FillOptions().withLatLngs(latLngs).withFillSortKey(2.0f);
+        fillManager.create(options);
+        fillManager.updateSourceNow();
+        verify(fillLayer, times(1)).setProperties(argThat(new PropertyValueMatcher(fillSortKey(get("fill-sort-key")))));
+
+        fillManager.create(options);
+        verify(fillLayer, times(1)).setProperties(argThat(new PropertyValueMatcher(fillSortKey(get("fill-sort-key")))));
+    }
 
     @Test
     public void testFillOpacityLayerProperty() {

--- a/plugin-annotation/src/test/java/org/maplibre/android/plugins/annotation/LineManagerTest.java
+++ b/plugin-annotation/src/test/java/org/maplibre/android/plugins/annotation/LineManagerTest.java
@@ -158,12 +158,14 @@ public class LineManagerTest {
 
         Feature feature = Feature.fromGeometry(geometry);
         feature.addStringProperty("line-join", LINE_JOIN_BEVEL);
+        feature.addNumberProperty("line-sort-key", 2.0f);
         feature.addNumberProperty("line-opacity", 2.0f);
         feature.addStringProperty("line-color", "rgba(0, 0, 0, 1)");
         feature.addNumberProperty("line-width", 2.0f);
         feature.addNumberProperty("line-gap-width", 2.0f);
         feature.addNumberProperty("line-offset", 2.0f);
         feature.addNumberProperty("line-blur", 2.0f);
+        feature.addProperty("line-dasharray", convertArray(new Float[]{}));
         feature.addStringProperty("line-pattern", "pedestrian-polygon");
         feature.addBooleanProperty("is-draggable", true);
 
@@ -172,12 +174,14 @@ public class LineManagerTest {
 
         assertEquals(line.geometry, geometry);
         assertEquals(line.getLineJoin(), LINE_JOIN_BEVEL);
+        assertEquals(line.getLineSortKey(), 2.0f);
         assertEquals(line.getLineOpacity(), 2.0f);
         assertEquals(line.getLineColor(), "rgba(0, 0, 0, 1)");
         assertEquals(line.getLineWidth(), 2.0f);
         assertEquals(line.getLineGapWidth(), 2.0f);
         assertEquals(line.getLineOffset(), 2.0f);
         assertEquals(line.getLineBlur(), 2.0f);
+        assertTrue(Arrays.equals(line.getLineDasharray(), new Float[]{}));
         assertEquals(line.getLinePattern(), "pedestrian-polygon");
         assertTrue(line.isDraggable());
     }
@@ -280,6 +284,23 @@ public class LineManagerTest {
     }
 
     @Test
+    public void testLineSortKeyLayerProperty() {
+        lineManager = new LineManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        verify(lineLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(lineSortKey(get("line-sort-key")))));
+
+        List<LatLng> latLngs = new ArrayList<>();
+        latLngs.add(new LatLng());
+        latLngs.add(new LatLng(1, 1));
+        LineOptions options = new LineOptions().withLatLngs(latLngs).withLineSortKey(2.0f);
+        lineManager.create(options);
+        lineManager.updateSourceNow();
+        verify(lineLayer, times(1)).setProperties(argThat(new PropertyValueMatcher(lineSortKey(get("line-sort-key")))));
+
+        lineManager.create(options);
+        verify(lineLayer, times(1)).setProperties(argThat(new PropertyValueMatcher(lineSortKey(get("line-sort-key")))));
+    }
+
+    @Test
     public void testLineOpacityLayerProperty() {
         lineManager = new LineManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
         verify(lineLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(lineOpacity(get("line-opacity")))));
@@ -379,6 +400,23 @@ public class LineManagerTest {
 
         lineManager.create(options);
         verify(lineLayer, times(1)).setProperties(argThat(new PropertyValueMatcher(lineBlur(get("line-blur")))));
+    }
+
+    @Test
+    public void testLineDasharrayLayerProperty() {
+        lineManager = new LineManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        verify(lineLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(lineDasharray(get("line-dasharray")))));
+
+        List<LatLng> latLngs = new ArrayList<>();
+        latLngs.add(new LatLng());
+        latLngs.add(new LatLng(1, 1));
+        LineOptions options = new LineOptions().withLatLngs(latLngs).withLineDasharray(new Float[]{});
+        lineManager.create(options);
+        lineManager.updateSourceNow();
+        verify(lineLayer, times(1)).setProperties(argThat(new PropertyValueMatcher(lineDasharray(get("line-dasharray")))));
+
+        lineManager.create(options);
+        verify(lineLayer, times(1)).setProperties(argThat(new PropertyValueMatcher(lineDasharray(get("line-dasharray")))));
     }
 
     @Test

--- a/plugin-annotation/src/test/java/org/maplibre/android/plugins/annotation/SymbolManagerTest.java
+++ b/plugin-annotation/src/test/java/org/maplibre/android/plugins/annotation/SymbolManagerTest.java
@@ -155,6 +155,7 @@ public class SymbolManagerTest {
         feature.addNumberProperty("icon-size", 2.0f);
         feature.addStringProperty("icon-image", "undefined");
         feature.addNumberProperty("icon-rotate", 2.0f);
+        feature.addNumberProperty("icon-padding", 2.0f);
         feature.addProperty("icon-offset", convertArray(new Float[]{0f, 0f}));
         feature.addStringProperty("icon-anchor", ICON_ANCHOR_CENTER);
         feature.addStringProperty("text-field", "");
@@ -188,6 +189,7 @@ public class SymbolManagerTest {
         assertEquals(symbol.getIconSize(), 2.0f);
         assertEquals(symbol.getIconImage(), "undefined");
         assertEquals(symbol.getIconRotate(), 2.0f);
+        assertEquals(symbol.getIconPadding(), 2.0f);
         PointF iconOffsetExpected = new PointF(new Float[]{0f, 0f}[0], new Float[]{0f, 0f}[1]);
         assertEquals(iconOffsetExpected.x, symbol.getIconOffset().x);
         assertEquals(iconOffsetExpected.y, symbol.getIconOffset().y);
@@ -329,6 +331,20 @@ public class SymbolManagerTest {
 
         symbolManager.create(options);
         verify(symbolLayer, times(1)).setProperties(argThat(new PropertyValueMatcher(iconRotate(get("icon-rotate")))));
+    }
+
+    @Test
+    public void testIconPaddingLayerProperty() {
+        symbolManager = new SymbolManager(mapView, maplibreMap, style, coreElementProvider, null, null, null, draggableAnnotationController);
+        verify(symbolLayer, times(0)).setProperties(argThat(new PropertyValueMatcher(iconPadding(get("icon-padding")))));
+
+        SymbolOptions options = new SymbolOptions().withLatLng(new LatLng()).withIconPadding(2.0f);
+        symbolManager.create(options);
+        symbolManager.updateSourceNow();
+        verify(symbolLayer, times(1)).setProperties(argThat(new PropertyValueMatcher(iconPadding(get("icon-padding")))));
+
+        symbolManager.create(options);
+        verify(symbolLayer, times(1)).setProperties(argThat(new PropertyValueMatcher(iconPadding(get("icon-padding")))));
     }
 
     @Test


### PR DESCRIPTION
Problem:

The MapLibre Android SDK v11.3.0 we depend on is outdated. I wanted to move us to v13.1.0 to pick up newer style-spec features and keep us aligned with upstream.

What I changed with AI Agent (Claude)

  Dependencies
  - mapLibreAndroidSdk: 11.3.0 -> 13.1.0
  - minSdkVersion: 21 -> 23 (required by maplibre v12+)
  - Kotlin plugin: 2.0.0 -> 2.2.0 (SDK 13.x is built with Kotlin 2.2.0)
  - mapLibreGeoJson / mapLibreTurf: 5.9.0 -> 6.0.1
  - mapLibreCore: kept at 5.9.0 - 6.0.1 isn't published to Maven Central yet
  - Split mapLibreJava into per-artifact version keys

  Annotation code generation

  The plugin's annotation classes are generated from the style spec. The old gl-js submodule (a 2019 Mapbox-era snapshot) had drifted from what SDK v13 actually expects.
  For example, icon-padding is now a padding type that returns Float[], so SymbolManager had to be hand-patched and no longer matched the generator output - which broke
  the nitpick check.

  I repointed the submodule to the spec the SDK is built from: maplibre-native android-v13.1.0 depends on @maplibre/maplibre-gl-style-spec ^24.7.0, so I moved it to
  v24.7.0 and renamed gl-js -> maplibre-style-spec. Now every generated property maps to a real SDK method.

  Changes I made to code-gen.js:
  - Generate only Android-supported properties - skip ones whose sdk-support.android is a GitHub issue URL (e.g. icon-overlap, text-overlap). This mirrors the
  maplibre-native generator.
  - Added types: padding -> Float, resolvedImage -> String.
  - Skip text-variable-anchor-offset (no per-feature representation).
  - Handle array-of-enum defaults (text-writing-mode).
  - isPointFProperty(): only fixed 2-element arrays (icon-offset / text-offset) become PointF; variable-length arrays (line-dasharray) stay plain Float[].
  
How I verified

  - nitpick passes (code-gen is idempotent)
  - compiles against SDK 13.1.0
  - 143/143 unit tests pass
  - checkstyle + ktlint clean
  - release build OK
  
AI usage disclosure

  In line with the MapLibre AI policy: I used Claude Opus 4.7/4.8 to assist with the code-gen.js changes. I reviewed, tested, and verified all generated code myself and take responsibility for its correctness.