### PR TITLE
Rework publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,18 +28,10 @@ jobs:
       - name: Build Plugins SDK
         run: make build-release
 
-      - name: Prepare MavenCentral release
-        env:
-          GPG_KEY_CONTENTS: ${{ secrets.GPG_KEY_CONTENTS }}
-        run: |
-          echo "${GPG_KEY_CONTENTS}" | base64 -d > signing-key.gpg
-        shell: bash
-
       - name: Publish to MavenCentral
         run: make publish
         env:
-          OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-          OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
-          SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
-          SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
-          SONATYPE_STAGING_PROFILE_ID: ${{ secrets.SONATYPE_STAGING_PROFILE_ID }}
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_PRIVATE_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_PASSWORD }}

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ javadoc:
 	./gradlew javadocrelease
 
 publish:
-	./gradlew publishReleasePublicationToSonatypeRepository closeAndReleaseSonatypeStagingRepository
+	./gradlew publishReleasePublicationToMavenCentralRepository
 
 generate-sanity-test:
 	npm install && node scripts/generate-activity-test.js

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,3 @@
-apply plugin: 'io.github.gradle-nexus.publish-plugin'
-
 buildscript {
   apply from: "${rootDir}/gradle/dependencies.gradle"
 
@@ -15,7 +13,7 @@ buildscript {
     classpath 'com.android.tools.build:gradle:8.6.0'
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:2.2.0"
     classpath "org.jlleitschuh.gradle:ktlint-gradle:8.1.0"
-    classpath "io.github.gradle-nexus:publish-plugin:2.0.0"
+    classpath "com.vanniktech:gradle-maven-publish-plugin:0.34.0"
   }
 }
 
@@ -46,16 +44,3 @@ task clean(type: Delete) {
   delete rootProject.buildDir
 }
 
-apply from: "${rootDir}/gradle/publish-root.gradle"
-// Set up Sonatype repository
-nexusPublishing {
-    repositories {
-        sonatype {
-            stagingProfileId = sonatypeStagingProfileId
-            username = ossrhUsername
-            password = ossrhPassword
-            nexusUrl.set(uri("https://s01.oss.sonatype.org/service/local/"))
-            snapshotRepositoryUrl.set(uri("https://s01.oss.sonatype.org/content/repositories/snapshots/"))            
-        }
-    }
-}

--- a/gradle/publish-root.gradle
+++ b/gradle/publish-root.gradle
@@ -1,7 +1,0 @@
-ext["signing.secretKeyRingFile"] = "${projectDir}/../signing-key.gpg"
-
-ext["ossrhUsername"] = System.getenv('OSSRH_USERNAME')
-ext["ossrhPassword"] = System.getenv('OSSRH_PASSWORD')
-ext["sonatypeStagingProfileId"] = System.getenv('SONATYPE_STAGING_PROFILE_ID')
-ext["signing.keyId"] = System.getenv('SIGNING_KEY_ID')
-ext["signing.password"] = System.getenv('SIGNING_PASSWORD')

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -1,12 +1,15 @@
-apply plugin: 'maven-publish'
-apply plugin: 'signing'
+apply plugin: 'com.vanniktech.maven.publish.base'
 apply from: '../gradle/artifact-settings.gradle'
-apply from: '../gradle/publish-root.gradle'
 
 version = project.ext.versionName
 group = project.ext.mapLibreArtifactGroupId
 
 afterEvaluate {
+    mavenPublishing {
+        publishToMavenCentral(true)
+        signAllPublications()
+    }
+
     publishing {
         publications {
             release(MavenPublication) {
@@ -44,8 +47,4 @@ afterEvaluate {
             }
         }
     }
-}
-
-signing {
-    sign publishing.publications
 }

--- a/ktx-mapbox-maps/gradle.properties
+++ b/ktx-mapbox-maps/gradle.properties
@@ -1,4 +1,4 @@
 VERSION_NAME=0.1.0-SNAPSHOT
-POM_ARTIFACT_ID=android-sdk-ktx-v7
+POM_ARTIFACT_ID=android-sdk-ktx
 POM_NAME=MapLibre Maps SDK for Android KTX
 POM_DESCRIPTION=A set of Kotlin extensions for the MapLibre Maps SDK for Android.

--- a/plugin-annotation/CHANGELOG.md
+++ b/plugin-annotation/CHANGELOG.md
@@ -1,75 +1,79 @@
-# Changelog for the Mapbox Annotation Plugin
+# Changelog for the MapLibre Annotation Plugin
 
-Mapbox welcomes participation and contributions from everyone.
+MapLibre welcomes participation and contributions from everyone.
 
-### mapbox-android-plugin-annotation-v9:0.9.0 - August 13, 2020
+### maplibre-android-plugin-annotation:4.0.0 - May 29, 2026
+- Targets MapLibre Android 13.1.0
+- Published to Maven Central via the vanniktech maven-publish plugin
+
+### maplibre-android-plugin-annotation-v9:0.9.0 - August 13, 2020
 #### Bugs
-- Consumable events for click listeners [1124](https://github.com/mapbox/mapbox-plugins-android/pull/1124)
-- Support multiple manager to be draggable [1125](https://github.com/mapbox/mapbox-plugins-android/pull/1125)
-- End of drag event is consumed [1141](https://github.com/mapbox/mapbox-plugins-android/pull/1141)
+- Consumable events for click listeners [1124](https://github.com/mapbox/maplibre-plugins-android/pull/1124)
+- Support multiple manager to be draggable [1125](https://github.com/mapbox/maplibre-plugins-android/pull/1125)
+- End of drag event is consumed [1141](https://github.com/mapbox/maplibre-plugins-android/pull/1141)
 
-### mapbox-android-plugin-annotation-v9:0.8.0 - March 5, 2020
+### maplibre-android-plugin-annotation-v9:0.8.0 - March 5, 2020
 #### Features
-- Switching all plugins to AndroidX [#1100](https://github.com/mapbox/mapbox-plugins-android/pull/1100)
-- Expose underlying, generated Layer ID [#1071](https://github.com/mapbox/mapbox-plugins-android/pull/1071)
+- Switching all plugins to AndroidX [#1100](https://github.com/mapbox/maplibre-plugins-android/pull/1100)
+- Expose underlying, generated Layer ID [#1071](https://github.com/mapbox/maplibre-plugins-android/pull/1071)
 
-### mapbox-android-plugin-annotation-v8:0.7.0 - June 11, 2019
+### maplibre-android-plugin-annotation-v8:0.7.0 - June 11, 2019
 #### Features
-- uppercase static fields [#939](https://github.com/mapbox/mapbox-plugins-android/pull/939)
-- add multi manager support [#941](https://github.com/mapbox/mapbox-plugins-android/pull/941)
-- add getGeometry [#940](https://github.com/mapbox/mapbox-plugins-android/pull/940)
-- remove java 8 language support [#943](https://github.com/mapbox/mapbox-plugins-android/pull/943)
-- allow to set custom arbitrary data on an annotation [#948](https://github.com/mapbox/mapbox-plugins-android/pull/948)
-- Update style spec, gen new features, remove obsolete zIndex [#947](https://github.com/mapbox/mapbox-plugins-android/pull/947)
+- uppercase static fields [#939](https://github.com/mapbox/maplibre-plugins-android/pull/939)
+- add multi manager support [#941](https://github.com/mapbox/maplibre-plugins-android/pull/941)
+- add getGeometry [#940](https://github.com/mapbox/maplibre-plugins-android/pull/940)
+- remove java 8 language support [#943](https://github.com/mapbox/maplibre-plugins-android/pull/943)
+- allow to set custom arbitrary data on an annotation [#948](https://github.com/mapbox/maplibre-plugins-android/pull/948)
+- Update style spec, gen new features, remove obsolete zIndex [#947](https://github.com/mapbox/maplibre-plugins-android/pull/947)
 
-### mapbox-android-plugin-annotation-v7:0.6.0 - April 5, 2019
+### maplibre-android-plugin-annotation-v7:0.6.0 - April 5, 2019
 #### Features
-- Maps SDK bump to 7.3.0 [#895](https://github.com/mapbox/mapbox-plugins-android/pull/895)
-- Add toString, hashcode and equals [#858](https://github.com/mapbox/mapbox-plugins-android/pull/858)
-- Delete all annotations method [#859](https://github.com/mapbox/mapbox-plugins-android/pull/859)
-- Add style spec documentation generation [#879](https://github.com/mapbox/mapbox-plugins-android/pull/879)
-- Move supported json properties docs to the public methods [#889](https://github.com/mapbox/mapbox-plugins-android/pull/889)
-- Support string color for layout properties [#897](https://github.com/mapbox/mapbox-plugins-android/pull/897)
-- Expose GeoJsonOptions [#909](https://github.com/mapbox/mapbox-plugins-android/pull/909)
+- Maps SDK bump to 7.3.0 [#895](https://github.com/mapbox/maplibre-plugins-android/pull/895)
+- Add toString, hashcode and equals [#858](https://github.com/mapbox/maplibre-plugins-android/pull/858)
+- Delete all annotations method [#859](https://github.com/mapbox/maplibre-plugins-android/pull/859)
+- Add style spec documentation generation [#879](https://github.com/mapbox/maplibre-plugins-android/pull/879)
+- Move supported json properties docs to the public methods [#889](https://github.com/mapbox/maplibre-plugins-android/pull/889)
+- Support string color for layout properties [#897](https://github.com/mapbox/maplibre-plugins-android/pull/897)
+- Expose GeoJsonOptions [#909](https://github.com/mapbox/maplibre-plugins-android/pull/909)
 #### Bugs
-- Check if annotation is an active annotation when updating [#891](https://github.com/mapbox/mapbox-plugins-android/pull/891)
-- Use with prefix for options [#898](https://github.com/mapbox/mapbox-plugins-android/pull/898)
-- Notify gesture manager when drag is handled [#906](https://github.com/mapbox/mapbox-plugins-android/pull/906)
-- Register only one style loaded listener [#905](https://github.com/mapbox/mapbox-plugins-android/pull/905)
-- Use constants wherever property name strings are needed [#910](https://github.com/mapbox/mapbox-plugins-android/pull/910)
+- Check if annotation is an active annotation when updating [#891](https://github.com/mapbox/maplibre-plugins-android/pull/891)
+- Use with prefix for options [#898](https://github.com/mapbox/maplibre-plugins-android/pull/898)
+- Notify gesture manager when drag is handled [#906](https://github.com/mapbox/maplibre-plugins-android/pull/906)
+- Register only one style loaded listener [#905](https://github.com/mapbox/maplibre-plugins-android/pull/905)
+- Use constants wherever property name strings are needed [#910](https://github.com/mapbox/maplibre-plugins-android/pull/910)
 
-### mapbox-android-plugin-annotation-v7:0.5.0 - February 5, 2019
-- Do not flag click events as handled [#822](https://github.com/mapbox/mapbox-plugins-android/pull/822)
-- Update dependencies and javadoc source reference [#827](https://github.com/mapbox/mapbox-plugins-android/pull/827)
-- Fixup remove drag listener naming [#833](https://github.com/mapbox/mapbox-plugins-android/pull/833)
-- Maps SDK v7.1.1 [#820](https://github.com/mapbox/mapbox-plugins-android/pull/820)
+### maplibre-android-plugin-annotation-v7:0.5.0 - February 5, 2019
+- Do not flag click events as handled [#822](https://github.com/mapbox/maplibre-plugins-android/pull/822)
+- Update dependencies and javadoc source reference [#827](https://github.com/mapbox/maplibre-plugins-android/pull/827)
+- Fixup remove drag listener naming [#833](https://github.com/mapbox/maplibre-plugins-android/pull/833)
+- Maps SDK v7.1.1 [#820](https://github.com/mapbox/maplibre-plugins-android/pull/820)
 
-### mapbox-android-plugin-annotation-v7:0.4.0 - January 8, 2019
-- Mapbox maps SDK for Android v7.0.0 [#800](https://github.com/mapbox/mapbox-plugins-android/pull/800)
-- Save plugin's state across style changes [#800](https://github.com/mapbox/mapbox-plugins-android/pull/800/commits/cba17474e6087faf94375570700d4edfc52b6dd6)
-- Exposed filter API [#775](https://github.com/mapbox/mapbox-plugins-android/pull/775)
-- Create annotations from FeatureCollection/GeoJSON [#772](https://github.com/mapbox/mapbox-plugins-android/pull/772)
-- Invalid symbol ID during animation fix [#776](https://github.com/mapbox/mapbox-plugins-android/pull/776/commits/c2488010f27107693fd529a01afc2f51ecde03cf)
-- Make package private abstract classes public [#769](https://github.com/mapbox/mapbox-plugins-android/pull/769)
-- Draggable builder option [#768](https://github.com/mapbox/mapbox-plugins-android/pull/768)
-- Generic geometry [#777](https://github.com/mapbox/mapbox-plugins-android/pull/777)
+### maplibre-android-plugin-annotation-v7:0.4.0 - January 8, 2019
+- Mapbox maps SDK for Android v7.0.0 [#800](https://github.com/mapbox/maplibre-plugins-android/pull/800)
+- Save plugin's state across style changes [#800](https://github.com/mapbox/maplibre-plugins-android/pull/800/commits/cba17474e6087faf94375570700d4edfc52b6dd6)
+- Exposed filter API [#775](https://github.com/mapbox/maplibre-plugins-android/pull/775)
+- Create annotations from FeatureCollection/GeoJSON [#772](https://github.com/mapbox/maplibre-plugins-android/pull/772)
+- Invalid symbol ID during animation fix [#776](https://github.com/mapbox/maplibre-plugins-android/pull/776/commits/c2488010f27107693fd529a01afc2f51ecde03cf)
+- Make package private abstract classes public [#769](https://github.com/mapbox/maplibre-plugins-android/pull/769)
+- Draggable builder option [#768](https://github.com/mapbox/maplibre-plugins-android/pull/768)
+- Generic geometry [#777](https://github.com/mapbox/maplibre-plugins-android/pull/777)
 
 ### 0.3.0 - November 9, 2018
-- Mapbox maps SDK for Android v6.7.0 [#728](https://github.com/mapbox/mapbox-plugins-android/pull/728)
-- Draggable annotations [#753](https://github.com/mapbox/mapbox-plugins-android/pull/753)
-- Set layer properties expressions only on utilized properties [#762](https://github.com/mapbox/mapbox-plugins-android/pull/762)
+- Mapbox maps SDK for Android v6.7.0 [#728](https://github.com/mapbox/maplibre-plugins-android/pull/728)
+- Draggable annotations [#753](https://github.com/mapbox/maplibre-plugins-android/pull/753)
+- Set layer properties expressions only on utilized properties [#762](https://github.com/mapbox/maplibre-plugins-android/pull/762)
 
 ### 0.2.0 - October 25, 2018
-- Expose below layer ID configuration [#677](https://github.com/mapbox/mapbox-plugins-android/pull/677)
-- Add long click listeners to annotation manager [#685](https://github.com/mapbox/mapbox-plugins-android/pull/685)
-- Add bulk annotation addition API [#689](https://github.com/mapbox/mapbox-plugins-android/pull/689)
-- Add builder classes [#700](https://github.com/mapbox/mapbox-plugins-android/pull/700)
-- Remove self update mechanism, CRUD interface [#702](https://github.com/mapbox/mapbox-plugins-android/pull/702)
-- Add GeoJSON compatible API [#704](https://github.com/mapbox/mapbox-plugins-android/pull/704)
-- Style spec update, z-ordering symbols [#718](https://github.com/mapbox/mapbox-plugins-android/pull/718)
-- Color API for android color ints, remove string API [#721](https://github.com/mapbox/mapbox-plugins-android/pull/721)
-- Use PointF instead of Float[] [#722](https://github.com/mapbox/mapbox-plugins-android/pull/722)
-- Integrate pattern for fills and lines [#726](https://github.com/mapbox/mapbox-plugins-android/pull/726)
+- Expose below layer ID configuration [#677](https://github.com/mapbox/maplibre-plugins-android/pull/677)
+- Add long click listeners to annotation manager [#685](https://github.com/mapbox/maplibre-plugins-android/pull/685)
+- Add bulk annotation addition API [#689](https://github.com/mapbox/maplibre-plugins-android/pull/689)
+- Add builder classes [#700](https://github.com/mapbox/maplibre-plugins-android/pull/700)
+- Remove self update mechanism, CRUD interface [#702](https://github.com/mapbox/maplibre-plugins-android/pull/702)
+- Add GeoJSON compatible API [#704](https://github.com/mapbox/maplibre-plugins-android/pull/704)
+- Style spec update, z-ordering symbols [#718](https://github.com/mapbox/maplibre-plugins-android/pull/718)
+- Color API for android color ints, remove string API [#721](https://github.com/mapbox/maplibre-plugins-android/pull/721)
+- Use PointF instead of Float[] [#722](https://github.com/mapbox/maplibre-plugins-android/pull/722)
+- Integrate pattern for fills and lines [#726](https://github.com/mapbox/maplibre-plugins-android/pull/726)
 
 ### 0.1.0 - September 12, 2018
 - Initial release

--- a/plugin-annotation/README.md
+++ b/plugin-annotation/README.md
@@ -17,19 +17,19 @@ repositories {
 
 ```
 
-Add [the latest version](https://central.sonatype.com/artifact/org.maplibre.gl/android-plugin-annotation-v9/versions) as a dependency to your project.
+Add [the latest version](https://central.sonatype.com/artifact/org.maplibre.gl/android-plugin-annotation/versions) as a dependency to your project.
 
 In the app-level `build.gradle` file:
 
 ```groovy
 dependencies {
-    implementation 'org.maplibre.gl:android-plugin-annotation-v9:3.0.2'
+    implementation 'org.maplibre.gl:android-plugin-annotation:4.0.0'
 }
 ```
 
 ```kotlin
 dependencies {
-    implementation("org.maplibre.gl:android-plugin-annotation-v9:3.0.2")
+    implementation("org.maplibre.gl:android-plugin-annotation:4.0.0")
 }
 ```
 

--- a/plugin-annotation/gradle.properties
+++ b/plugin-annotation/gradle.properties
@@ -1,4 +1,4 @@
 VERSION_NAME=0.10.0-SNAPSHOT
-POM_ARTIFACT_ID=android-plugin-annotation-v9
+POM_ARTIFACT_ID=android-plugin-annotation
 POM_NAME=MapLibre Android Annotation Plugin
 POM_DESCRIPTION=MapLibre Android Annotation Plugin

--- a/plugin-building/CHANGELOG.md
+++ b/plugin-building/CHANGELOG.md
@@ -1,29 +1,33 @@
-# Changelog for the Mapbox Building Plugin
+# Changelog for the MapLibre Building Plugin
 
-Mapbox welcomes participation and contributions from everyone.
+MapLibre welcomes participation and contributions from everyone.
 
-### mapbox-android-plugin-building-v9:0.7.0 - March 5, 2020
+### maplibre-android-plugin-building:4.0.0 - May 29, 2026
+- Targets MapLibre Android 13.1.0
+- Published to Maven Central via the vanniktech maven-publish plugin
+
+### maplibre-android-plugin-building-v9:0.7.0 - March 5, 2020
 #### Features
-- Switching all plugins to AndroidX [#1100](https://github.com/mapbox/mapbox-plugins-android/pull/1100)
-- Make LAYER_ID of BuildingPlugin public [#997](https://github.com/mapbox/mapbox-plugins-android/pull/997)
+- Switching all plugins to AndroidX [#1100](https://github.com/mapbox/maplibre-plugins-android/pull/1100)
+- Make LAYER_ID of BuildingPlugin public [#997](https://github.com/mapbox/maplibre-plugins-android/pull/997)
 
-### mapbox-android-plugin-building-v8:0.6.0 - June 11, 2019
+### maplibre-android-plugin-building-v8:0.6.0 - June 11, 2019
 
 No changes since last release. Release happened to update the module to `-v8`. 
 
-### mapbox-android-plugin-building-v7:0.5.0 - January 8, 2019
-- Update building plugin with Maps SDK 7.0.0 [#795](https://github.com/mapbox/mapbox-plugins-android/pull/795)
+### maplibre-android-plugin-building-v7:0.5.0 - January 8, 2019
+- Update building plugin with Maps SDK 7.0.0 [#795](https://github.com/mapbox/maplibre-plugins-android/pull/795)
 
 ### 0.4.0 - May 23, 2018
-- Updates Map SDK to 6.1.1 [#531](https://github.com/mapbox/mapbox-plugins-android/pull/531)
+- Updates Map SDK to 6.1.1 [#531](https://github.com/mapbox/maplibre-plugins-android/pull/531)
 
 ### 0.3.0 - May 7, 2018
-- Updates Map SDK to 6.1.1 [#488](https://github.com/mapbox/mapbox-plugins-android/pull/488)
-- Lowered min SDK to API level 14 to match Map SDK [#472](https://github.com/mapbox/mapbox-plugins-android/pull/472)
+- Updates Map SDK to 6.1.1 [#488](https://github.com/mapbox/maplibre-plugins-android/pull/488)
+- Lowered min SDK to API level 14 to match Map SDK [#472](https://github.com/mapbox/maplibre-plugins-android/pull/472)
 
 ### 0.2.0 - April 18, 2018
 - Updates Map SDK to 6.0.1
-- Adds `isVisible` API [#404](https://github.com/mapbox/mapbox-plugins-android/pull/404)
+- Adds `isVisible` API [#404](https://github.com/mapbox/maplibre-plugins-android/pull/404)
 
 ### 0.1.0 - July 19, 2017
 - Initial release as a standalone package.

--- a/plugin-building/README.md
+++ b/plugin-building/README.md
@@ -19,19 +19,19 @@ repositories {
 
 ```
 
-Add [the latest version](https://central.sonatype.com/artifact/org.maplibre.gl/android-plugin-building-v9/versions) as a dependency to your project.
+Add [the latest version](https://central.sonatype.com/artifact/org.maplibre.gl/android-plugin-building/versions) as a dependency to your project.
 
 In the app-level `build.gradle` file:
 
 ```groovy
 dependencies {
-    implementation 'org.maplibre.gl:android-plugin-building-v9:3.0.2'
+    implementation 'org.maplibre.gl:android-plugin-building:4.0.0'
 }
 ```
 
 ```kotlin
 dependencies {
-    implementation("org.maplibre.gl:android-plugin-building-v9:3.0.2")
+    implementation("org.maplibre.gl:android-plugin-building:4.0.0")
 }
 ```
 

--- a/plugin-building/gradle.properties
+++ b/plugin-building/gradle.properties
@@ -1,4 +1,4 @@
 VERSION_NAME=0.8.0-SNAPSHOT
-POM_ARTIFACT_ID=android-plugin-building-v9
+POM_ARTIFACT_ID=android-plugin-building
 POM_NAME=MapLibre Android Building Plugin
 POM_DESCRIPTION=MapLibre Android Building Plugin

--- a/plugin-localization/CHANGELOG.md
+++ b/plugin-localization/CHANGELOG.md
@@ -1,58 +1,62 @@
-# Changelog for the Mapbox Localization Plugin
+# Changelog for the MapLibre Localization Plugin
 
-Mapbox welcomes participation and contributions from everyone.
+MapLibre welcomes participation and contributions from everyone.
 
-### mapbox-android-plugin-localization-v9:0.12.0 - March 5, 2020
+### maplibre-android-plugin-localization:4.0.0 - May 29, 2026
+- Targets MapLibre Android 13.1.0
+- Published to Maven Central via the vanniktech maven-publish plugin
+
+### maplibre-android-plugin-localization-v9:0.12.0 - March 5, 2020
 #### Features
-- Switching all plugins to AndroidX [#1100](https://github.com/mapbox/mapbox-plugins-android/pull/1100)
+- Switching all plugins to AndroidX [#1100](https://github.com/mapbox/maplibre-plugins-android/pull/1100)
 
 #### Bugs
-- Switch Timber log level to debug for setMapLanguage [#1085](https://github.com/mapbox/mapbox-plugins-android/pull/1085)
+- Switch Timber log level to debug for setMapLanguage [#1085](https://github.com/mapbox/maplibre-plugins-android/pull/1085)
 
-### mapbox-android-plugin-localization-v8:0.11.0 - August 20, 2019
+### maplibre-android-plugin-localization-v8:0.11.0 - August 20, 2019
 #### Features
-- adjusted Timber.e to Timber.d [#993](https://github.com/mapbox/mapbox-plugins-android/pull/993)
+- adjusted Timber.e to Timber.d [#993](https://github.com/mapbox/maplibre-plugins-android/pull/993)
 
-### mapbox-android-plugin-localization-v8:0.10.0 - June 11, 2019
+### maplibre-android-plugin-localization-v8:0.10.0 - June 11, 2019
 #### Features
-- Adding Portuguese language support to Localization Plugin [#979](https://github.com/mapbox/mapbox-plugins-android/pull/979)
+- Adding Portuguese language support to Localization Plugin [#979](https://github.com/mapbox/maplibre-plugins-android/pull/979)
 
-### mapbox-android-plugin-localization-v7:0.9.0 - April 5, 2019
+### maplibre-android-plugin-localization-v7:0.9.0 - April 5, 2019
 #### Features
-- Maps SDK bump to 7.3.0 [#895](https://github.com/mapbox/mapbox-plugins-android/pull/895)
-- Add better support for Chinese languages [#878](https://github.com/mapbox/mapbox-plugins-android/pull/878)
+- Maps SDK bump to 7.3.0 [#895](https://github.com/mapbox/maplibre-plugins-android/pull/895)
+- Add better support for Chinese languages [#878](https://github.com/mapbox/maplibre-plugins-android/pull/878)
 #### Bugs
-- Correct javadoc syntax [#871](https://github.com/mapbox/mapbox-plugins-android/commit/0761054e0be8b55e5c41415bf196ab8c42a4decc)
-- Remove textField constant value check [#875](https://github.com/mapbox/mapbox-plugins-android/pull/875)
-- Register only one style loaded listener [#905](https://github.com/mapbox/mapbox-plugins-android/pull/905)
+- Correct javadoc syntax [#871](https://github.com/mapbox/maplibre-plugins-android/commit/0761054e0be8b55e5c41415bf196ab8c42a4decc)
+- Remove textField constant value check [#875](https://github.com/mapbox/maplibre-plugins-android/pull/875)
+- Register only one style loaded listener [#905](https://github.com/mapbox/maplibre-plugins-android/pull/905)
 
-### mapbox-android-plugin-localization-v7:0.8.0 - February 5, 2019
-- Language fallbacks for Localization plugin [#823](https://github.com/mapbox/mapbox-plugins-android/pull/823)
-- Update dependencies and javadoc source reference [#827](https://github.com/mapbox/mapbox-plugins-android/pull/827)
-- Increase usefulness of warning log for Localization sources [#825](https://github.com/mapbox/mapbox-plugins-android/pull/825)
-- Maps SDK v7.1.1 [#820](https://github.com/mapbox/mapbox-plugins-android/pull/820)
+### maplibre-android-plugin-localization-v7:0.8.0 - February 5, 2019
+- Language fallbacks for Localization plugin [#823](https://github.com/mapbox/maplibre-plugins-android/pull/823)
+- Update dependencies and javadoc source reference [#827](https://github.com/mapbox/maplibre-plugins-android/pull/827)
+- Increase usefulness of warning log for Localization sources [#825](https://github.com/mapbox/maplibre-plugins-android/pull/825)
+- Maps SDK v7.1.1 [#820](https://github.com/mapbox/maplibre-plugins-android/pull/820)
 
-### mapbox-android-plugin-localization-v7:0.7.0 - January 8, 2019
- - Update localization plugin with the Maps SDK v7.0.0 [#791](https://github.com/mapbox/mapbox-plugins-android/pull/791)
+### maplibre-android-plugin-localization-v7:0.7.0 - January 8, 2019
+ - Update localization plugin with the Maps SDK v7.0.0 [#791](https://github.com/mapbox/maplibre-plugins-android/pull/791)
 
 ### 0.6.0 - December 20, 2018
- - Add support for Russian locale [#678](https://github.com/mapbox/mapbox-plugins-android/pull/678)
- - Support for streets v8 sources [#778](https://github.com/mapbox/mapbox-plugins-android/pull/778)
- - Maps 6.8.0 bump [#797](https://github.com/mapbox/mapbox-plugins-android/pull/797)
+ - Add support for Russian locale [#678](https://github.com/mapbox/maplibre-plugins-android/pull/678)
+ - Support for streets v8 sources [#778](https://github.com/mapbox/maplibre-plugins-android/pull/778)
+ - Maps 6.8.0 bump [#797](https://github.com/mapbox/maplibre-plugins-android/pull/797)
 
 ### 0.5.0 - September 12, 2018
- - Update ProGuard to support built-in shrinker of Gradle Plugin [#582](https://github.com/mapbox/mapbox-plugins-android/pull/582)
- - Update localization plugin to support expressions [#654](https://github.com/mapbox/mapbox-plugins-android/pull/654)
- - Fix Localization set camera to locale country Javadoc broken link [#640](https://github.com/mapbox/mapbox-plugins-android/pull/640)
- - Adding japanese and korean support to localization plugin [#575](https://github.com/mapbox/mapbox-plugins-android/pull/575)
- - Maps SDK bump to 6.5.0 [#634](https://github.com/mapbox/mapbox-plugins-android/pull/634)
+ - Update ProGuard to support built-in shrinker of Gradle Plugin [#582](https://github.com/mapbox/maplibre-plugins-android/pull/582)
+ - Update localization plugin to support expressions [#654](https://github.com/mapbox/maplibre-plugins-android/pull/654)
+ - Fix Localization set camera to locale country Javadoc broken link [#640](https://github.com/mapbox/maplibre-plugins-android/pull/640)
+ - Adding japanese and korean support to localization plugin [#575](https://github.com/mapbox/maplibre-plugins-android/pull/575)
+ - Maps SDK bump to 6.5.0 [#634](https://github.com/mapbox/maplibre-plugins-android/pull/634)
 
 ### 0.4.0 - May 23, 2018
-- Updates the Map SDK to 6.1.3 [#531](https://github.com/mapbox/mapbox-plugins-android/pull/531)
+- Updates the Map SDK to 6.1.3 [#531](https://github.com/mapbox/maplibre-plugins-android/pull/531)
 
 ### 0.3.0 - May 7, 2018
-- Updates Map SDK to 6.1.1 [#488](https://github.com/mapbox/mapbox-plugins-android/pull/488)
-- Lowered min SDK to API level 14 to match Map SDK [#472](https://github.com/mapbox/mapbox-plugins-android/pull/472)
+- Updates Map SDK to 6.1.1 [#488](https://github.com/mapbox/maplibre-plugins-android/pull/488)
+- Lowered min SDK to API level 14 to match Map SDK [#472](https://github.com/mapbox/maplibre-plugins-android/pull/472)
 
 ### 0.2.0 - April 18, 2018
 - Updates Map SDK to 6.0.1

--- a/plugin-localization/README.md
+++ b/plugin-localization/README.md
@@ -19,19 +19,19 @@ repositories {
 
 ```
 
-Add [the latest version](https://central.sonatype.com/artifact/org.maplibre.gl/android-plugin-localization-v9/versions) as a dependency to your project.
+Add [the latest version](https://central.sonatype.com/artifact/org.maplibre.gl/android-plugin-localization/versions) as a dependency to your project.
 
 In the app-level `build.gradle` file:
 
 ```groovy
 dependencies {
-    implementation 'org.maplibre.gl:android-plugin-localization-v9:3.0.2'
+    implementation 'org.maplibre.gl:android-plugin-localization:4.0.0'
 }
 ```
 
 ```kotlin
 dependencies {
-    implementation("org.maplibre.gl:android-plugin-localization-v9:3.0.2")
+    implementation("org.maplibre.gl:android-plugin-localization:4.0.0")
 }
 ```
 

--- a/plugin-localization/gradle.properties
+++ b/plugin-localization/gradle.properties
@@ -1,5 +1,5 @@
 VERSION_NAME=0.13.0-SNAPSHOT
-POM_ARTIFACT_ID=android-plugin-localization-v9
+POM_ARTIFACT_ID=android-plugin-localization
 POM_NAME=MapLibre Android Localization Plugin
 POM_DESCRIPTION=MapLibre Android Localization Plugin
 

--- a/plugin-markerview/CHANGELOG.md
+++ b/plugin-markerview/CHANGELOG.md
@@ -1,18 +1,22 @@
-# Changelog for the Mapbox MarkerView Plugin
+# Changelog for the MapLibre MarkerView Plugin
 
-Mapbox welcomes participation and contributions from everyone.
+MapLibre welcomes participation and contributions from everyone.
 
-### mapbox-android-plugin-markerview-v9:0.4.0 - March 5, 2020
+### maplibre-android-plugin-markerview:4.0.0 - May 29, 2026
+- Targets MapLibre Android 13.1.0
+- Published to Maven Central via the vanniktech maven-publish plugin
+
+### maplibre-android-plugin-markerview-v9:0.4.0 - March 5, 2020
 #### Features
-- Switching all plugins to AndroidX [#1100](https://github.com/mapbox/mapbox-plugins-android/pull/1100)
+- Switching all plugins to AndroidX [#1100](https://github.com/mapbox/maplibre-plugins-android/pull/1100)
 
-### mapbox-android-plugin-markerview-v8:0.3.0 - June 11, 2019
+### maplibre-android-plugin-markerview-v8:0.3.0 - June 11, 2019
 #### Features
-- remove obsolete build tools declaration [#827](https://github.com/mapbox/mapbox-plugins-android/pull/827)
-- remove java 8 language support [#943](https://github.com/mapbox/mapbox-plugins-android/pull/943)
+- remove obsolete build tools declaration [#827](https://github.com/mapbox/maplibre-plugins-android/pull/827)
+- remove java 8 language support [#943](https://github.com/mapbox/maplibre-plugins-android/pull/943)
 
-### mapbox-android-plugin-markerview-v7:0.2.0 - January 8, 2019
-- Update MarkerView plugin with the Maps SDK v7.0.0 [#789](https://github.com/mapbox/mapbox-plugins-android/pull/789)
+### maplibre-android-plugin-markerview-v7:0.2.0 - January 8, 2019
+- Update MarkerView plugin with the Maps SDK v7.0.0 [#789](https://github.com/mapbox/maplibre-plugins-android/pull/789)
 
 ### 0.1.0 - September 12, 2018
 - Initial release

--- a/plugin-markerview/README.md
+++ b/plugin-markerview/README.md
@@ -21,19 +21,19 @@ repositories {
 
 ```
 
-Add [the latest version](https://central.sonatype.com/artifact/org.maplibre.gl/android-plugin-markerview-v9/versions) as a dependency to your project.
+Add [the latest version](https://central.sonatype.com/artifact/org.maplibre.gl/android-plugin-markerview/versions) as a dependency to your project.
 
 In the app-level `build.gradle` file:
 
 ```groovy
 dependencies {
-    implementation 'org.maplibre.gl:android-plugin-markerview-v9:3.0.2'
+    implementation 'org.maplibre.gl:android-plugin-markerview:4.0.0'
 }
 ```
 
 ```kotlin
 dependencies {
-    implementation("org.maplibre.gl:android-plugin-markerview-v9:3.0.2")
+    implementation("org.maplibre.gl:android-plugin-markerview:4.0.0")
 }
 ```
 

--- a/plugin-markerview/gradle.properties
+++ b/plugin-markerview/gradle.properties
@@ -1,4 +1,4 @@
 VERSION_NAME=0.5.0-SNAPSHOT
-POM_ARTIFACT_ID=android-plugin-markerview-v9
+POM_ARTIFACT_ID=android-plugin-markerview
 POM_NAME=MapLibre Android MarkerView Plugin
 POM_DESCRIPTION=MapLibre Android MarkerView Plugin

--- a/plugin-offline/CHANGELOG.md
+++ b/plugin-offline/CHANGELOG.md
@@ -1,41 +1,45 @@
-# Changelog for the Mapbox Offline Plugin
+# Changelog for the MapLibre Offline Plugin
 
-Mapbox welcomes participation and contributions from everyone.
+MapLibre welcomes participation and contributions from everyone.
 
-### mapbox-android-plugin-offline-v9:0.8.0 - March 23, 2021
+### maplibre-android-plugin-offline:4.0.0 - May 29, 2026
+- Targets MapLibre Android 13.1.0
+- Published to Maven Central via the vanniktech maven-publish plugin
+
+### maplibre-android-plugin-offline-v9:0.8.0 - March 23, 2021
 #### Bugs
-- Fix download notification doesn't dismiss issue. [#1176](https://github.com/mapbox/mapbox-plugins-android/pull/1176)
+- Fix download notification doesn't dismiss issue. [#1176](https://github.com/mapbox/maplibre-plugins-android/pull/1176)
 
-### mapbox-android-plugin-offline-v9:0.7.0 - March 5, 2020
+### maplibre-android-plugin-offline-v9:0.7.0 - March 5, 2020
 #### Features
-- Switching all plugins to AndroidX [#1100](https://github.com/mapbox/mapbox-plugins-android/pull/1100)
+- Switching all plugins to AndroidX [#1100](https://github.com/mapbox/maplibre-plugins-android/pull/1100)
 
-### mapbox-android-plugin-offline-v8:0.6.0 - June 11, 2019
+### maplibre-android-plugin-offline-v8:0.6.0 - June 11, 2019
 
 No changes since last release. Release happened to update the module to `-v8`.
 
-### mapbox-android-plugin-offline-v7:0.5.0 - April 5, 2019
+### maplibre-android-plugin-offline-v7:0.5.0 - April 5, 2019
 #### Features
-- Maps SDK bump to 7.3.0 [#895](https://github.com/mapbox/mapbox-plugins-android/pull/895)
-- Use a generic OfflineRegionDefinition [#913](https://github.com/mapbox/mapbox-plugins-android/pull/913)
+- Maps SDK bump to 7.3.0 [#895](https://github.com/mapbox/maplibre-plugins-android/pull/895)
+- Use a generic OfflineRegionDefinition [#913](https://github.com/mapbox/maplibre-plugins-android/pull/913)
 #### Bugs
-- Include missing Timber dependency [#820](https://github.com/mapbox/mapbox-plugins-android/pull/820/commits/12083e8964fd81b4cd0818bfcc2d433ba361b6fa)
-- Disable vector drawable in download notification on pre lollipop devices [#866](https://github.com/mapbox/mapbox-plugins-android/pull/866)
-- Check for null intent in case of a service restart [#912](https://github.com/mapbox/mapbox-plugins-android/pull/912)
+- Include missing Timber dependency [#820](https://github.com/mapbox/maplibre-plugins-android/pull/820/commits/12083e8964fd81b4cd0818bfcc2d433ba361b6fa)
+- Disable vector drawable in download notification on pre lollipop devices [#866](https://github.com/mapbox/maplibre-plugins-android/pull/866)
+- Check for null intent in case of a service restart [#912](https://github.com/mapbox/maplibre-plugins-android/pull/912)
 
-### mapbox-android-plugin-offline-v7:0.4.0 - January 8, 2019
-- Update Offline plugin with the Maps SDK v7.0.0 [#789](https://github.com/mapbox/mapbox-plugins-android/pull/789)
-- Cancelling download reworked [#779](https://github.com/mapbox/mapbox-plugins-android/pull/779)
-- Add cancel text and enable/disable map snapshots notification options [#805](https://github.com/mapbox/mapbox-plugins-android/pull/805)
+### maplibre-android-plugin-offline-v7:0.4.0 - January 8, 2019
+- Update Offline plugin with the Maps SDK v7.0.0 [#789](https://github.com/mapbox/maplibre-plugins-android/pull/789)
+- Cancelling download reworked [#779](https://github.com/mapbox/maplibre-plugins-android/pull/779)
+- Add cancel text and enable/disable map snapshots notification options [#805](https://github.com/mapbox/maplibre-plugins-android/pull/805)
 
 ### 0.3.0 - May 23, 2018
-- Updates the Map SDK to 6.1.3 [#531](https://github.com/mapbox/mapbox-plugins-android/pull/531)
+- Updates the Map SDK to 6.1.3 [#531](https://github.com/mapbox/maplibre-plugins-android/pull/531)
 
 ### 0.2.0 - May 7, 2018
-- Updates Map SDK to 6.1.1 [#488](https://github.com/mapbox/mapbox-plugins-android/pull/488)
-- Lowered min SDK to API level 14 to match Map SDK [#472](https://github.com/mapbox/mapbox-plugins-android/pull/472)
-- Adds offline UI Options [#468](https://github.com/mapbox/mapbox-plugins-android/pull/468)
-- Adds additional documentation to offline classes [#466](https://github.com/mapbox/mapbox-plugins-android/pull/466)
+- Updates Map SDK to 6.1.1 [#488](https://github.com/mapbox/maplibre-plugins-android/pull/488)
+- Lowered min SDK to API level 14 to match Map SDK [#472](https://github.com/mapbox/maplibre-plugins-android/pull/472)
+- Adds offline UI Options [#468](https://github.com/mapbox/maplibre-plugins-android/pull/468)
+- Adds additional documentation to offline classes [#466](https://github.com/mapbox/maplibre-plugins-android/pull/466)
 
 ### 0.1.0 - April 18, 2018
 - Initial release as a standalone package.

--- a/plugin-offline/README.md
+++ b/plugin-offline/README.md
@@ -19,19 +19,19 @@ repositories {
 
 ```
 
-Add [the latest version](https://central.sonatype.com/artifact/org.maplibre.gl/android-plugin-offline-v9/versions) as a dependency to your project.
+Add [the latest version](https://central.sonatype.com/artifact/org.maplibre.gl/android-plugin-offline/versions) as a dependency to your project.
 
 In the app-level `build.gradle` file:
 
 ```groovy
 dependencies {
-    implementation 'org.maplibre.gl:android-plugin-offline-v9:3.0.2'
+    implementation 'org.maplibre.gl:android-plugin-offline:4.0.0'
 }
 ```
 
 ```kotlin
 dependencies {
-    implementation("org.maplibre.gl:android-plugin-offline-v9:3.0.2")
+    implementation("org.maplibre.gl:android-plugin-offline:4.0.0")
 }
 ```
 

--- a/plugin-offline/gradle.properties
+++ b/plugin-offline/gradle.properties
@@ -1,4 +1,4 @@
 VERSION_NAME=0.9.0-SNAPSHOT
-POM_ARTIFACT_ID=android-plugin-offline-v9
+POM_ARTIFACT_ID=android-plugin-offline
 POM_NAME=MapLibre Android Offline Plugin
 POM_DESCRIPTION=MapLibre Android Offline Plugin

--- a/plugin-scalebar/CHANGELOG.md
+++ b/plugin-scalebar/CHANGELOG.md
@@ -1,38 +1,42 @@
-# Changelog for the Mapbox Scale Bar Plugin
+# Changelog for the MapLibre Scale Bar Plugin
 
-Mapbox welcomes participation and contributions from everyone.
+MapLibre welcomes participation and contributions from everyone.
 
-### mapbox-android-plugin-scalebar-v9:0.5.0 - March 31, 2020
+### maplibre-android-plugin-scalebar:4.0.0 - May 29, 2026
+- Targets MapLibre Android 13.1.0
+- Published to Maven Central via the vanniktech maven-publish plugin
+
+### maplibre-android-plugin-scalebar-v9:0.5.0 - March 31, 2020
 ####Features
 
-- Add option to config max width of scalebar [#1048](https://github.com/mapbox/mapbox-plugins-android/pull/1048)
+- Add option to config max width of scalebar [#1048](https://github.com/mapbox/maplibre-plugins-android/pull/1048)
 
 ####Bugs
 
-- Fix scalebar not show correctly when pixelRatio is set  [#1104](https://github.com/mapbox/mapbox-plugins-android/pull/1104)
+- Fix scalebar not show correctly when pixelRatio is set  [#1104](https://github.com/mapbox/maplibre-plugins-android/pull/1104)
 
-### mapbox-android-plugin-scalebar-v9:0.4.0 - March 5, 2020
+### maplibre-android-plugin-scalebar-v9:0.4.0 - March 5, 2020
 #### Features
-- Switching all plugins to AndroidX [#1100](https://github.com/mapbox/mapbox-plugins-android/pull/1100)
+- Switching all plugins to AndroidX [#1100](https://github.com/mapbox/maplibre-plugins-android/pull/1100)
 #### Bugs
-- Fix scale bar incorrect scale [#1088](https://github.com/mapbox/mapbox-plugins-android/pull/1088)
+- Fix scale bar incorrect scale [#1088](https://github.com/mapbox/maplibre-plugins-android/pull/1088)
 
-### mapbox-android-plugin-scalebar-v8:0.3.0 - August 20, 2019
+### maplibre-android-plugin-scalebar-v8:0.3.0 - August 20, 2019
 
 #### Features
-- Refactor plugins state management in case of widget recreation [#1033](https://github.com/mapbox/mapbox-plugins-android/pull/1033)
+- Refactor plugins state management in case of widget recreation [#1033](https://github.com/mapbox/maplibre-plugins-android/pull/1033)
 
 #### Bugs
-- Listen for camera idle event [#1035](https://github.com/mapbox/mapbox-plugins-android/pull/1035)
-- Invalidate the widget when plugin is toggled [#1036](https://github.com/mapbox/mapbox-plugins-android/pull/1036)
+- Listen for camera idle event [#1035](https://github.com/mapbox/maplibre-plugins-android/pull/1035)
+- Invalidate the widget when plugin is toggled [#1036](https://github.com/mapbox/maplibre-plugins-android/pull/1036)
 
 
-### mapbox-android-plugin-scalebar-v8:0.2.0 - July 29, 2019
+### maplibre-android-plugin-scalebar-v8:0.2.0 - July 29, 2019
 
 #### Bugs
-- Change the unit of scalebar according distance [#1010](https://github.com/mapbox/mapbox-plugins-android/pull/1010)
-- Remove .0 from distance text in scale bar [#1014](https://github.com/mapbox/mapbox-plugins-android/pull/1014)
+- Change the unit of scalebar according distance [#1010](https://github.com/mapbox/maplibre-plugins-android/pull/1010)
+- Remove .0 from distance text in scale bar [#1014](https://github.com/mapbox/maplibre-plugins-android/pull/1014)
 
-### mapbox-android-plugin-scalebar-v8:0.1.0 - June 11, 2019
+### maplibre-android-plugin-scalebar-v8:0.1.0 - June 11, 2019
 
 - Initial release as a standalone package.

--- a/plugin-scalebar/README.md
+++ b/plugin-scalebar/README.md
@@ -19,19 +19,19 @@ repositories {
 
 ```
 
-Add [the latest version](https://central.sonatype.com/artifact/org.maplibre.gl/android-plugin-scalebar-v9/versions) as a dependency to your project.
+Add [the latest version](https://central.sonatype.com/artifact/org.maplibre.gl/android-plugin-scalebar/versions) as a dependency to your project.
 
 In the app-level `build.gradle` file:
 
 ```groovy
 dependencies {
-    implementation 'org.maplibre.gl:android-plugin-scalebar-v9:3.0.2'
+    implementation 'org.maplibre.gl:android-plugin-scalebar:4.0.0'
 }
 ```
 
 ```kotlin
 dependencies {
-    implementation("org.maplibre.gl:android-plugin-scalebar-v9:3.0.2")
+    implementation("org.maplibre.gl:android-plugin-scalebar:4.0.0")
 }
 ```
 

--- a/plugin-scalebar/gradle.properties
+++ b/plugin-scalebar/gradle.properties
@@ -1,4 +1,4 @@
 VERSION_NAME=0.6.0-SNAPSHOT
-POM_ARTIFACT_ID=android-plugin-scalebar-v9
+POM_ARTIFACT_ID=android-plugin-scalebar
 POM_NAME=MapLibre Android Scalebar Plugin
 POM_DESCRIPTION=MapLibre Android Scalebar Plugin


### PR DESCRIPTION
Rework publishing to use the same plugin as MapLibre Android.

Move away from OSSHR.

This was done by pointing Copilot to maplibre/maplibre-native and nudging it along. I tested the release on this branch and it worked (except that the release failed because this tag was already out).